### PR TITLE
feat(platform): add apiv2 route

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1276,6 +1276,33 @@ resource "kubernetes_manifest" "virtualservice_platform_ui" {
           "match" = [
             {
               "uri" = {
+                "prefix" = "/apiv2/"
+              }
+            },
+            {
+              "uri" = {
+                "exact" = "/apiv2"
+              }
+            }
+          ]
+          "rewrite" = {
+            "uri" = "/"
+          }
+          "route" = [
+            {
+              "destination" = {
+                "host" = "gateway-gateway.platform.svc.cluster.local"
+                "port" = {
+                  "number" = 8080
+                }
+              }
+            }
+          ]
+        },
+        {
+          "match" = [
+            {
+              "uri" = {
                 "prefix" = "/api"
               }
             }


### PR DESCRIPTION
## Summary
- add /apiv2 route to platform-ui VirtualService before /api
- route apiv2 traffic to gateway service with rewrite to /

## Testing
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform fmt -check -recursive
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/k8s validate
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/system validate
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/platform validate

Fixes #70