### PR TITLE
chore(platform): bump gateway 0.3.0

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -2426,14 +2426,14 @@ resource "argocd_application" "gateway" {
     source {
       repo_url        = "ghcr.io"
       chart           = "agynio/charts/gateway"
-      target_revision = "0.2.1"
+      target_revision = "0.3.0"
 
       helm {
         values = yamlencode({
           gateway = {
             platformBaseUrl = "http://platform-server.${var.platform_namespace}.svc.cluster.local:3010"
             image = {
-              tag = "0.2.1"
+              tag = "0.3.0"
             }
           }
         })


### PR DESCRIPTION
## Summary
- bump gateway chart and image tag to 0.3.0

## Testing
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform fmt -check -recursive
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/platform validate

#74