### PR TITLE
fix(litellm): enable model storage

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -454,7 +454,8 @@ locals {
         }
       ]
       general_settings = {
-        master_key = "os.environ/LITELLM_MASTER_KEY"
+        master_key        = "os.environ/LITELLM_MASTER_KEY"
+        store_model_in_db = true
       }
     }
     db = {


### PR DESCRIPTION
## Summary
- enable LiteLLM model storage in DB by default

## Testing
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform fmt -check -recursive
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/platform validate

Fixes #59