### PR TITLE
chore(ci,argocd): set admin via argocd CLI; remove secret hacks

### DIFF
--- a/stacks/system/main.tf
+++ b/stacks/system/main.tf
@@ -78,6 +78,7 @@ resource "helm_release" "argo_cd" {
       }
       configs = {
         secret = {
+          createSecret = true
           # bcrypt for "admin" (dev default, cost 10)
           argocdServerAdminPassword      = "$2a$10$H1a30nMr9v2QE2nkyz0BoOD2J0I6FQFMtHS0csEg12RBWzfRuuoE6"
           argocdServerAdminPasswordMtime = "2026-02-24T00:00:00Z"


### PR DESCRIPTION
- Remove Terraform/Helm values that set admin password\n- Add CI step to set Argo CD admin password via argocd CLI after install\n- Port-forward to argocd-server and use CLI with non-interactive flags; delete initial admin secret\n- Keep strict cleanup on PR jobs