### PR TITLE
Fix agents orchestrator address

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -931,6 +931,10 @@ locals {
       {
         name  = "RUNNER_ADDRESS"
         value = "k8s-runner:50051"
+      },
+      {
+        name  = "AGENTS_ADDRESS"
+        value = "agents:50051"
       }
     ]
   })


### PR DESCRIPTION
## Summary
- set AGENTS_ADDRESS for agents-orchestrator to point at the renamed agents service

## Testing
- terraform fmt -check -recursive
- terraform -chdir=stacks/platform validate

Closes #138