### PR TITLE
Bump notifications chart to 0.2.1

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -56,7 +56,7 @@ variable "token_counting_chart_version" {
 variable "notifications_chart_version" {
   type        = string
   description = "Version of the notifications Helm chart published to GHCR"
-  default     = "0.2.0"
+  default     = "0.2.1"
 }
 
 variable "notifications_redis_chart_version" {


### PR DESCRIPTION
## Summary
- bump the default notifications chart version to 0.2.1

## Testing
- ./apply.sh -y

## Issue
- #88