### PR TITLE
fix: add filesGrpcTarget to gateway Helm values

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -2763,6 +2763,7 @@ resource "argocd_application" "gateway" {
         values = yamlencode({
           gateway = {
             platformBaseUrl = "http://platform-server.${var.platform_namespace}.svc.cluster.local:3010"
+            filesGrpcTarget = "files.${var.platform_namespace}.svc.cluster.local:50051"
             image = {
               tag = "0.3.0"
             }


### PR DESCRIPTION
## Problem

`POST /apiv2/files/v1/files` returns **404**.

The gateway registers the files upload route **conditionally** — only when `FILES_GRPC_TARGET` is set:

```go
if config.FilesGRPCTarget != "" {
    filesHandler := handlers.NewFilesHandler(filesClient)
    root.Route("/files/v1", func(r chi.Router) {
        r.Post("/files", filesHandler.Upload)
    })
}
```

This env var is injected by the gateway Helm chart only when `gateway.filesGrpcTarget` is provided. The bootstrap values never set it, so the route is never registered → 404.

## Fix

Add `filesGrpcTarget` to the gateway's Helm values in `stacks/platform/main.tf`, pointing at the files gRPC service:

```
files.platform.svc.cluster.local:50051
```

## Request path after fix

```
Client POST /apiv2/files/v1/files
  → Istio rewrites /apiv2/ → /
  → Gateway receives POST /files/v1/files
  → chi router matches → filesHandler.Upload
  → gRPC call to files.platform.svc.cluster.local:50051
```