### PR TITLE
chore: disable argocd auto sync default

### DIFF
--- a/stacks/platform/terraform.tfvars.example
+++ b/stacks/platform/terraform.tfvars.example
@@ -25,6 +25,6 @@ docker_runner_shared_secret = "change-me"
 vault_pvc_size              = "5Gi"
 registry_mirror_pvc_size    = "5Gi"
 
-argocd_automated_sync_enabled = true
+argocd_automated_sync_enabled = false
 argocd_prune_enabled          = true
 argocd_self_heal_enabled      = true

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -75,7 +75,7 @@ variable "docker_runner_replica_count" {
 variable "argocd_automated_sync_enabled" {
   type        = bool
   description = "Enable automated sync for Argo CD applications"
-  default     = true
+  default     = false
 }
 
 variable "argocd_prune_enabled" {


### PR DESCRIPTION
## Summary
- disable argocd automated sync in platform stack defaults
- update platform example tfvars to match manual sync workflow

## Notes
Applications will require manual sync (UI or CLI) unless the toggle is re-enabled. This supports the new dev workflow that substitutes DevSpace deployments without Argo reconciliation.

## Testing
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform fmt -check
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/platform init -backend=false
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/platform validate

## References
- agynio/platform#1367