### PR TITLE
chore: bump teams chart to 0.2.0

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -758,17 +758,17 @@ locals {
 
   teams_values = yamlencode({
     fullnameOverride = "teams"
-    service = {
-      port = 50051
-    }
-    database = {
-      url = format("postgresql://teams:%s@teams-db:5432/teams?sslmode=disable", var.teams_db_password)
-    }
     image = {
       repository = "ghcr.io/agynio/teams"
       tag        = local.resolved_teams_image_tag
       pullPolicy = "IfNotPresent"
     }
+    env = [
+      {
+        name  = "DATABASE_URL"
+        value = format("postgresql://teams:%s@teams-db:5432/teams?sslmode=disable", var.teams_db_password)
+      },
+    ]
   })
 
   agents_orchestrator_values = yamlencode({

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -14,7 +14,7 @@ locals {
   resolved_secrets_image_tag             = trimspace(var.secrets_image_tag) != "" ? var.secrets_image_tag : format("v%s", var.secrets_chart_version)
   resolved_token_counting_image_tag      = trimspace(var.token_counting_image_tag) != "" ? var.token_counting_image_tag : format("v%s", var.token_counting_chart_version)
   resolved_notifications_image_tag       = trimspace(var.notifications_image_tag) != "" ? var.notifications_image_tag : var.notifications_chart_version
-  resolved_teams_image_tag               = trimspace(var.teams_image_tag) != "" ? var.teams_image_tag : format("v%s", var.teams_chart_version)
+  resolved_teams_image_tag               = trimspace(var.teams_image_tag) != "" ? var.teams_image_tag : var.teams_chart_version
   resolved_authorization_image_tag       = trimspace(var.authorization_image_tag) != "" ? var.authorization_image_tag : format("v%s", var.authorization_chart_version)
 
   postgres_image                 = "postgres:16.6-alpine"

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -80,7 +80,7 @@ variable "postgres_chart_version" {
 variable "teams_chart_version" {
   type        = string
   description = "Version of the teams Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "chat_app_chart_version" {


### PR DESCRIPTION
## Summary

Bumps `teams_chart_version` from `0.1.0` to `0.2.0` to deploy the new entity model and rewritten proto contracts.

### Changes in teams v0.2.0
- feat(variables): add CRUD support (#4)
- chore: align teams architecture (#6)
- feat(teams): implement new entity model (#8)

This is required to unblock `agents-orchestrator` E2E tests — the current deployed `teams:0.1.0` uses old proto contracts that are wire-incompatible with the latest BSR.