### PR TITLE
Enable Argo CD exec access

### DIFF
--- a/stacks/system/main.tf
+++ b/stacks/system/main.tf
@@ -255,6 +255,11 @@ resource "helm_release" "argo_cd" {
           admin = {
             enabled = true
           }
+          "exec.enabled" = "true"
+        }
+        rbac = {
+          "policy.csv"     = "p, role:admin, exec, create, */*, allow"
+          "policy.default" = "role:readonly"
         }
         secret = {
           argocdServerAdminPassword      = "$2a$10$hR1GwTdUGuvKqOZBrM2ctu8eAwE70ItpOXOHgslxBqG6UHIRhRrzK"


### PR DESCRIPTION
## Summary
- enable Argo CD exec in the config map
- add RBAC policies for admin exec access with readonly default

## Testing
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform fmt -recursive
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform fmt -check -recursive
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/k8s validate
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/system validate
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/routing validate
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/platform validate

Closes #39