### PR TITLE
chore: bump gateway to v0.6.0, remove dead config overrides

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -2891,19 +2891,13 @@ resource "argocd_application" "gateway" {
     source {
       repo_url        = "ghcr.io"
       chart           = "agynio/charts/gateway"
-      target_revision = "0.5.0"
+      target_revision = "0.6.0"
 
       helm {
         values = yamlencode({
           gateway = {
-            platformBaseUrl   = "http://platform-server.${var.platform_namespace}.svc.cluster.local:3010"
-            secretsGrpcTarget = "secrets.${var.platform_namespace}.svc.cluster.local:50051"
-            teamsGrpcTarget   = "teams.${var.platform_namespace}.svc.cluster.local:50051"
-            filesGrpcTarget   = "files.${var.platform_namespace}.svc.cluster.local:50051"
-            llmGrpcTarget     = "llm.${var.platform_namespace}.svc.cluster.local:50051"
-            llmHttpBaseUrl    = "http://llm.${var.platform_namespace}.svc.cluster.local:8080"
             image = {
-              tag = "0.5.0"
+              tag = "0.6.0"
             }
           }
         })


### PR DESCRIPTION
Bumps the gateway chart and image from `0.5.0` to `0.6.0`.

Gateway v0.6.0 ([agynio/gateway#45](https://github.com/agynio/gateway/pull/45)):
- Removed platform-server reverse proxy (`PLATFORM_BASE_URL`)
- Removed LLM HTTP proxy (`LLM_HTTP_BASE_URL`)
- Added K8s DNS defaults for all gRPC targets — chart defaults are now correct for same-namespace deployments

**Removed from Helm value overrides** (no longer needed):
- `platformBaseUrl` — proxy removed
- `llmHttpBaseUrl` — proxy removed
- `secretsGrpcTarget` — chart default: `secrets:50051`
- `teamsGrpcTarget` — chart default: `teams:50051`
- `filesGrpcTarget` — chart default: `files:50051`
- `llmGrpcTarget` — chart default: `llm:50051`

This also fixes the `POST /apiv2/files/v1/files` 404 — the files route is now always registered by default.