### PR TITLE
chore: reduce gateway replicas to 1 for local cluster

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -3029,6 +3029,7 @@ resource "argocd_application" "gateway" {
 
       helm {
         values = yamlencode({
+          replicaCount = 1
           image = {
             tag = local.resolved_gateway_image_tag
           }


### PR DESCRIPTION
## Summary
- set gateway helm replicaCount to 1 in platform stack

## Testing
- terraform fmt -check -recursive
- terraform -chdir=stacks/platform validate

Refs #94