### PR TITLE
fix(system): rotate argocd admin password

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Apply system stack (Istio + Argo CD)
         working-directory: stacks/system
         run: |
+          export TF_VAR_argocd_admin_password_mtime=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           terraform init -input=false
           terraform apply -auto-approve -input=false
 

--- a/stacks/system/main.tf
+++ b/stacks/system/main.tf
@@ -63,11 +63,12 @@ resource "helm_release" "istio_gateway" {
 
 # Argo CD
 resource "helm_release" "argo_cd" {
-  name       = "argo-cd"
-  repository = local.argo_repository_url
-  chart      = "argo-cd"
-  version    = var.argocd_chart_version
-  namespace  = kubernetes_namespace.argocd.metadata[0].name
+  name         = "argo-cd"
+  repository   = local.argo_repository_url
+  chart        = "argo-cd"
+  version      = var.argocd_chart_version
+  namespace    = kubernetes_namespace.argocd.metadata[0].name
+  force_update = true
 
   values = [
     yamlencode({
@@ -79,7 +80,7 @@ resource "helm_release" "argo_cd" {
       configs = {
         secret = {
           argocdServerAdminPassword      = "$2a$10$H1a30nMr9v2QE2nkyz0BoOD2J0I6FQFMtHS0csEg12RBWzfRuuoE6"
-          argocdServerAdminPasswordMtime = "2026-02-24T00:00:00Z"
+          argocdServerAdminPasswordMtime = coalesce(var.argocd_admin_password_mtime, "2026-02-24T00:00:00Z")
         }
       }
     })

--- a/stacks/system/variables.tf
+++ b/stacks/system/variables.tf
@@ -15,3 +15,9 @@ variable "argocd_chart_version" {
   description = "Argo CD chart version"
   default     = "5.33.0"
 }
+
+variable "argocd_admin_password_mtime" {
+  type        = string
+  description = "Timestamp used to rotate the Argo CD admin password"
+  default     = null
+}


### PR DESCRIPTION
## Summary
- allow overriding the Argo CD admin password mtime via Terraform variable to trigger rotations when desired
- default the mtime to the known timestamp to preserve existing behavior for manual runs
- force Helm upgrades so the new secret is rendered even without chart bumps
- ensure CI passes a fresh timestamp each run to guarantee rotation

## Testing
- terraform fmt -recursive
- terraform -chdir=stacks/k8s init
- terraform -chdir=stacks/k8s validate
- terraform -chdir=stacks/k8s plan
- terraform -chdir=stacks/system init
- terraform -chdir=stacks/system validate
- terraform -chdir=stacks/system plan