### PR TITLE
feat(platform): add threads apps

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -653,6 +653,9 @@ locals {
     database = {
       url = format("postgresql://threads:%s@threads-db:5432/threads?sslmode=disable", var.threads_db_password)
     }
+    # Forward reference: the notifications service (agynio/notifications) is a real
+    # dependency — Threads publishes message.created events via its gRPC API.
+    # The notifications deployment will be added to bootstrap separately.
     notifications = {
       address = "notifications:50051"
     }

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -3,6 +3,7 @@ locals {
   resolved_docker_runner_image_tag   = trimspace(var.docker_runner_image_tag) != "" ? var.docker_runner_image_tag : var.platform_chart_version
   resolved_platform_ui_image_tag     = local.resolved_platform_server_image_tag
   resolved_agent_state_image_tag     = trimspace(var.agent_state_image_tag) != "" ? var.agent_state_image_tag : format("v%s", var.agent_state_chart_version)
+  resolved_threads_image_tag         = trimspace(var.threads_image_tag) != "" ? var.threads_image_tag : format("v%s", var.threads_chart_version)
   resolved_files_image_tag           = trimspace(var.files_image_tag) != "" ? var.files_image_tag : var.files_chart_version
   resolved_llm_image_tag             = trimspace(var.llm_image_tag) != "" ? var.llm_image_tag : format("v%s", var.llm_chart_version)
   resolved_secrets_image_tag         = trimspace(var.secrets_image_tag) != "" ? var.secrets_image_tag : format("v%s", var.secrets_chart_version)
@@ -29,6 +30,7 @@ locals {
   platform_server_chart_name     = "agynio/charts/platform-server"
   platform_ui_chart_name         = "agynio/charts/platform-ui"
   agent_state_chart_name         = "agynio/charts/agent-state"
+  threads_chart_name             = "agynio/charts/threads"
   files_chart_name               = "agynio/charts/files"
   llm_chart_name                 = "agynio/charts/llm"
   secrets_chart_name             = "agynio/charts/secrets"
@@ -508,6 +510,29 @@ locals {
     }
   })
 
+  threads_db_values = yamlencode({
+    fullnameOverride = "threads-db"
+    postgres = {
+      database = "threads"
+      username = "threads"
+      password = var.threads_db_password
+      pgdata   = "/var/lib/postgresql/data/pgdata"
+    }
+    persistence = {
+      size                    = var.threads_db_pvc_size
+      mountPath               = "/var/lib/postgresql/data"
+      volumeClaimTemplateName = "data"
+    }
+    probes = {
+      readiness = {
+        execCommand = ["pg_isready", "-U", "threads", "-d", "threads"]
+      }
+      liveness = {
+        execCommand = ["pg_isready", "-U", "threads", "-d", "threads"]
+      }
+    }
+  })
+
   secrets_db_values = yamlencode({
     fullnameOverride = "secrets-db"
     postgres = {
@@ -615,6 +640,25 @@ locals {
     image = {
       repository = "ghcr.io/agynio/agent-state"
       tag        = local.resolved_agent_state_image_tag
+      pullPolicy = "IfNotPresent"
+    }
+  })
+
+  threads_values = yamlencode({
+    replicaCount     = 1
+    fullnameOverride = "threads"
+    service = {
+      port = 50051
+    }
+    database = {
+      url = format("postgresql://threads:%s@threads-db:5432/threads?sslmode=disable", var.threads_db_password)
+    }
+    notifications = {
+      address = "notifications:50051"
+    }
+    image = {
+      repository = "ghcr.io/agynio/threads"
+      tag        = local.resolved_threads_image_tag
       pullPolicy = "IfNotPresent"
     }
   })
@@ -2097,6 +2141,56 @@ resource "argocd_application" "agent_state_db" {
   }
 }
 
+resource "argocd_application" "threads_db" {
+  depends_on = [argocd_repository.litellm_repo]
+  wait       = true
+
+  metadata {
+    name      = "threads-db"
+    namespace = "argocd"
+    annotations = {
+      "argocd.argoproj.io/sync-wave" = "7"
+    }
+  }
+
+  spec {
+    project = "default"
+
+    source {
+      repo_url        = local.postgres_chart_repo_host
+      chart           = local.postgres_chart_name
+      target_revision = var.postgres_chart_version
+
+      helm {
+        values = local.threads_db_values
+      }
+    }
+
+    destination {
+      server    = var.destination_server
+      namespace = var.platform_namespace
+    }
+
+    sync_policy {
+      # DB apps always use automated sync with prune disabled for stateful safety,
+      # independent of var.argocd_automated_sync_enabled.
+      automated {
+        prune       = false
+        self_heal   = true
+        allow_empty = false
+      }
+
+      sync_options = local.postgres_sync_options
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
 resource "argocd_application" "secrets_db" {
   depends_on = [argocd_repository.litellm_repo]
   wait       = true
@@ -2405,6 +2499,52 @@ resource "argocd_application" "agent_state" {
 
       helm {
         values = local.agent_state_values
+      }
+    }
+
+    destination {
+      server    = var.destination_server
+      namespace = var.platform_namespace
+    }
+
+    sync_policy {
+      dynamic "automated" {
+        for_each = var.argocd_automated_sync_enabled ? [1] : []
+        content {
+          prune       = var.argocd_prune_enabled
+          self_heal   = var.argocd_self_heal_enabled
+          allow_empty = false
+        }
+      }
+
+      sync_options = local.default_sync_options
+    }
+  }
+}
+
+resource "argocd_application" "threads" {
+  depends_on = [
+    argocd_repository.litellm_repo,
+    argocd_application.threads_db,
+  ]
+  metadata {
+    name      = "threads"
+    namespace = "argocd"
+    annotations = {
+      "argocd.argoproj.io/sync-wave" = "16"
+    }
+  }
+
+  spec {
+    project = "default"
+
+    source {
+      repo_url        = local.platform_chart_repo_host
+      chart           = local.threads_chart_name
+      target_revision = var.threads_chart_version
+
+      helm {
+        values = local.threads_values
       }
     }
 

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -32,7 +32,7 @@ variable "agent_state_chart_version" {
 variable "threads_chart_version" {
   type        = string
   description = "Version of the threads Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.1.1"
 }
 
 variable "token_counting_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -29,6 +29,12 @@ variable "agent_state_chart_version" {
   default     = "0.1.0"
 }
 
+variable "threads_chart_version" {
+  type        = string
+  description = "Version of the threads Helm chart published to GHCR"
+  default     = "0.1.0"
+}
+
 variable "token_counting_chart_version" {
   type        = string
   description = "Version of the token-counting Helm chart published to GHCR"
@@ -68,6 +74,12 @@ variable "docker_runner_image_tag" {
 variable "agent_state_image_tag" {
   type        = string
   description = "Optional override for the agent-state image tag"
+  default     = ""
+}
+
+variable "threads_image_tag" {
+  type        = string
+  description = "Optional override for the threads image tag"
   default     = ""
 }
 
@@ -134,9 +146,22 @@ variable "agent_state_db_password" {
   sensitive   = true
 }
 
+variable "threads_db_password" {
+  type        = string
+  description = "Password for the threads PostgreSQL database user"
+  default     = "threads"
+  sensitive   = true
+}
+
 variable "agent_state_db_pvc_size" {
   type        = string
   description = "Persistent volume claim size for the agent-state PostgreSQL primary"
+  default     = "5Gi"
+}
+
+variable "threads_db_pvc_size" {
+  type        = string
+  description = "Persistent volume claim size for the threads PostgreSQL primary"
   default     = "5Gi"
 }
 


### PR DESCRIPTION
## Summary
- add threads chart and image locals alongside existing platform services
- configure threads postgres and service values for Helm
- register ArgoCD apps for threads-db (sync-wave 7) and threads (sync-wave 16)

## Issue
Closes #1