### PR TITLE
chore: bump files chart version to 0.1.2

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -143,7 +143,7 @@ variable "agent_state_db_pvc_size" {
 variable "files_chart_version" {
   type        = string
   description = "Version of the files Helm chart published to GHCR"
-  default     = "0.1.1"
+  default     = "0.1.2"
 }
 
 variable "files_image_tag" {


### PR DESCRIPTION
Bumps `files_chart_version` from `0.1.1` to `0.1.2` in `stacks/platform/variables.tf`.

## Why
Chart `v0.1.1` defines `httpGet` health probes by default. The bootstrap overrides in `main.tf` specify `grpc` probes. Helm deep-merges both, producing probes with two handler types, which Kubernetes rejects:

```
Deployment.apps "files" is invalid:
  spec.template.spec.containers[0].livenessProbe.grpc: Forbidden: may not specify more than 1 handler type
```

Chart `v0.1.2` ([agynio/files v0.1.2](https://github.com/agynio/files/releases/tag/v0.1.2)) uses gRPC-only probes, eliminating the conflict.