### PR TITLE
Standardize docker-runner gRPC port

### DIFF
--- a/stacks/platform/README.md
+++ b/stacks/platform/README.md
@@ -93,7 +93,7 @@ The jobs wait for successful completion during `terraform apply` to ensure boots
 | 10        | `vault`            | HashiCorp Vault in standalone mode  | Sidecar consumes the Terraform-managed script and PVC for init/unseal |
 | 12        | `litellm`          | LiteLLM API deployment              | Connects to Argo CD-managed `litellm-db`; master key sourced from `litellm-master-key` secret |
 | 16        | `agent-state`      | Agent state gRPC service            | Internal-only gRPC; no external routing required |
-| 18        | `docker-runner`    | Platform workspace runner           | Uses shared secret and exposes gRPC on 7071 |
+| 18        | `docker-runner`    | Platform workspace runner           | Uses shared secret and exposes gRPC on 50051 |
 | 20        | `platform-server`  | Core platform API                   | Depends on `platform-db`, LiteLLM bootstrap, and Vault dev-root token |
 | 25        | `platform-ui`      | Platform web UI                     | Connects to `platform-server` |
 

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -839,7 +839,7 @@ locals {
       },
       {
         name  = "DOCKER_RUNNER_PORT"
-        value = "7071"
+        value = "50051"
       },
       {
         name  = "DOCKER_RUNNER_SIGNATURE_TTL_MS"
@@ -855,7 +855,7 @@ locals {
       ports = [
         {
           name       = "grpc"
-          port       = 7071
+          port       = 50051
           targetPort = "grpc"
           protocol   = "TCP"
         }
@@ -864,7 +864,7 @@ locals {
     containerPorts = [
       {
         name          = "grpc"
-        containerPort = 7071
+        containerPort = 50051
         protocol      = "TCP"
       }
     ]
@@ -1037,11 +1037,11 @@ locals {
       },
       {
         name  = "DOCKER_RUNNER_GRPC_PORT"
-        value = "7071"
+        value = "50051"
       },
       {
         name  = "DOCKER_RUNNER_PORT"
-        value = "7071"
+        value = "50051"
       },
       {
         name  = "DOCKER_RUNNER_SHARED_SECRET"


### PR DESCRIPTION
## Summary
- align docker-runner gRPC port values with 50051 in platform stack
- update platform stack documentation to match the new port

## Testing
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform fmt -recursive
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/platform init -backend=false
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/platform validate

Refs #68