### PR TITLE
Bump agents-orchestrator chart

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -931,10 +931,6 @@ locals {
       {
         name  = "RUNNER_ADDRESS"
         value = "k8s-runner:50051"
-      },
-      {
-        name  = "AGENTS_ADDRESS"
-        value = "agents:50051"
       }
     ]
   })

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -38,7 +38,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.1.7"
+  default     = "0.1.8"
 }
 
 variable "k8s_runner_chart_version" {


### PR DESCRIPTION
## Summary
- bump agents-orchestrator chart version to 0.1.8
- remove the AGENTS_ADDRESS override now that the binary defaults correctly

## Testing
- terraform fmt -check -recursive
- terraform -chdir=stacks/platform validate

Closes #141