### PR TITLE
feat(platform): switch dbs to argocd

### DIFF
--- a/.github/scripts/verify_platform_health.sh
+++ b/.github/scripts/verify_platform_health.sh
@@ -16,7 +16,7 @@ if [[ ! -f "$KUBECONFIG_PATH" ]]; then
   exit 1
 fi
 
-REQUIRED_APPS_JSON='["vault","registry-mirror","litellm","agent-state","docker-runner","platform-server","platform-ui"]'
+REQUIRED_APPS_JSON='["vault","registry-mirror","platform-db","litellm-db","agent-state-db","litellm","agent-state","docker-runner","platform-server","platform-ui"]'
 
 deadline=$((SECONDS + TOTAL_TIMEOUT))
 

--- a/stacks/platform/README.md
+++ b/stacks/platform/README.md
@@ -58,7 +58,7 @@ Override this behaviour by setting the optional environment variables
 
 ### Chart source
 
-Platform charts are pulled from the GHCR OCI registry (`ghcr.io/agynio/charts`). Pin the release with `platform_chart_version` in `terraform.tfvars`. If you need private registry credentials, register the GHCR repo in Argo CD before applying the stack. The `registry-mirror` app is the exception: it still pulls the upstream git chart from `https://github.com/twuni/docker-registry.helm.git`.
+Platform charts are pulled from the GHCR OCI registry (`ghcr.io/agynio/charts`). Pin the release with `platform_chart_version` in `terraform.tfvars`. The PostgreSQL Argo CD applications use the same registry and are pinned via `postgres_chart_version`. If you need private registry credentials, register the GHCR repo in Argo CD before applying the stack. The `registry-mirror` app is the exception: it still pulls the upstream git chart from `https://github.com/twuni/docker-registry.helm.git`.
 
 ### Graph persistence
 
@@ -89,6 +89,7 @@ The jobs wait for successful completion during `terraform apply` to ensure boots
 | 1         | `registry-mirror`  | Twuni docker-registry proxy         | Proxies Docker Hub with persistent storage |
 | 5         | `platform-db`      | PostgreSQL for platform workloads   | Uses chart `oci://ghcr.io/agynio/charts/postgres-helm` with inline Helm values |
 | 6         | `litellm-db`       | PostgreSQL backing LiteLLM          | Same chart with LiteLLM-specific credentials and PVC sizing |
+| 7         | `agent-state-db`   | PostgreSQL backing agent-state      | Same chart with agent-state credentials and PVC sizing |
 | 10        | `vault`            | HashiCorp Vault in standalone mode  | Sidecar consumes the Terraform-managed script and PVC for init/unseal |
 | 12        | `litellm`          | LiteLLM API deployment              | Connects to Argo CD-managed `litellm-db`; master key sourced from `litellm-master-key` secret |
 | 16        | `agent-state`      | Agent state gRPC service            | Internal-only gRPC; no external routing required |

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -21,6 +21,8 @@ locals {
   ncps_chart_name                = "agynio/charts/ncps"
   ncps_chart_revision            = "0.1.3"
   platform_chart_repo_host       = "ghcr.io"
+  postgres_chart_repo_host       = "ghcr.io"
+  postgres_chart_name            = "agynio/charts/postgres-helm"
   docker_runner_chart_name       = "agynio/charts/docker-runner"
   platform_server_chart_name     = "agynio/charts/platform-server"
   platform_ui_chart_name         = "agynio/charts/platform-ui"
@@ -35,6 +37,12 @@ locals {
     "PrunePropagationPolicy=foreground",
     "PruneLast=true",
     "ApplyOutOfSyncOnly=true",
+  ]
+
+  postgres_sync_options = [
+    "CreateNamespace=true",
+    "ApplyOutOfSyncOnly=true",
+    "RespectIgnoreDifferences=true",
   ]
 
   vault_standalone_config = <<-EOT
@@ -424,6 +432,75 @@ locals {
     proxy = {
       enabled   = true
       remoteurl = "https://registry-1.docker.io"
+    }
+  })
+
+  platform_db_values = yamlencode({
+    fullnameOverride = "platform-db"
+    postgres = {
+      database = "agents"
+      username = "agents"
+      password = var.platform_db_password
+      pgdata   = "/var/lib/postgresql/data/pgdata"
+    }
+    persistence = {
+      size                    = var.platform_db_pvc_size
+      mountPath               = "/var/lib/postgresql/data"
+      volumeClaimTemplateName = "data"
+    }
+    probes = {
+      readiness = {
+        execCommand = ["pg_isready", "-U", "agents", "-d", "agents"]
+      }
+      liveness = {
+        execCommand = ["pg_isready", "-U", "agents", "-d", "agents"]
+      }
+    }
+  })
+
+  litellm_db_values = yamlencode({
+    fullnameOverride = "litellm-db"
+    postgres = {
+      database = "litellm"
+      username = "litellm"
+      password = var.litellm_db_password
+      pgdata   = "/var/lib/postgresql/data/pgdata"
+    }
+    persistence = {
+      size                    = var.litellm_db_pvc_size
+      mountPath               = "/var/lib/postgresql/data"
+      volumeClaimTemplateName = "data"
+    }
+    probes = {
+      readiness = {
+        execCommand = ["pg_isready", "-U", "litellm", "-d", "litellm"]
+      }
+      liveness = {
+        execCommand = ["pg_isready", "-U", "litellm", "-d", "litellm"]
+      }
+    }
+  })
+
+  agent_state_db_values = yamlencode({
+    fullnameOverride = "agent-state-db"
+    postgres = {
+      database = "agentstate"
+      username = "agentstate"
+      password = var.agent_state_db_password
+      pgdata   = "/var/lib/postgresql/data/pgdata"
+    }
+    persistence = {
+      size                    = var.agent_state_db_pvc_size
+      mountPath               = "/var/lib/postgresql/data"
+      volumeClaimTemplateName = "data"
+    }
+    probes = {
+      readiness = {
+        execCommand = ["pg_isready", "-U", "agentstate", "-d", "agentstate"]
+      }
+      liveness = {
+        execCommand = ["pg_isready", "-U", "agentstate", "-d", "agentstate"]
+      }
     }
   })
 
