### PR TITLE
Decouple docker-runner chart version

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1,6 +1,6 @@
 locals {
   resolved_platform_server_image_tag = trimspace(var.platform_server_image_tag) != "" ? var.platform_server_image_tag : var.platform_chart_version
-  resolved_docker_runner_image_tag   = trimspace(var.docker_runner_image_tag) != "" ? var.docker_runner_image_tag : var.platform_chart_version
+  resolved_docker_runner_image_tag   = trimspace(var.docker_runner_image_tag) != "" ? var.docker_runner_image_tag : var.docker_runner_chart_version
   resolved_platform_ui_image_tag     = local.resolved_platform_server_image_tag
   resolved_gateway_image_tag         = trimspace(var.gateway_image_tag) != "" ? var.gateway_image_tag : var.gateway_chart_version
   resolved_agent_state_image_tag     = trimspace(var.agent_state_image_tag) != "" ? var.agent_state_image_tag : format("v%s", var.agent_state_chart_version)
@@ -2894,7 +2894,7 @@ resource "argocd_application" "docker_runner" {
     source {
       repo_url        = local.platform_chart_repo_host
       chart           = local.docker_runner_chart_name
-      target_revision = var.platform_chart_version
+      target_revision = var.docker_runner_chart_version
 
       helm {
         values = local.docker_runner_values

--- a/stacks/platform/terraform.tfvars.example
+++ b/stacks/platform/terraform.tfvars.example
@@ -6,6 +6,7 @@ kubeconfig_path = "../k8s/.kube/agyn-local-kubeconfig.yaml"
 
 platform_namespace         = "platform"
 platform_chart_version     = "0.15.2"
+docker_runner_chart_version = "0.1.0"
 agent_state_chart_version  = "0.1.0"
 token_counting_chart_version = "0.2.0"
 postgres_chart_version     = "0.1.1"
@@ -13,7 +14,7 @@ docker_runner_replica_count = 1
 
 # Optional overrides for image tags
 # platform_server_image_tag = "0.15.2"
-# docker_runner_image_tag   = "0.15.2"
+# docker_runner_image_tag   = "0.1.0"
 # agent_state_image_tag     = "v0.1.0"
 # token_counting_image_tag  = "v0.2.0"
 # files_image_tag           = "0.1.1"

--- a/stacks/platform/terraform.tfvars.example
+++ b/stacks/platform/terraform.tfvars.example
@@ -6,7 +6,7 @@ kubeconfig_path = "../k8s/.kube/agyn-local-kubeconfig.yaml"
 
 platform_namespace         = "platform"
 platform_chart_version     = "0.15.2"
-docker_runner_chart_version = "0.1.0"
+docker_runner_chart_version = "0.1.1"
 agent_state_chart_version  = "0.1.0"
 token_counting_chart_version = "0.2.0"
 postgres_chart_version     = "0.1.1"
@@ -14,7 +14,7 @@ docker_runner_replica_count = 1
 
 # Optional overrides for image tags
 # platform_server_image_tag = "0.15.2"
-# docker_runner_image_tag   = "0.1.0"
+# docker_runner_image_tag   = "0.1.1"
 # agent_state_image_tag     = "v0.1.0"
 # token_counting_image_tag  = "v0.2.0"
 # files_image_tag           = "0.1.1"

--- a/stacks/platform/terraform.tfvars.example
+++ b/stacks/platform/terraform.tfvars.example
@@ -6,7 +6,7 @@ kubeconfig_path = "../k8s/.kube/agyn-local-kubeconfig.yaml"
 
 platform_namespace         = "platform"
 platform_chart_version     = "0.15.2"
-docker_runner_chart_version = "0.1.1"
+docker_runner_chart_version = "0.1.2"
 agent_state_chart_version  = "0.1.0"
 token_counting_chart_version = "0.2.0"
 postgres_chart_version     = "0.1.1"
@@ -14,7 +14,7 @@ docker_runner_replica_count = 1
 
 # Optional overrides for image tags
 # platform_server_image_tag = "0.15.2"
-# docker_runner_image_tag   = "0.1.1"
+# docker_runner_image_tag   = "0.1.2"
 # agent_state_image_tag     = "v0.1.0"
 # token_counting_image_tag  = "v0.2.0"
 # files_image_tag           = "0.1.1"

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -26,7 +26,7 @@ variable "platform_chart_version" {
 variable "docker_runner_chart_version" {
   type        = string
   description = "Version of the docker-runner Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.1.1"
 }
 
 variable "gateway_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -23,6 +23,12 @@ variable "platform_chart_version" {
   default     = "0.15.2"
 }
 
+variable "docker_runner_chart_version" {
+  type        = string
+  description = "Version of the docker-runner Helm chart published to GHCR"
+  default     = "0.1.0"
+}
+
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -26,7 +26,7 @@ variable "platform_chart_version" {
 variable "docker_runner_chart_version" {
   type        = string
   description = "Version of the docker-runner Helm chart published to GHCR"
-  default     = "0.1.1"
+  default     = "0.1.2"
 }
 
 variable "gateway_chart_version" {


### PR DESCRIPTION
## Summary
- add a docker-runner chart version variable for platform stack configuration
- use the docker-runner chart version for image tag fallback and Argo CD target revision
- document the docker-runner chart version override in terraform.tfvars.example

## Testing
- terraform fmt -check -recursive
- terraform -chdir=stacks/k8s validate
- terraform -chdir=stacks/system validate
- terraform -chdir=stacks/routing validate
- terraform -chdir=stacks/platform validate

Fixes #96