### PR TITLE
chore: bump chat-app and tracing-app to 0.1.2

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -86,7 +86,7 @@ variable "teams_chart_version" {
 variable "chat_app_chart_version" {
   type        = string
   description = "Version of the chat-app Helm chart published to GHCR"
-  default     = "0.1.1"
+  default     = "0.1.2"
 }
 
 variable "chat_app_image_tag" {
@@ -98,7 +98,7 @@ variable "chat_app_image_tag" {
 variable "tracing_app_chart_version" {
   type        = string
   description = "Version of the tracing-app Helm chart published to GHCR"
-  default     = "0.1.1"
+  default     = "0.1.2"
 }
 
 variable "tracing_app_image_tag" {


### PR DESCRIPTION
Bumps both frontend apps to v0.1.2, which replaces all API dependencies with static mock data so the UI renders without any backend services (except `/files/v1`).

### Changes
- `chat_app_chart_version`: `0.1.1` → `0.1.2`
- `tracing_app_chart_version`: `0.1.1` → `0.1.2`

### Release notes
- All `/api` calls replaced with static mock data
- Socket.io disabled in production
- E2e test pipelines updated (build + preview in-pod)
- No backend dependencies required for UI rendering