@@ -1491,366 +1568,6 @@ resource "kubernetes_manifest" "virtualservice_vault" {
   ]
 }
 
-resource "kubernetes_service_v1" "platform_db" {
-  metadata {
-    name      = "platform-db"
-    namespace = kubernetes_namespace.platform.metadata[0].name
-    labels = {
-      "app.kubernetes.io/name" = "platform-db"
-    }
-  }
-
-  spec {
-    selector = {
-      "app.kubernetes.io/name" = "platform-db"
-    }
-
-    port {
-      name        = "postgres"
-      port        = 5432
-      target_port = 5432
-      protocol    = "TCP"
-    }
-  }
-}
-
-resource "kubernetes_stateful_set_v1" "platform_db" {
-  metadata {
-    name      = "platform-db"
-    namespace = kubernetes_namespace.platform.metadata[0].name
-    labels = {
-      "app.kubernetes.io/name" = "platform-db"
-    }
-  }
-
-  spec {
-    service_name = kubernetes_service_v1.platform_db.metadata[0].name
-    replicas     = 1
-
-    selector {
-      match_labels = {
-        "app.kubernetes.io/name" = "platform-db"
-      }
-    }
-
-    template {
-      metadata {
-        labels = {
-          "app.kubernetes.io/name" = "platform-db"
-        }
-      }
-
-      spec {
-        termination_grace_period_seconds = 30
-
-        container {
-          name              = "postgres"
-          image             = local.postgres_image
-          image_pull_policy = "IfNotPresent"
-          env {
-            name  = "POSTGRES_DB"
-            value = "agents"
-          }
-          env {
-            name  = "POSTGRES_USER"
-            value = "agents"
-          }
-          env {
-            name  = "POSTGRES_PASSWORD"
-            value = var.platform_db_password
-          }
-          env {
-            name  = "PGDATA"
-            value = "/var/lib/postgresql/data/pgdata"
-          }
-
-          port {
-            name           = "postgres"
-            container_port = 5432
-          }
-
-          readiness_probe {
-            exec {
-              command = ["pg_isready", "-U", "agents", "-d", "agents"]
-            }
-            initial_delay_seconds = 5
-            period_seconds        = 10
-          }
-
-          liveness_probe {
-            exec {
-              command = ["pg_isready", "-U", "agents", "-d", "agents"]
-            }
-            initial_delay_seconds = 30
-            period_seconds        = 20
-          }
-
-          volume_mount {
-            name       = "data"
-            mount_path = "/var/lib/postgresql/data"
-          }
-        }
-      }
-    }
-
-    volume_claim_template {
-      metadata {
-        name = "data"
-      }
-
-      spec {
-        access_modes = ["ReadWriteOnce"]
-
-        resources {
-          requests = {
-            storage = var.platform_db_pvc_size
-          }
-        }
-      }
-    }
-  }
-}
-
-resource "kubernetes_service_v1" "litellm_db" {
-  metadata {
-    name      = "litellm-db"
-    namespace = kubernetes_namespace.platform.metadata[0].name
-    labels = {
-      "app.kubernetes.io/name" = "litellm-db"
-    }
-  }
-
-  spec {
-    selector = {
-      "app.kubernetes.io/name" = "litellm-db"
-    }
-
-    port {
-      name        = "postgres"
-      port        = 5432
-      target_port = 5432
-      protocol    = "TCP"
-    }
-  }
-}
-
-resource "kubernetes_stateful_set_v1" "litellm_db" {
-  metadata {
-    name      = "litellm-db"
-    namespace = kubernetes_namespace.platform.metadata[0].name
-    labels = {
-      "app.kubernetes.io/name" = "litellm-db"
-    }
-  }
-
-  spec {
-    service_name = kubernetes_service_v1.litellm_db.metadata[0].name
-    replicas     = 1
-
-    selector {
-      match_labels = {
-        "app.kubernetes.io/name" = "litellm-db"
-      }
-    }
-
-    template {
-      metadata {
-        labels = {
-          "app.kubernetes.io/name" = "litellm-db"
-        }
-      }
-
-      spec {
-        termination_grace_period_seconds = 30
-
-        container {
-          name              = "postgres"
-          image             = local.postgres_image
-          image_pull_policy = "IfNotPresent"
-          env {
-            name  = "POSTGRES_DB"
-            value = "litellm"
-          }
-          env {
-            name  = "POSTGRES_USER"
-            value = "litellm"
-          }
-          env {
-            name  = "POSTGRES_PASSWORD"
-            value = var.litellm_db_password
-          }
-          env {
-            name  = "PGDATA"
-            value = "/var/lib/postgresql/data/pgdata"
-          }
-
-          port {
-            name           = "postgres"
-            container_port = 5432
-          }
-
-          readiness_probe {
-            exec {
-              command = ["pg_isready", "-U", "litellm", "-d", "litellm"]
-            }
-            initial_delay_seconds = 5
-            period_seconds        = 10
-          }
-
-          liveness_probe {
-            exec {
-              command = ["pg_isready", "-U", "litellm", "-d", "litellm"]
-            }
-            initial_delay_seconds = 30
-            period_seconds        = 20
-          }
-
-          volume_mount {
-            name       = "data"
-            mount_path = "/var/lib/postgresql/data"
-          }
-        }
-      }
-    }
-
-    volume_claim_template {
-      metadata {
-        name = "data"
-      }
-
-      spec {
-        access_modes = ["ReadWriteOnce"]
-
-        resources {
-          requests = {
-            storage = var.litellm_db_pvc_size
-          }
-        }
-      }
-    }
-  }
-}
-
-resource "kubernetes_service_v1" "agent_state_db" {
-  metadata {
-    name      = "agent-state-db"
-    namespace = kubernetes_namespace.platform.metadata[0].name
-    labels = {
-      "app.kubernetes.io/name" = "agent-state-db"
-    }
-  }
-
-  spec {
-    selector = {
-      "app.kubernetes.io/name" = "agent-state-db"
-    }
-
-    port {
-      name        = "postgres"
-      port        = 5432
-      target_port = 5432
-      protocol    = "TCP"
-    }
-  }
-}
-
-resource "kubernetes_stateful_set_v1" "agent_state_db" {
-  metadata {
-    name      = "agent-state-db"
-    namespace = kubernetes_namespace.platform.metadata[0].name
-    labels = {
-      "app.kubernetes.io/name" = "agent-state-db"
-    }
-  }
-
-  spec {
-    service_name = kubernetes_service_v1.agent_state_db.metadata[0].name
-    replicas     = 1
-
-    selector {
-      match_labels = {
-        "app.kubernetes.io/name" = "agent-state-db"
-      }
-    }
-
-    template {
-      metadata {
-        labels = {
-          "app.kubernetes.io/name" = "agent-state-db"
-        }
-      }
-
-      spec {
-        termination_grace_period_seconds = 30
-
-        container {
-          name              = "postgres"
-          image             = local.postgres_image
-          image_pull_policy = "IfNotPresent"
-          env {
-            name  = "POSTGRES_DB"
-            value = "agentstate"
-          }
-          env {
-            name  = "POSTGRES_USER"
-            value = "agentstate"
-          }
-          env {
-            name  = "POSTGRES_PASSWORD"
-            value = var.agent_state_db_password
-          }
-          env {
-            name  = "PGDATA"
-            value = "/var/lib/postgresql/data/pgdata"
-          }
-
-          port {
-            name           = "postgres"
-            container_port = 5432
-          }
-
-          readiness_probe {
-            exec {
-              command = ["pg_isready", "-U", "agentstate", "-d", "agentstate"]
-            }
-            initial_delay_seconds = 5
-            period_seconds        = 10
-          }
-
-          liveness_probe {
-            exec {
-              command = ["pg_isready", "-U", "agentstate", "-d", "agentstate"]
-            }
-            initial_delay_seconds = 30
-            period_seconds        = 20
-          }
-
-          volume_mount {
-            name       = "data"
-            mount_path = "/var/lib/postgresql/data"
-          }
-        }
-      }
-    }
-
-    volume_claim_template {
-      metadata {
-        name = "data"
-      }
-
-      spec {
-        access_modes = ["ReadWriteOnce"]
-
-        resources {
-          requests = {
-            storage = var.agent_state_db_pvc_size
-          }
-        }
-      }
-    }
-  }
-}
-
 resource "kubernetes_service_v1" "files_db" {
   metadata {
     name      = "files-db"
@@ -2110,6 +1827,150 @@ resource "argocd_repository" "litellm_repo" {
   enable_oci = true
 }
 
+resource "argocd_application" "platform_db" {
+  depends_on = [argocd_repository.litellm_repo]
+  wait       = true
+
+  metadata {
+    name      = "platform-db"
+    namespace = "argocd"
+    annotations = {
+      "argocd.argoproj.io/sync-wave" = "5"
+    }
+  }
+
+  spec {
+    project = "default"
+
+    source {
+      repo_url        = local.postgres_chart_repo_host
+      chart           = local.postgres_chart_name
+      target_revision = var.postgres_chart_version
+
+      helm {
+        values = local.platform_db_values
+      }
+    }
+
+    destination {
+      server    = var.destination_server
+      namespace = var.platform_namespace
+    }
+
+    sync_policy {
+      automated {
+        prune       = false
+        self_heal   = true
+        allow_empty = false
+      }
+
+      sync_options = local.postgres_sync_options
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
+resource "argocd_application" "litellm_db" {
+  depends_on = [argocd_repository.litellm_repo]
+  wait       = true
+
+  metadata {
+    name      = "litellm-db"
+    namespace = "argocd"
+    annotations = {
+      "argocd.argoproj.io/sync-wave" = "6"
+    }
+  }
+
+  spec {
+    project = "default"
+
+    source {
+      repo_url        = local.postgres_chart_repo_host
+      chart           = local.postgres_chart_name
+      target_revision = var.postgres_chart_version
+
+      helm {
+        values = local.litellm_db_values
+      }
+    }
+
+    destination {
+      server    = var.destination_server
+      namespace = var.platform_namespace
+    }
+
+    sync_policy {
+      automated {
+        prune       = false
+        self_heal   = true
+        allow_empty = false
+      }
+
+      sync_options = local.postgres_sync_options
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
+resource "argocd_application" "agent_state_db" {
+  depends_on = [argocd_repository.litellm_repo]
+  wait       = true
+
+  metadata {
+    name      = "agent-state-db"
+    namespace = "argocd"
+    annotations = {
+      "argocd.argoproj.io/sync-wave" = "7"
+    }
+  }
+
+  spec {
+    project = "default"
+
+    source {
+      repo_url        = local.postgres_chart_repo_host
+      chart           = local.postgres_chart_name
+      target_revision = var.postgres_chart_version
+
+      helm {
+        values = local.agent_state_db_values
+      }
+    }
+
+    destination {
+      server    = var.destination_server
+      namespace = var.platform_namespace
+    }
+
+    sync_policy {
+      automated {
+        prune       = false
+        self_heal   = true
+        allow_empty = false
+      }
+
+      sync_options = local.postgres_sync_options
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
 resource "argocd_application" "vault" {
   depends_on = [kubernetes_config_map_v1.vault_auto_init]
 
@@ -2209,7 +2070,7 @@ resource "argocd_application" "registry_mirror" {
 resource "argocd_application" "litellm" {
   depends_on = [
     argocd_repository.litellm_repo,
-    kubernetes_stateful_set_v1.litellm_db,
+    argocd_application.litellm_db,
   ]
   metadata {
     name      = "litellm"
@@ -2298,7 +2159,7 @@ resource "argocd_application" "ncps" {
 resource "argocd_application" "agent_state" {
   depends_on = [
     argocd_repository.litellm_repo,
-    kubernetes_stateful_set_v1.agent_state_db,
+    argocd_application.agent_state_db,
   ]
   metadata {
     name      = "agent-state"
@@ -2477,7 +2338,7 @@ resource "argocd_application" "docker_runner" {
 resource "argocd_application" "platform_server" {
   depends_on = [
     argocd_repository.litellm_repo,
-    kubernetes_stateful_set_v1.platform_db,
+    argocd_application.platform_db,
   ]
   metadata {
     name      = "platform-server"

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1858,6 +1858,8 @@ resource "argocd_application" "platform_db" {
     }
 
     sync_policy {
+      # DB apps always use automated sync with prune disabled for stateful safety,
+      # independent of var.argocd_automated_sync_enabled.
       automated {
         prune       = false
         self_heal   = true
@@ -1906,6 +1908,8 @@ resource "argocd_application" "litellm_db" {
     }
 
     sync_policy {
+      # DB apps always use automated sync with prune disabled for stateful safety,
+      # independent of var.argocd_automated_sync_enabled.
       automated {
         prune       = false
         self_heal   = true
@@ -1954,6 +1958,8 @@ resource "argocd_application" "agent_state_db" {
     }
 
     sync_policy {
+      # DB apps always use automated sync with prune disabled for stateful safety,
+      # independent of var.argocd_automated_sync_enabled.
       automated {
         prune       = false
         self_heal   = true

--- a/stacks/platform/outputs.tf
+++ b/stacks/platform/outputs.tf
@@ -3,6 +3,9 @@ output "platform_app_names" {
   value = [
     argocd_application.vault.metadata[0].name,
     argocd_application.registry_mirror.metadata[0].name,
+    argocd_application.platform_db.metadata[0].name,
+    argocd_application.litellm_db.metadata[0].name,
+    argocd_application.agent_state_db.metadata[0].name,
     argocd_application.litellm.metadata[0].name,
     argocd_application.ncps.metadata[0].name,
     argocd_application.agent_state.metadata[0].name,
@@ -19,6 +22,9 @@ output "platform_app_ids" {
   value = [
     argocd_application.vault.id,
     argocd_application.registry_mirror.id,
+    argocd_application.platform_db.id,
+    argocd_application.litellm_db.id,
+    argocd_application.agent_state_db.id,
     argocd_application.litellm.id,
     argocd_application.ncps.id,
     argocd_application.agent_state.id,

--- a/stacks/platform/terraform.tfvars.example
+++ b/stacks/platform/terraform.tfvars.example
@@ -8,6 +8,7 @@ platform_namespace         = "platform"
 platform_chart_version     = "0.15.2"
 agent_state_chart_version  = "0.1.0"
 token_counting_chart_version = "0.1.0"
+postgres_chart_version     = "0.1.1"
 docker_runner_replica_count = 1
 
 # Optional overrides for image tags

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -35,6 +35,12 @@ variable "token_counting_chart_version" {
   default     = "0.1.0"
 }
 
+variable "postgres_chart_version" {
+  type        = string
+  description = "Version of the postgres-helm chart published to GHCR"
+  default     = "0.1.1"
+}
+
 variable "platform_namespace" {
   type        = string
   description = "Namespace where platform workloads should be deployed"


### PR DESCRIPTION
## Summary
- replace platform, litellm, and agent-state DB StatefulSets/Services with postgres-helm Argo CD applications
- add postgres chart version variable and include DB apps in outputs/health checks
- refresh platform README and tfvars example for DB app deployment details

## Testing
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform fmt -recursive
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/platform init -input=false
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/platform validate

Closes #64