### PR TITLE
feat(system): set default argo admin

### DIFF
--- a/stacks/system/main.tf
+++ b/stacks/system/main.tf
@@ -76,6 +76,12 @@ resource "helm_release" "argo_cd" {
           type = "ClusterIP"
         }
       }
+      configs = {
+        secret = {
+          argocdServerAdminPassword      = "$2a$10$H1a30nMr9v2QE2nkyz0BoOD2J0I6FQFMtHS0csEg12RBWzfRuuoE6"
+          argocdServerAdminPasswordMtime = "2026-02-24T00:00:00Z"
+        }
+      }
     })
   ]
 }


### PR DESCRIPTION
## Summary
- set the Argo CD Helm release to seed the admin password via configs.secret so the instance defaults to admin/admin
- keep chart repository URLs unchanged and only extend the values file
- follow-up to #4 to land the default credentials commit post-merge

## Testing
- terraform fmt -recursive
- terraform -chdir=stacks/k8s init
- terraform -chdir=stacks/k8s validate
- terraform -chdir=stacks/k8s plan
- terraform -chdir=stacks/system init
- terraform -chdir=stacks/system validate
- terraform -chdir=stacks/system plan