### PR TITLE
fix: bump threads chart to 0.1.2 for multi-arch image

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -44,7 +44,7 @@ variable "agent_state_chart_version" {
 variable "threads_chart_version" {
   type        = string
   description = "Version of the threads Helm chart published to GHCR"
-  default     = "0.1.2"
+  default     = "0.1.1"
 }
 
 variable "token_counting_chart_version" {
@@ -134,7 +134,7 @@ variable "agent_state_image_tag" {
 variable "threads_image_tag" {
   type        = string
   description = "Optional override for the threads image tag"
-  default     = ""
+  default     = "v0.1.2"
 }
 
 variable "chat_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -44,7 +44,7 @@ variable "agent_state_chart_version" {
 variable "threads_chart_version" {
   type        = string
   description = "Version of the threads Helm chart published to GHCR"
-  default     = "0.1.1"
+  default     = "0.1.2"
 }
 
 variable "token_counting_chart_version" {


### PR DESCRIPTION
## Summary
- revert `threads_chart_version` to 0.1.1 (published chart)
- pin `threads_image_tag` to v0.1.2 for the multi-arch image override

## Testing
- terraform -chdir=stacks/k8s apply -input=false -auto-approve
- terraform -chdir=stacks/system apply -input=false -auto-approve
- terraform -chdir=stacks/routing apply -input=false -auto-approve
- terraform -chdir=stacks/data apply -input=false -auto-approve
- terraform -chdir=stacks/platform apply -input=false -auto-approve

Related: agynio/threads#6
