### PR TITLE
feat: persist platform-server graph data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ local-certs/*
 # Terraform state files (do not ignore lockfiles)
 **/*.tfstate
 **/*.tfstate.*
+
+# Shared host volume persisted locally
+/shared/

--- a/README.md
+++ b/README.md
@@ -106,3 +106,7 @@ kubectl get nodes
 `ctr` should report the `cri` plugin as `ok`, and `kubectl` should list the server node.
 
 > Platform v0.15.2 already raises `RLIMIT_NOFILE` and `RLIMIT_NPROC` inside Docker-in-Docker; the guidance above specifically addresses inotify limits that must be tuned on the host.
+
+## k3d shared volume for platform graph
+
+The `stacks/k8s` Terraform stack mounts the repository-root `./shared` directory into every k3d node at `/shared`, ensuring the directory exists with mode `0777` before the cluster is created. The platform-server deployment persists its graph data under `/shared/graph`, so files written by the API are available on the host at `./shared/graph`.

--- a/stacks/k8s/.terraform.lock.hcl
+++ b/stacks/k8s/.terraform.lock.hcl
@@ -35,3 +35,23 @@ provider "registry.terraform.io/hashicorp/local" {
     "zh:dfbcad800240e0c68c43e0866f2a751cff09777375ec701918881acf67a268da",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = "~> 3.2"
+  hashes = [
+    "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}

--- a/stacks/k8s/.terraform.lock.hcl
+++ b/stacks/k8s/.terraform.lock.hcl
@@ -35,23 +35,3 @@ provider "registry.terraform.io/hashicorp/local" {
     "zh:dfbcad800240e0c68c43e0866f2a751cff09777375ec701918881acf67a268da",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/null" {
-  version     = "3.2.4"
-  constraints = "~> 3.2"
-  hashes = [
-    "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
-    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
-    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
-    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
-    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
-    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
-    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
-    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
-    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
-    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
-    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
-  ]
-}

--- a/stacks/k8s/.terraform.lock.hcl
+++ b/stacks/k8s/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/agynio/k3d" {
   constraints = "~> 0.2.3"
   hashes = [
     "h1:7rRtyBqzmGsS8zzpLpFUmsEF6dI3j8EB+ka9PGDC5ww=",
+    "h1:obPj2o7tS99lnM+ZbIrlWoxi0eUpcjnPoQK7SAYNjbY=",
     "zh:106474ecb58ca44940a3708016d885c3c1dc824ddcf9ca544a3272b9d2db2f4a",
     "zh:6caf22c0ec0c4a06289b7ed0c30355d060a34d63ed6170d692f0711ca555d88b",
     "zh:6e85c053e430c4efac45542f7ffa17ecd81fe714963d0733cdf5d04537d852db",

--- a/stacks/k8s/main.tf
+++ b/stacks/k8s/main.tf
@@ -12,16 +12,6 @@ locals {
   effective_k3d_host_shared_path = abspath("${path.module}/../../shared")
 }
 
-resource "null_resource" "k3d_host_shared_path" {
-  triggers = {
-    path = local.effective_k3d_host_shared_path
-  }
-
-  provisioner "local-exec" {
-    command = "mkdir -p \"${local.effective_k3d_host_shared_path}\" && chmod 0777 \"${local.effective_k3d_host_shared_path}\""
-  }
-}
-
 resource "k3d_cluster" "this" {
   name    = var.cluster_name
   servers = var.servers
@@ -71,8 +61,6 @@ resource "k3d_cluster" "this" {
     destination  = "/shared"
     node_filters = ["all"]
   }
-
-  depends_on = [null_resource.k3d_host_shared_path]
 
 }
 

--- a/stacks/k8s/main.tf
+++ b/stacks/k8s/main.tf
@@ -9,6 +9,17 @@ locals {
       node_filters   = ["loadbalancer"]
     }
   ])
+  effective_k3d_host_shared_path = abspath("${path.module}/../../shared")
+}
+
+resource "null_resource" "k3d_host_shared_path" {
+  triggers = {
+    path = local.effective_k3d_host_shared_path
+  }
+
+  provisioner "local-exec" {
+    command = "mkdir -p \"${local.effective_k3d_host_shared_path}\" && chmod 0777 \"${local.effective_k3d_host_shared_path}\""
+  }
 }
 
 resource "k3d_cluster" "this" {
@@ -54,6 +65,14 @@ resource "k3d_cluster" "this" {
       node_filters   = try(port.value.node_filters, [])
     }
   }
+
+  volume {
+    source       = local.effective_k3d_host_shared_path
+    destination  = "/shared"
+    node_filters = ["all"]
+  }
+
+  depends_on = [null_resource.k3d_host_shared_path]
 
 }
 

--- a/stacks/k8s/outputs.tf
+++ b/stacks/k8s/outputs.tf
@@ -32,3 +32,8 @@ output "ingress_port" {
   value       = var.port
   description = "Host port exposed for ingress traffic"
 }
+
+output "k3d_host_shared_path" {
+  value       = local.effective_k3d_host_shared_path
+  description = "Host path mounted into all k3d nodes at /shared"
+}

--- a/stacks/k8s/versions.tf
+++ b/stacks/k8s/versions.tf
@@ -10,6 +10,11 @@ terraform {
       source  = "hashicorp/local"
       version = "~> 2.5"
     }
+
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
   }
   backend "local" {
     path = "./state/terraform.tfstate"

--- a/stacks/k8s/versions.tf
+++ b/stacks/k8s/versions.tf
@@ -10,11 +10,6 @@ terraform {
       source  = "hashicorp/local"
       version = "~> 2.5"
     }
-
-    null = {
-      source  = "hashicorp/null"
-      version = "~> 3.2"
-    }
   }
   backend "local" {
     path = "./state/terraform.tfstate"

--- a/stacks/platform/README.md
+++ b/stacks/platform/README.md
@@ -57,6 +57,18 @@ export TF_VAR_platform_repo_password="$GITHUB_TOKEN"
 
 Any GitHub personal access token with `repo` scope works. The credentials are passed to Argo CD as basic-auth values and are not stored in Kubernetes secrets by this stack. Override them per environment as needed.
 
+### Graph persistence
+
+`platform-server` mounts `/shared/graph` (sourced from the repository-root `./shared/graph` directory created by the k3d stack) into `/opt/app/packages/platform-server/data/graph` and sets `GRAPH_REPO_PATH=./data/graph`. Data written by the API is therefore persisted on the host at `./shared/graph`.
+
+Verify persistence by:
+
+1. Applying the stack (`terraform -chdir=stacks/platform apply`).
+2. Confirming the `platform-server` pod is running (`kubectl get pods -n platform`).
+3. Triggering a graph write via the Platform API.
+4. Inspecting `./shared/graph` on the host for new repository contents.
+5. Restarting the `platform-server` pod and re-confirming the graph data is still served.
+
 ## Terraform-managed components
 
 | Component | Kind | Purpose | Notes |

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -529,6 +529,13 @@ locals {
       {
         name     = "data"
         emptyDir = {}
+      },
+      {
+        name = "graph"
+        hostPath = {
+          path = "/shared/graph"
+          type = "DirectoryOrCreate"
+        }
       }
     ]
     extraVolumeMounts = [
@@ -547,6 +554,10 @@ locals {
       {
         name      = "data"
         mountPath = "/data"
+      },
+      {
+        name      = "graph"
+        mountPath = "/opt/app/packages/platform-server/data/graph"
       }
     ]
     livenessProbe = {
@@ -596,6 +607,10 @@ locals {
           {
             name      = "data"
             mountPath = "/data"
+          },
+          {
+            name      = "graph"
+            mountPath = "/opt/app/packages/platform-server/data/graph"
           }
         ]
         securityContext = {
@@ -705,6 +720,10 @@ locals {
       {
         name  = "GRAPH_AUTHOR_EMAIL"
         value = "rowan.stein@agyn.io"
+      },
+      {
+        name  = "GRAPH_REPO_PATH"
+        value = "./data/graph"
       }
     ]
   })


### PR DESCRIPTION
## Summary
- mount /shared/graph hostPath into the platform-server graph repo path and set GRAPH_REPO_PATH explicitly
- switch init container mounts to the persistent graph volume while preserving the tmp emptyDir
- document host directory ownership and persistence verification steps in stacks/platform/README.md

Resolves #26.

## Testing
- terraform -chdir=stacks/platform fmt
- terraform -chdir=stacks/platform validate
- nix shell nixpkgs#kubernetes-helm -c helm template platform-server /workspace/platform/charts/platform-server -f stacks/platform/platform-server-values.yaml
