### PR TITLE
Bump gateway chart for LLM

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -787,11 +787,6 @@ locals {
         name          = "grpc"
         containerPort = 50051
         protocol      = "TCP"
-      },
-      {
-        name          = "http"
-        containerPort = 8080
-        protocol      = "TCP"
       }
     ]
     service = {
@@ -802,12 +797,6 @@ locals {
           name       = "grpc"
           port       = 50051
           targetPort = "grpc"
-          protocol   = "TCP"
-        },
-        {
-          name       = "http"
-          port       = 8080
-          targetPort = "http"
           protocol   = "TCP"
         }
       ]
@@ -2906,7 +2895,6 @@ resource "argocd_application" "gateway" {
             teamsGrpcTarget   = "teams.${var.platform_namespace}.svc.cluster.local:50051"
             filesGrpcTarget   = "files.${var.platform_namespace}.svc.cluster.local:50051"
             llmGrpcTarget     = "llm.${var.platform_namespace}.svc.cluster.local:50051"
-            llmHttpBaseUrl    = "http://llm.${var.platform_namespace}.svc.cluster.local:8080"
           }
         })
       }

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -2,6 +2,7 @@ locals {
   resolved_platform_server_image_tag = trimspace(var.platform_server_image_tag) != "" ? var.platform_server_image_tag : var.platform_chart_version
   resolved_docker_runner_image_tag   = trimspace(var.docker_runner_image_tag) != "" ? var.docker_runner_image_tag : var.platform_chart_version
   resolved_platform_ui_image_tag     = local.resolved_platform_server_image_tag
+  resolved_gateway_image_tag         = trimspace(var.gateway_image_tag) != "" ? var.gateway_image_tag : var.gateway_chart_version
   resolved_agent_state_image_tag     = trimspace(var.agent_state_image_tag) != "" ? var.agent_state_image_tag : format("v%s", var.agent_state_chart_version)
   resolved_files_image_tag           = trimspace(var.files_image_tag) != "" ? var.files_image_tag : var.files_chart_version
   resolved_llm_image_tag             = trimspace(var.llm_image_tag) != "" ? var.llm_image_tag : format("v%s", var.llm_chart_version)
@@ -2877,6 +2878,7 @@ resource "argocd_application" "platform_ui" {
 }
 
 resource "argocd_application" "gateway" {
+  depends_on = [argocd_application.llm]
   metadata {
     name      = "gateway"
     namespace = "argocd"
@@ -2891,10 +2893,13 @@ resource "argocd_application" "gateway" {
     source {
       repo_url        = "ghcr.io"
       chart           = "agynio/charts/gateway"
-      target_revision = "0.5.0"
+      target_revision = var.gateway_chart_version
 
       helm {
         values = yamlencode({
+          image = {
+            tag = local.resolved_gateway_image_tag
+          }
           gateway = {
             platformBaseUrl   = "http://platform-server.${var.platform_namespace}.svc.cluster.local:3010"
             secretsGrpcTarget = "secrets.${var.platform_namespace}.svc.cluster.local:50051"
@@ -2902,9 +2907,6 @@ resource "argocd_application" "gateway" {
             filesGrpcTarget   = "files.${var.platform_namespace}.svc.cluster.local:50051"
             llmGrpcTarget     = "llm.${var.platform_namespace}.svc.cluster.local:50051"
             llmHttpBaseUrl    = "http://llm.${var.platform_namespace}.svc.cluster.local:8080"
-            image = {
-              tag = "0.5.0"
-            }
           }
         })
       }

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -23,6 +23,12 @@ variable "platform_chart_version" {
   default     = "0.15.2"
 }
 
+variable "gateway_chart_version" {
+  type        = string
+  description = "Version of the gateway Helm chart published to GHCR"
+  default     = "0.5.0"
+}
+
 variable "agent_state_chart_version" {
   type        = string
   description = "Version of the agent-state Helm chart published to GHCR"
@@ -86,6 +92,12 @@ variable "token_counting_image_tag" {
 variable "teams_image_tag" {
   type        = string
   description = "Optional override for the teams image tag"
+  default     = ""
+}
+
+variable "gateway_image_tag" {
+  type        = string
+  description = "Optional override for the gateway image tag"
   default     = ""
 }
 


### PR DESCRIPTION
## Summary
- add gateway chart/image version variables and resolved tag
- bump gateway chart revision and configure LLM service targets
- add gateway dependency on the LLM app
- remove LLM HTTP port/base URL references from the platform stack

## Testing
- terraform -chdir=/workspace/bootstrap_v2 fmt -recursive
- terraform -chdir=/workspace/bootstrap_v2/stacks/platform validate

Closes #82