### PR TITLE
fix(platform): align graph mounts

### DIFF
--- a/stacks/platform/README.md
+++ b/stacks/platform/README.md
@@ -62,14 +62,14 @@ Platform charts are pulled from the GHCR OCI registry (`ghcr.io/agynio/charts`).
 
 ### Graph persistence
 
-`platform-server` mounts `/shared/graph` (sourced from the repository-root `./shared/graph` directory created by the k3d stack) into `/opt/app/packages/platform-server/data/graph` and sets `GRAPH_REPO_PATH=./data/graph`. Data written by the API is therefore persisted on the host at `./shared/graph`.
+`platform-server` mounts `/shared/graph` (sourced from the repository-root `./shared/graph` directory created by the k3d stack) into `/opt/app/packages/platform-server/data` and sets `GRAPH_REPO_PATH=./data/graph`. The graph repository is created under the host directory at `./shared/graph/graph`, keeping the repository and its parent on the same filesystem.
 
 Verify persistence by:
 
 1. Applying the stack (`terraform -chdir=stacks/platform apply`).
 2. Confirming the `platform-server` pod is running (`kubectl get pods -n platform`).
 3. Triggering a graph write via the Platform API.
-4. Inspecting `./shared/graph` on the host for new repository contents.
+4. Inspecting `./shared/graph/graph` on the host for new repository contents.
 5. Restarting the `platform-server` pod and re-confirming the graph data is still served.
 
 ## Terraform-managed components

--- a/stacks/platform/README.md
+++ b/stacks/platform/README.md
@@ -62,14 +62,14 @@ Platform charts are pulled from the GHCR OCI registry (`ghcr.io/agynio/charts`).
 
 ### Graph persistence
 
-`platform-server` mounts `/shared` (sourced from the repository-root `./shared` directory created by the k3d stack) into `/opt/app/packages/platform-server/data` and sets `GRAPH_REPO_PATH=./data/graph`. The graph repository is created under the host directory at `./shared/graph`, keeping the repository and its parent on the same filesystem.
+`platform-server` mounts `/shared/graph` (sourced from the repository-root `./shared/graph` directory created by the k3d stack) into `/opt/app/packages/platform-server/data` and sets `GRAPH_REPO_PATH=./data/graph`. The graph repository is created under the host directory at `./shared/graph/graph`, keeping the repository and its parent on the same filesystem.
 
 Verify persistence by:
 
 1. Applying the stack (`terraform -chdir=stacks/platform apply`).
 2. Confirming the `platform-server` pod is running (`kubectl get pods -n platform`).
 3. Triggering a graph write via the Platform API.
-4. Inspecting `./shared/graph` on the host for new repository contents.
+4. Inspecting `./shared/graph/graph` on the host for new repository contents.
 5. Restarting the `platform-server` pod and re-confirming the graph data is still served.
 
 ## Terraform-managed components

--- a/stacks/platform/README.md
+++ b/stacks/platform/README.md
@@ -62,14 +62,14 @@ Platform charts are pulled from the GHCR OCI registry (`ghcr.io/agynio/charts`).
 
 ### Graph persistence
 
-`platform-server` mounts `/shared/graph` (sourced from the repository-root `./shared/graph` directory created by the k3d stack) into `/opt/app/packages/platform-server/data` and sets `GRAPH_REPO_PATH=./data/graph`. The graph repository is created under the host directory at `./shared/graph/graph`, keeping the repository and its parent on the same filesystem.
+`platform-server` mounts `/shared` (sourced from the repository-root `./shared` directory created by the k3d stack) into `/opt/app/packages/platform-server/data` and sets `GRAPH_REPO_PATH=./data/graph`. The graph repository is created under the host directory at `./shared/graph`, keeping the repository and its parent on the same filesystem.
 
 Verify persistence by:
 
 1. Applying the stack (`terraform -chdir=stacks/platform apply`).
 2. Confirming the `platform-server` pod is running (`kubectl get pods -n platform`).
 3. Triggering a graph write via the Platform API.
