### PR TITLE
Add OIDC config to gateway values

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -3902,6 +3902,11 @@ resource "argocd_application" "gateway" {
           image = {
             tag = local.resolved_gateway_image_tag
           }
+          gateway = {
+            oidcIssuerUrl   = var.oidc_issuer_url
+            oidcClientId    = var.oidc_client_id
+            usersGrpcTarget = "users:50051"
+          }
         })
       }
     }


### PR DESCRIPTION
## Summary
- add OIDC gateway values to ArgoCD Helm config

## Testing
- `NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform fmt -check stacks/platform/main.tf`
- `NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/platform validate`

Closes #143