### PR TITLE
fix(platform): bump token-counting v0.2.0

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -4,7 +4,7 @@ locals {
   resolved_platform_ui_image_tag     = local.resolved_platform_server_image_tag
   resolved_agent_state_image_tag     = trimspace(var.agent_state_image_tag) != "" ? var.agent_state_image_tag : format("v%s", var.agent_state_chart_version)
   resolved_files_image_tag           = trimspace(var.files_image_tag) != "" ? var.files_image_tag : var.files_chart_version
-  resolved_token_counting_image_tag  = trimspace(var.token_counting_image_tag) != "" ? var.token_counting_image_tag : var.token_counting_chart_version
+  resolved_token_counting_image_tag  = trimspace(var.token_counting_image_tag) != "" ? var.token_counting_image_tag : format("v%s", var.token_counting_chart_version)
 
   postgres_image                 = "postgres:16.6-alpine"
   minio_image                    = "quay.io/minio/minio:RELEASE.2024-11-07T00-52-20Z"

--- a/stacks/platform/terraform.tfvars.example
+++ b/stacks/platform/terraform.tfvars.example
@@ -7,7 +7,7 @@ kubeconfig_path = "../k8s/.kube/agyn-local-kubeconfig.yaml"
 platform_namespace         = "platform"
 platform_chart_version     = "0.15.2"
 agent_state_chart_version  = "0.1.0"
-token_counting_chart_version = "0.1.0"
+token_counting_chart_version = "0.2.0"
 postgres_chart_version     = "0.1.1"
 docker_runner_replica_count = 1
 
@@ -15,7 +15,7 @@ docker_runner_replica_count = 1
 # platform_server_image_tag = "0.15.2"
 # docker_runner_image_tag   = "0.15.2"
 # agent_state_image_tag     = "v0.1.0"
-# token_counting_image_tag  = "0.1.0"
+# token_counting_image_tag  = "v0.2.0"
 # files_image_tag           = "0.1.1"
 
 platform_db_password        = "agents"

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -32,7 +32,7 @@ variable "agent_state_chart_version" {
 variable "token_counting_chart_version" {
   type        = string
   description = "Version of the token-counting Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "postgres_chart_version" {


### PR DESCRIPTION
## Summary
- restore v-prefixed token-counting image tag resolution
- bump token-counting chart version to 0.2.0 in defaults and example tfvars

## Testing
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform fmt -recursive -check
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/platform validate

#66