### PR TITLE
Upgrade Argo CD Helm to 9.4.3; set admin creds via chart values

### DIFF
--- a/stacks/system/main.tf
+++ b/stacks/system/main.tf
@@ -77,9 +77,14 @@ resource "helm_release" "argo_cd" {
         }
       }
       configs = {
+        cm = {
+          admin = {
+            enabled = true
+          }
+        }
         secret = {
-          argocdServerAdminPassword      = "$2a$10$H1a30nMr9v2QE2nkyz0BoOD2J0I6FQFMtHS0csEg12RBWzfRuuoE6"
-          argocdServerAdminPasswordMtime = "2026-02-24T00:00:00Z"
+          argocdServerAdminPassword      = "$2a$10$hR1GwTdUGuvKqOZBrM2ctu8eAwE70ItpOXOHgslxBqG6UHIRhRrzK"
+          argocdServerAdminPasswordMtime = "2026-02-27T14:54:31Z"
         }
       }
     })

--- a/stacks/system/variables.tf
+++ b/stacks/system/variables.tf
@@ -13,5 +13,5 @@ variable "istio_chart_version" {
 variable "argocd_chart_version" {
   type        = string
   description = "Argo CD chart version"
-  default     = "5.33.0"
+  default     = "9.4.3"
 }


### PR DESCRIPTION
Fixes #9.

## Summary
- upgrade the argo-cd helm release to chart 9.4.3 (app v3.3.1)
- enable admin user and manage admin password/mtime via chart values

## Verification

```bash
terraform apply -auto-approve -input=false
# Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
KUBECONFIG=../k8s/.kube/agyn-local-kubeconfig.yaml kubectl -n argocd rollout status deploy/argo-cd-argocd-server --timeout=180s
# deployment "argo-cd-argocd-server" successfully rolled out
curl -sk -H 'Content-Type: application/json' -X POST https://127.0.0.1:8080/api/v1/session -d '{"username":"admin","password":"admin"}'
# HTTP/1.1 200 OK
argocd login 127.0.0.1:8080 --username admin --password admin --insecure --grpc-web
# 'admin:login' logged in successfully
```