### PR TITLE
chore: bump orchestrator to 0.1.7, add DOCKER_RUNNER_SHARED_SECRET

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -44,7 +44,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.1.6"
+  default     = "0.1.7"
 }
 
 variable "threads_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -44,7 +44,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.1.5"
+  default     = "0.1.6"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
## Summary

- Bumps `agents_orchestrator_chart_version` from `0.1.4` to `0.1.7`
- Adds `DOCKER_RUNNER_SHARED_SECRET` env var to the orchestrator deployment

### Changes in v0.1.5–v0.1.7

- **v0.1.5**: HMAC authentication for docker-runner gRPC calls; `DOCKER_RUNNER_SHARED_SECRET` env var required
- **v0.1.6**: Keep-alive command (`sleep infinity`) on agent containers — fixes infinite create/exit/remove loop
- **v0.1.7**: Include thread ID in container name — fixes Docker name conflict when same agent serves multiple threads

### E2E Verification

All 4 E2E tests pass locally with v0.1.7.