### PR TITLE
chore: bump orchestrator to 0.1.5, add DOCKER_RUNNER_SHARED_SECRET

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -798,6 +798,10 @@ locals {
       {
         name  = "IDLE_TIMEOUT"
         value = "30s"
+      },
+      {
+        name  = "DOCKER_RUNNER_SHARED_SECRET"
+        value = var.docker_runner_shared_secret
       }
     ]
   })

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -44,7 +44,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.1.4"
+  default     = "0.1.5"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
## Summary

- Bumps `agents_orchestrator_chart_version` from `0.1.4` to `0.1.5`
- Adds `DOCKER_RUNNER_SHARED_SECRET` env var to the orchestrator deployment

### Why

The orchestrator now authenticates gRPC calls to docker-runner using HMAC-SHA256 (added in agents-orchestrator PR #27). The `DOCKER_RUNNER_SHARED_SECRET` env var is **required** — the orchestrator will fail to start without it.

This was the root cause of E2E test failures: the orchestrator wasn't running because it lacked this env var, so no workloads were being created.