-4. Inspecting `./shared/graph/graph` on the host for new repository contents.
+4. Inspecting `./shared/graph` on the host for new repository contents.
 5. Restarting the `platform-server` pod and re-confirming the graph data is still served.
 
 ## Terraform-managed components

--- a/stacks/platform/README.md
+++ b/stacks/platform/README.md
@@ -62,14 +62,14 @@ Platform charts are pulled from the GHCR OCI registry (`ghcr.io/agynio/charts`).
 
 ### Graph persistence
 
-`platform-server` mounts `/shared/graph` (sourced from the repository-root `./shared/graph` directory created by the k3d stack) into `/opt/app/packages/platform-server/data` and sets `GRAPH_REPO_PATH=./data/graph`. The graph repository is created under the host directory at `./shared/graph/graph`, keeping the repository and its parent on the same filesystem.
+`platform-server` mounts `/shared` (sourced from the repository-root `./shared` directory created by the k3d stack) into `/mnt/graph` and sets `GRAPH_REPO_PATH=/mnt/graph/graph`. The graph repository is created under the host directory at `./shared/graph`, and swap artifacts land transiently under `./shared`.
 
 Verify persistence by:
 
 1. Applying the stack (`terraform -chdir=stacks/platform apply`).
 2. Confirming the `platform-server` pod is running (`kubectl get pods -n platform`).
 3. Triggering a graph write via the Platform API.
-4. Inspecting `./shared/graph/graph` on the host for new repository contents.
+4. Inspecting `./shared/graph` on the host for new repository contents.
 5. Restarting the `platform-server` pod and re-confirming the graph data is still served.
 
 ## Terraform-managed components

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -727,7 +727,7 @@ locals {
       {
         name = "data"
         hostPath = {
-          path = "/shared"
+          path = "/shared/graph"
           type = "DirectoryOrCreate"
         }
       }

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -727,7 +727,7 @@ locals {
       {
         name = "data"
         hostPath = {
-          path = "/shared/graph"
+          path = "/shared"
           type = "DirectoryOrCreate"
         }
       }

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -725,11 +725,7 @@ locals {
         emptyDir = {}
       },
       {
-        name     = "data"
-        emptyDir = {}
-      },
-      {
-        name = "graph"
+        name = "data"
         hostPath = {
           path = "/shared/graph"
           type = "DirectoryOrCreate"
@@ -753,10 +749,6 @@ locals {
         name      = "data"
         mountPath = "/data"
       },
-      {
-        name      = "graph"
-        mountPath = "/opt/app/packages/platform-server/data/graph"
-      }
     ]
     livenessProbe = {
       enabled = false
@@ -805,10 +797,6 @@ locals {
           {
             name      = "data"
             mountPath = "/data"
-          },
-          {
-            name      = "graph"
-            mountPath = "/opt/app/packages/platform-server/data/graph"
           }
         ]
         securityContext = {

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -725,9 +725,13 @@ locals {
         emptyDir = {}
       },
       {
-        name = "data"
+        name     = "data"
+        emptyDir = {}
+      },
+      {
+        name = "graph-data"
         hostPath = {
-          path = "/shared/graph"
+          path = "/shared"
           type = "DirectoryOrCreate"
         }
       }
@@ -748,6 +752,10 @@ locals {
       {
         name      = "data"
         mountPath = "/data"
+      },
+      {
+        name      = "graph-data"
+        mountPath = "/mnt/graph"
       },
     ]
     livenessProbe = {
@@ -909,7 +917,7 @@ locals {
       },
       {
         name  = "GRAPH_REPO_PATH"
-        value = "./data/graph"
+        value = "/mnt/graph/graph"
       }
     ]
   })


### PR DESCRIPTION
## Summary
- switch platform-server data volume to hostPath /shared/graph and drop the separate graph mount
- align platform-server migrations initContainer mounts with the shared hostPath volume
- update graph persistence docs for the new host directory layout

## Testing
- terraform fmt stacks/platform
- terraform -chdir=stacks/platform validate

Refs #47