### PR TITLE
feat(platform): add users stack

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -15,6 +15,7 @@ locals {
   resolved_token_counting_image_tag      = trimspace(var.token_counting_image_tag) != "" ? var.token_counting_image_tag : format("v%s", var.token_counting_chart_version)
   resolved_notifications_image_tag       = trimspace(var.notifications_image_tag) != "" ? var.notifications_image_tag : var.notifications_chart_version
   resolved_teams_image_tag               = trimspace(var.teams_image_tag) != "" ? var.teams_image_tag : var.teams_chart_version
+  resolved_users_image_tag               = trimspace(var.users_image_tag) != "" ? var.users_image_tag : var.users_chart_version
   resolved_authorization_image_tag       = trimspace(var.authorization_image_tag) != "" ? var.authorization_image_tag : format("v%s", var.authorization_chart_version)
 
   postgres_image                 = "postgres:16.6-alpine"
@@ -49,6 +50,7 @@ locals {
   notifications_chart_name       = "agynio/charts/notifications"
   redis_chart_name               = "redis"
   teams_chart_name               = "agynio/charts/teams"
+  users_chart_name               = "agynio/charts/users"
   authorization_chart_name       = "agynio/charts/authorization"
   istio_gateway_namespace        = data.terraform_remote_state.system.outputs.istio_gateway_namespace
   istio_gateway_tls_secret_name  = data.terraform_remote_state.system.outputs.wildcard_tls_gateway_secret_name
@@ -619,6 +621,29 @@ locals {
     }
   })
 
+  users_db_values = yamlencode({
+    fullnameOverride = "users-db"
+    postgres = {
+      database = "users"
+      username = "users"
+      password = var.users_db_password
+      pgdata   = "/var/lib/postgresql/data/pgdata"
+    }
+    persistence = {
+      size                    = var.users_db_pvc_size
+      mountPath               = "/var/lib/postgresql/data"
+      volumeClaimTemplateName = "data"
+    }
+    probes = {
+      readiness = {
+        execCommand = ["pg_isready", "-U", "users", "-d", "users"]
+      }
+      liveness = {
+        execCommand = ["pg_isready", "-U", "users", "-d", "users"]
+      }
+    }
+  })
+
   agents_orchestrator_db_values = yamlencode({
     fullnameOverride = "agents-orchestrator-db"
     postgres = {
@@ -767,6 +792,21 @@ locals {
       {
         name  = "DATABASE_URL"
         value = format("postgresql://teams:%s@teams-db:5432/teams?sslmode=disable", var.teams_db_password)
+      },
+    ]
+  })
+
+  users_values = yamlencode({
+    fullnameOverride = "users"
+    image = {
+      repository = "ghcr.io/agynio/users"
+      tag        = local.resolved_users_image_tag
+      pullPolicy = "IfNotPresent"
+    }
+    env = [
+      {
+        name  = "DATABASE_URL"
+        value = format("postgresql://users:%s@users-db:5432/users?sslmode=disable", var.users_db_password)
       },
     ]
   })
@@ -2652,6 +2692,56 @@ resource "argocd_application" "teams_db" {
   }
 }
 
+resource "argocd_application" "users_db" {
+  depends_on = [argocd_repository.litellm_repo]
+  wait       = true
+
+  metadata {
+    name      = "users-db"
+    namespace = "argocd"
+    annotations = {
+      "argocd.argoproj.io/sync-wave" = "8"
+    }
+  }
+
+  spec {
+    project = "default"
+
+    source {
+      repo_url        = local.postgres_chart_repo_host
+      chart           = local.postgres_chart_name
+      target_revision = var.postgres_chart_version
+
+      helm {
+        values = local.users_db_values
+      }
+    }
+
+    destination {
+      server    = var.destination_server
+      namespace = var.platform_namespace
+    }
+
+    sync_policy {
+      # DB apps always use automated sync with prune disabled for stateful safety,
+      # independent of var.argocd_automated_sync_enabled.
+      automated {
+        prune       = false
+        self_heal   = true
+        allow_empty = false
+      }
+
+      sync_options = local.postgres_sync_options
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
 resource "argocd_application" "agents_orchestrator_db" {
   depends_on = [argocd_repository.litellm_repo]
   wait       = true
@@ -3226,6 +3316,52 @@ resource "argocd_application" "teams" {
 
       helm {
         values = local.teams_values
+      }
+    }
+
+    destination {
+      server    = var.destination_server
+      namespace = var.platform_namespace
+    }
+
+    sync_policy {
+      dynamic "automated" {
+        for_each = var.argocd_automated_sync_enabled ? [1] : []
+        content {
+          prune       = var.argocd_prune_enabled
+          self_heal   = var.argocd_self_heal_enabled
+          allow_empty = false
+        }
+      }
+
+      sync_options = local.default_sync_options
+    }
+  }
+}
+
+resource "argocd_application" "users" {
+  depends_on = [
+    argocd_repository.litellm_repo,
+    argocd_application.users_db,
+  ]
+  metadata {
+    name      = "users"
+    namespace = "argocd"
+    annotations = {
+      "argocd.argoproj.io/sync-wave" = "17"
+    }
+  }
+
+  spec {
+    project = "default"
+
+    source {
+      repo_url        = local.platform_chart_repo_host
+      chart           = local.users_chart_name
+      target_revision = var.users_chart_version
+
+      helm {
+        values = local.users_values
       }
     }
 

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -83,6 +83,12 @@ variable "teams_chart_version" {
   default     = "0.2.0"
 }
 
+variable "users_chart_version" {
+  type        = string
+  description = "Version of the users Helm chart published to GHCR"
+  default     = "0.1.0"
+}
+
 variable "chat_app_chart_version" {
   type        = string
   description = "Version of the chat-app Helm chart published to GHCR"
@@ -176,6 +182,12 @@ variable "notifications_image_tag" {
 variable "teams_image_tag" {
   type        = string
   description = "Optional override for the teams image tag"
+  default     = ""
+}
+
+variable "users_image_tag" {
+  type        = string
+  description = "Optional override for the users image tag"
   default     = ""
 }
 
@@ -340,6 +352,19 @@ variable "teams_db_password" {
 variable "teams_db_pvc_size" {
   type        = string
   description = "Persistent volume claim size for the teams PostgreSQL primary"
+  default     = "5Gi"
+}
+
+variable "users_db_password" {
+  type        = string
+  description = "Password for the users PostgreSQL database user"
+  default     = "users"
+  sensitive   = true
+}
+
+variable "users_db_pvc_size" {
+  type        = string
+  description = "Persistent volume claim size for the users PostgreSQL primary"
   default     = "5Gi"
 }
 


### PR DESCRIPTION
## Summary
- add users chart variables, image tags, and database settings
- define Argo CD applications for users service and database
- wire users values into the platform stack locals

## Testing
- terraform -chdir=stacks/platform init
- terraform -chdir=stacks/platform fmt
- terraform -chdir=stacks/platform validate

Refs #1