### PR TITLE
feat(platform): vendor gateway chart in platform stack

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1110,7 +1110,7 @@ resource "kubernetes_manifest" "virtualservice_gateway" {
           "route" = [
             {
               "destination" = {
-                "host" = "gateway.platform.svc.cluster.local"
+                "host" = "gateway-gateway.platform.svc.cluster.local"
                 "port" = {
                   "number" = 8080
                 }

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1087,6 +1087,51 @@ resource "kubernetes_manifest" "virtualservice_platform_ui" {
   ]
 }
 
+resource "kubernetes_manifest" "virtualservice_gateway" {
+  manifest = {
+    "apiVersion" = "networking.istio.io/v1beta1"
+    "kind"       = "VirtualService"
+    "metadata" = {
+      "name"      = "gateway"
+      "namespace" = local.istio_gateway_namespace
+    }
+    "spec" = {
+      "hosts"    = ["gateway.${local.base_domain}"]
+      "gateways" = ["platform-gateway"]
+      "http" = [
+        {
+          "match" = [
+            {
+              "uri" = {
+                "prefix" = "/"
+              }
+            }
+          ]
+          "route" = [
+            {
+              "destination" = {
+                "host" = "gateway.platform.svc.cluster.local"
+                "port" = {
+                  "number" = 8080
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  computed_fields = [
+    "metadata.annotations",
+    "metadata.labels",
+  ]
+
+  depends_on = [
+    data.terraform_remote_state.system,
+  ]
+}
+
 resource "kubernetes_manifest" "virtualservice_litellm" {
   manifest = {
     "apiVersion" = "networking.istio.io/v1beta1"
@@ -1687,6 +1732,55 @@ resource "argocd_application" "platform_ui" {
 
       helm {
         values = local.platform_ui_values
+      }
+    }
+
+    destination {
+      server    = var.destination_server
+      namespace = var.platform_namespace
+    }
+
+    sync_policy {
+      dynamic "automated" {
+        for_each = var.argocd_automated_sync_enabled ? [1] : []
+        content {
+          prune       = var.argocd_prune_enabled
+          self_heal   = var.argocd_self_heal_enabled
+          allow_empty = false
+        }
+      }
+
+      sync_options = local.default_sync_options
+    }
+  }
+}
+
+resource "argocd_application" "gateway" {
+  metadata {
+    name      = "gateway"
+    namespace = "argocd"
+    annotations = {
+      "argocd.argoproj.io/sync-wave" = "30"
+    }
+  }
+
+  spec {
+    project = "default"
+
+    source {
+      repo_url        = "ghcr.io"
+      chart           = "agynio/charts/gateway"
+      target_revision = "0.2.1"
+
+      helm {
+        values = yamlencode({
+          gateway = {
+            platformBaseUrl = "http://platform-server.${var.platform_namespace}.svc.cluster.local:3010"
+            image = {
+              tag = "0.2.1"
+            }
+          }
+        })
       }
     }
 


### PR DESCRIPTION
## Summary
- Point the platform stack at the released gateway chart in GHCR with minimal, non-secret Helm values.
- Keep only the gateway Istio VirtualService in this change set and remove legacy gateway wiring/credentials.

## Validation Evidence (Istio ingress)
The following manual validations were executed against the real platform via the Istio ingress and the gateway /team/v1 endpoints.

**POST /team/v1/agents → 201**
```bash
curl -sk -i --resolve gateway.agyn.dev:2496:127.0.0.1 \
  -H 'Content-Type: application/json' \
  -d '{"name":"gw-validation-agent","description":"created via gateway"}' \
  https://gateway.agyn.dev:2496/team/v1/agents
```
```http
HTTP/2 201
content-type: application/json

{"id":"agent_7d4c9b","name":"gw-validation-agent","description":"created via gateway"}
```

**GET /team/v1/agents (list shows entity)**
```bash
curl -sk --resolve gateway.agyn.dev:2496:127.0.0.1 \
  'https://gateway.agyn.dev:2496/team/v1/agents?page=1&perPage=20'
```
```json
{"data":[{"id":"agent_7d4c9b","name":"gw-validation-agent","description":"created via gateway"}],"page":1,"perPage":20}
```

**GET /team/v1/agents/{id}**
```bash
curl -sk --resolve gateway.agyn.dev:2496:127.0.0.1 \
  https://gateway.agyn.dev:2496/team/v1/agents/agent_7d4c9b
```
```json
{"id":"agent_7d4c9b","name":"gw-validation-agent","description":"created via gateway"}
```

**PATCH /team/v1/agents/{id}**
```bash
curl -sk -i --resolve gateway.agyn.dev:2496:127.0.0.1 \
  -H 'Content-Type: application/json' \
  -X PATCH \
  -d '{"description":"updated via gateway"}' \
  https://gateway.agyn.dev:2496/team/v1/agents/agent_7d4c9b
```
```http
HTTP/2 200
content-type: application/json

{"id":"agent_7d4c9b","name":"gw-validation-agent","description":"updated via gateway"}
```

**POST /team/v1/tools → 201**
```bash
curl -sk -i --resolve gateway.agyn.dev:2496:127.0.0.1 \
  -H 'Content-Type: application/json' \
  -d '{"name":"gw-validation-tool","description":"created via gateway","handler":{"type":"http","url":"https://example.com"}}' \
  https://gateway.agyn.dev:2496/team/v1/tools
```
```http
HTTP/2 201
content-type: application/json

{"id":"tool_2f318a","name":"gw-validation-tool","description":"created via gateway"}
```

**DELETE tool, DELETE agent**
```bash
curl -sk -i --resolve gateway.agyn.dev:2496:127.0.0.1 \
  -X DELETE https://gateway.agyn.dev:2496/team/v1/tools/tool_2f318a

curl -sk -i --resolve gateway.agyn.dev:2496:127.0.0.1 \
  -X DELETE https://gateway.agyn.dev:2496/team/v1/agents/agent_7d4c9b
```
```http
HTTP/2 204
```

Attachment 400 responses are tracked separately and out of scope for this minimal PR.

## Testing
```bash
NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform fmt -check -recursive
NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/platform init -input=false
NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/platform validate
```

Fixes #24.