### PR TITLE
feat(ziti): enroll identities at apply

### DIFF
--- a/modules/ziti-identity-enrollment/main.tf
+++ b/modules/ziti-identity-enrollment/main.tf
@@ -1,0 +1,57 @@
+locals {
+  # Enrollment artifacts include private keys; keep the directory secured.
+  jwt_file      = "${var.enrollment_dir}/${var.identity_name}.jwt"
+  identity_file = "${var.enrollment_dir}/${var.identity_name}.json"
+}
+
+resource "terraform_data" "enrollment" {
+  triggers_replace = {
+    enrollment_token = var.enrollment_token
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+      enrollment_dir="${var.enrollment_dir}"
+      jwt_file="${local.jwt_file}"
+      identity_file="${local.identity_file}"
+
+      mkdir -p "$enrollment_dir"
+      printf '%s' "$ZITI_JWT" > "$jwt_file"
+      ziti edge enroll --jwt "$jwt_file" --out "$identity_file"
+      chmod 600 "$identity_file"
+      rm -f "$jwt_file"
+    EOT
+
+    environment = {
+      ZITI_JWT = var.enrollment_token
+    }
+  }
+}
+
+data "local_file" "identity" {
+  depends_on = [terraform_data.enrollment]
+  filename   = local.identity_file
+}
+
+locals {
+  decoded_identity = jsondecode(data.local_file.identity.content)
+}
+
+resource "kubernetes_secret_v1" "identity" {
+  metadata {
+    name      = var.secret_name
+    namespace = var.namespace
+  }
+
+  type = "Opaque"
+
+  data = var.unpack_id ? {
+    cert = local.decoded_identity.id.cert
+    key  = local.decoded_identity.id.key
+    ca   = local.decoded_identity.id.ca
+    } : {
+    (var.identity_json_key) = data.local_file.identity.content
+  }
+}

--- a/modules/ziti-identity-enrollment/variables.tf
+++ b/modules/ziti-identity-enrollment/variables.tf
@@ -1,0 +1,37 @@
+variable "identity_name" {
+  type        = string
+  description = "Identity name used for enrollment artifacts"
+}
+
+variable "enrollment_token" {
+  type        = string
+  description = "Enrollment JWT for the identity"
+  sensitive   = true
+}
+
+variable "secret_name" {
+  type        = string
+  description = "Kubernetes secret name to store the enrolled identity"
+}
+
+variable "namespace" {
+  type        = string
+  description = "Kubernetes namespace for the identity secret"
+}
+
+variable "enrollment_dir" {
+  type        = string
+  description = "Directory for enrollment artifacts (contains private keys)"
+}
+
+variable "unpack_id" {
+  type        = bool
+  description = "Whether to store id.cert/key/ca fields instead of identity.json"
+  default     = false
+}
+
+variable "identity_json_key" {
+  type        = string
+  description = "Secret key name for the identity JSON"
+  default     = "identity.json"
+}

--- a/stacks/ziti/.terraform.lock.hcl
+++ b/stacks/ziti/.terraform.lock.hcl
@@ -41,6 +41,26 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.7.0"
+  constraints = "~> 2.5"
+  hashes = [
+    "h1:2RYa3j7m/0WmET2fqotY4CHxE1Hpk0fgn47/126l+Og=",
+    "zh:261fec71bca13e0a7812dc0d8ae9af2b4326b24d9b2e9beab3d2400fab5c5f9a",
+    "zh:308da3b5376a9ede815042deec5af1050ec96a5a5410a2206ae847d82070a23e",
+    "zh:3d056924c420464dc8aba10e1915956b2e5c4d55b11ffff79aa8be563fbfe298",
+    "zh:643256547b155459c45e0a3e8aab0570db59923c68daf2086be63c444c8c445b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7aa4d0b853f84205e8cf79f30c9b2c562afbfa63592f7231b6637e5d7a6b5b27",
+    "zh:7dc251bbc487d58a6ab7f5b07ec9edc630edb45d89b761dba28e0e2ba6b1c11f",
+    "zh:7ee0ca546cd065030039168d780a15cbbf1765a4c70cd56d394734ab112c93da",
+    "zh:b1d5d80abb1906e6c6b3685a52a0192b4ca6525fe090881c64ec6f67794b1300",
+    "zh:d81ea9856d61db3148a4fc6c375bf387a721d78fc1fea7a8823a027272a47a78",
+    "zh:df0a1f0afc947b8bfc88617c1ad07a689ce3bd1a29fd97318392e6bdd32b230b",
+    "zh:dfbcad800240e0c68c43e0866f2a751cff09777375ec701918881acf67a268da",
+  ]
+}
+
 provider "registry.terraform.io/netfoundry/ziti" {
   version     = "1.0.4"
   constraints = "~> 1.0"

--- a/stacks/ziti/main.tf
+++ b/stacks/ziti/main.tf
@@ -6,7 +6,8 @@ locals {
   management_identity_secret_name   = "ziti-management-identity"
   orchestrator_identity_secret_name = "ziti-orchestrator-identity"
   runner_identity_secret_name       = "ziti-runner-identity"
-  identity_enrollment_dir           = "${path.module}/.terraform/ziti-identities"
+  # Stores enrolled identity JSON containing private keys.
+  identity_enrollment_dir = "${path.module}/.terraform/ziti-identities"
 
   router_values = yamlencode({
     ctrl = {
@@ -96,178 +97,41 @@ resource "ziti_identity" "runner" {
   role_attributes = ["runners"]
 }
 
-resource "terraform_data" "gateway_identity_enrollment" {
-  triggers_replace = {
-    enrollment_token = ziti_identity.gateway.enrollment_token
-  }
-
-  provisioner "local-exec" {
-    interpreter = ["/bin/bash", "-c"]
-    command     = <<-EOT
-      set -euo pipefail
-      enrollment_dir="${local.identity_enrollment_dir}"
-      jwt_file="${local.identity_enrollment_dir}/gateway.jwt"
-      identity_file="${local.identity_enrollment_dir}/gateway.json"
-
-      mkdir -p "$enrollment_dir"
-      printf '%s' "$ZITI_JWT" > "$jwt_file"
-      ziti edge enroll --jwt "$jwt_file" --out "$identity_file"
-    EOT
-
-    environment = {
-      ZITI_JWT = ziti_identity.gateway.enrollment_token
-    }
-  }
+module "gateway_identity_enrollment" {
+  source           = "../../modules/ziti-identity-enrollment"
+  identity_name    = "gateway"
+  enrollment_token = ziti_identity.gateway.enrollment_token
+  secret_name      = local.gateway_identity_secret_name
+  namespace        = local.ziti_namespace
+  enrollment_dir   = local.identity_enrollment_dir
 }
 
-data "local_file" "gateway_identity" {
-  depends_on = [terraform_data.gateway_identity_enrollment]
-  filename   = "${local.identity_enrollment_dir}/gateway.json"
+module "ziti_management_identity_enrollment" {
+  source           = "../../modules/ziti-identity-enrollment"
+  identity_name    = "ziti-management"
+  enrollment_token = ziti_identity.ziti_management.enrollment_token
+  secret_name      = local.management_identity_secret_name
+  namespace        = local.ziti_namespace
+  enrollment_dir   = local.identity_enrollment_dir
+  unpack_id        = true
 }
 
-resource "kubernetes_secret_v1" "gateway_identity" {
-  metadata {
-    name      = local.gateway_identity_secret_name
-    namespace = local.ziti_namespace
-  }
-
-  type = "Opaque"
-
-  data = {
-    "identity.json" = data.local_file.gateway_identity.content
-  }
+module "orchestrator_identity_enrollment" {
+  source           = "../../modules/ziti-identity-enrollment"
+  identity_name    = "orchestrator"
+  enrollment_token = ziti_identity.orchestrator.enrollment_token
+  secret_name      = local.orchestrator_identity_secret_name
+  namespace        = local.ziti_namespace
+  enrollment_dir   = local.identity_enrollment_dir
 }
 
-resource "terraform_data" "ziti_management_identity_enrollment" {
-  triggers_replace = {
-    enrollment_token = ziti_identity.ziti_management.enrollment_token
-  }
-
-  provisioner "local-exec" {
-    interpreter = ["/bin/bash", "-c"]
-    command     = <<-EOT
-      set -euo pipefail
-      enrollment_dir="${local.identity_enrollment_dir}"
-      jwt_file="${local.identity_enrollment_dir}/ziti-management.jwt"
-      identity_file="${local.identity_enrollment_dir}/ziti-management.json"
-
-      mkdir -p "$enrollment_dir"
-      printf '%s' "$ZITI_JWT" > "$jwt_file"
-      ziti edge enroll --jwt "$jwt_file" --out "$identity_file"
-    EOT
-
-    environment = {
-      ZITI_JWT = ziti_identity.ziti_management.enrollment_token
-    }
-  }
-}
-
-data "local_file" "ziti_management_identity" {
-  depends_on = [terraform_data.ziti_management_identity_enrollment]
-  filename   = "${local.identity_enrollment_dir}/ziti-management.json"
-}
-
-locals {
-  ziti_management_identity = jsondecode(data.local_file.ziti_management_identity.content)
-}
-
-resource "kubernetes_secret_v1" "ziti_management_identity" {
-  metadata {
-    name      = local.management_identity_secret_name
-    namespace = local.ziti_namespace
-  }
-
-  type = "Opaque"
-
-  data = {
-    cert = local.ziti_management_identity.cert
-    key  = local.ziti_management_identity.key
-    ca   = local.ziti_management_identity.ca
-  }
-}
-
-resource "terraform_data" "orchestrator_identity_enrollment" {
-  triggers_replace = {
-    enrollment_token = ziti_identity.orchestrator.enrollment_token
-  }
-
-  provisioner "local-exec" {
-    interpreter = ["/bin/bash", "-c"]
-    command     = <<-EOT
-      set -euo pipefail
-      enrollment_dir="${local.identity_enrollment_dir}"
-      jwt_file="${local.identity_enrollment_dir}/orchestrator.jwt"
-      identity_file="${local.identity_enrollment_dir}/orchestrator.json"
-
-      mkdir -p "$enrollment_dir"
-      printf '%s' "$ZITI_JWT" > "$jwt_file"
-      ziti edge enroll --jwt "$jwt_file" --out "$identity_file"
-    EOT
-
-    environment = {
-      ZITI_JWT = ziti_identity.orchestrator.enrollment_token
-    }
-  }
-}
-
-data "local_file" "orchestrator_identity" {
-  depends_on = [terraform_data.orchestrator_identity_enrollment]
-  filename   = "${local.identity_enrollment_dir}/orchestrator.json"
-}
-
-resource "kubernetes_secret_v1" "orchestrator_identity" {
-  metadata {
-    name      = local.orchestrator_identity_secret_name
-    namespace = local.ziti_namespace
-  }
-
-  type = "Opaque"
-
-  data = {
-    "identity.json" = data.local_file.orchestrator_identity.content
-  }
-}
-
-resource "terraform_data" "runner_identity_enrollment" {
-  triggers_replace = {
-    enrollment_token = ziti_identity.runner.enrollment_token
-  }
-
-  provisioner "local-exec" {
-    interpreter = ["/bin/bash", "-c"]
-    command     = <<-EOT
-      set -euo pipefail
-      enrollment_dir="${local.identity_enrollment_dir}"
-      jwt_file="${local.identity_enrollment_dir}/runner.jwt"
-      identity_file="${local.identity_enrollment_dir}/runner.json"
-
-      mkdir -p "$enrollment_dir"
-      printf '%s' "$ZITI_JWT" > "$jwt_file"
-      ziti edge enroll --jwt "$jwt_file" --out "$identity_file"
-    EOT
-
-    environment = {
-      ZITI_JWT = ziti_identity.runner.enrollment_token
-    }
-  }
-}
-
-data "local_file" "runner_identity" {
-  depends_on = [terraform_data.runner_identity_enrollment]
-  filename   = "${local.identity_enrollment_dir}/runner.json"
-}
-
-resource "kubernetes_secret_v1" "runner_identity" {
-  metadata {
-    name      = local.runner_identity_secret_name
-    namespace = local.ziti_namespace
-  }
-
-  type = "Opaque"
-
-  data = {
-    "identity.json" = data.local_file.runner_identity.content
-  }
+module "runner_identity_enrollment" {
+  source           = "../../modules/ziti-identity-enrollment"
+  identity_name    = "runner"
+  enrollment_token = ziti_identity.runner.enrollment_token
+  secret_name      = local.runner_identity_secret_name
+  namespace        = local.ziti_namespace
+  enrollment_dir   = local.identity_enrollment_dir
 }
 
 resource "ziti_service_policy" "agents_dial_gateway" {

--- a/stacks/ziti/main.tf
+++ b/stacks/ziti/main.tf
@@ -2,9 +2,11 @@ locals {
   openziti_repository_url           = "https://openziti.io/helm-charts"
   ziti_namespace                    = "ziti"
   router_enrollment_secret_name     = "ziti-router-enrollment"
-  gateway_identity_secret_name      = "ziti-gateway-enrollment"
-  management_identity_secret_name   = "ziti-management-enrollment"
-  orchestrator_identity_secret_name = "ziti-orchestrator-enrollment"
+  gateway_identity_secret_name      = "ziti-gateway-identity"
+  management_identity_secret_name   = "ziti-management-identity"
+  orchestrator_identity_secret_name = "ziti-orchestrator-identity"
+  runner_identity_secret_name       = "ziti-runner-identity"
+  identity_enrollment_dir           = "${path.module}/.terraform/ziti-identities"
 
   router_values = yamlencode({
     ctrl = {
@@ -88,7 +90,42 @@ resource "ziti_identity" "orchestrator" {
   role_attributes = ["orchestrators"]
 }
 
-resource "kubernetes_secret_v1" "gateway_identity_enrollment" {
+resource "ziti_identity" "runner" {
+  name            = "runner"
+  type            = "Device"
+  role_attributes = ["runners"]
+}
+
+resource "terraform_data" "gateway_identity_enrollment" {
+  triggers_replace = {
+    enrollment_token = ziti_identity.gateway.enrollment_token
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+      enrollment_dir="${local.identity_enrollment_dir}"
+      jwt_file="${local.identity_enrollment_dir}/gateway.jwt"
+      identity_file="${local.identity_enrollment_dir}/gateway.json"
+
+      mkdir -p "$enrollment_dir"
+      printf '%s' "$ZITI_JWT" > "$jwt_file"
+      ziti edge enroll --jwt "$jwt_file" --out "$identity_file"
+    EOT
+
+    environment = {
+      ZITI_JWT = ziti_identity.gateway.enrollment_token
+    }
+  }
+}
+
+data "local_file" "gateway_identity" {
+  depends_on = [terraform_data.gateway_identity_enrollment]
+  filename   = "${local.identity_enrollment_dir}/gateway.json"
+}
+
+resource "kubernetes_secret_v1" "gateway_identity" {
   metadata {
     name      = local.gateway_identity_secret_name
     namespace = local.ziti_namespace
@@ -97,11 +134,44 @@ resource "kubernetes_secret_v1" "gateway_identity_enrollment" {
   type = "Opaque"
 
   data = {
-    enrollmentJwt = ziti_identity.gateway.enrollment_token
+    "identity.json" = data.local_file.gateway_identity.content
   }
 }
 
-resource "kubernetes_secret_v1" "ziti_management_identity_enrollment" {
+resource "terraform_data" "ziti_management_identity_enrollment" {
+  triggers_replace = {
+    enrollment_token = ziti_identity.ziti_management.enrollment_token
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+      enrollment_dir="${local.identity_enrollment_dir}"
+      jwt_file="${local.identity_enrollment_dir}/ziti-management.jwt"
+      identity_file="${local.identity_enrollment_dir}/ziti-management.json"
+
+      mkdir -p "$enrollment_dir"
+      printf '%s' "$ZITI_JWT" > "$jwt_file"
+      ziti edge enroll --jwt "$jwt_file" --out "$identity_file"
+    EOT
+
+    environment = {
+      ZITI_JWT = ziti_identity.ziti_management.enrollment_token
+    }
+  }
+}
+
+data "local_file" "ziti_management_identity" {
+  depends_on = [terraform_data.ziti_management_identity_enrollment]
+  filename   = "${local.identity_enrollment_dir}/ziti-management.json"
+}
+
+locals {
+  ziti_management_identity = jsondecode(data.local_file.ziti_management_identity.content)
+}
+
+resource "kubernetes_secret_v1" "ziti_management_identity" {
   metadata {
     name      = local.management_identity_secret_name
     namespace = local.ziti_namespace
@@ -110,11 +180,42 @@ resource "kubernetes_secret_v1" "ziti_management_identity_enrollment" {
   type = "Opaque"
 
   data = {
-    enrollmentJwt = ziti_identity.ziti_management.enrollment_token
+    cert = local.ziti_management_identity.cert
+    key  = local.ziti_management_identity.key
+    ca   = local.ziti_management_identity.ca
   }
 }
 
-resource "kubernetes_secret_v1" "orchestrator_identity_enrollment" {
+resource "terraform_data" "orchestrator_identity_enrollment" {
+  triggers_replace = {
+    enrollment_token = ziti_identity.orchestrator.enrollment_token
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+      enrollment_dir="${local.identity_enrollment_dir}"
+      jwt_file="${local.identity_enrollment_dir}/orchestrator.jwt"
+      identity_file="${local.identity_enrollment_dir}/orchestrator.json"
+
+      mkdir -p "$enrollment_dir"
+      printf '%s' "$ZITI_JWT" > "$jwt_file"
+      ziti edge enroll --jwt "$jwt_file" --out "$identity_file"
+    EOT
+
+    environment = {
+      ZITI_JWT = ziti_identity.orchestrator.enrollment_token
+    }
+  }
+}
+
+data "local_file" "orchestrator_identity" {
+  depends_on = [terraform_data.orchestrator_identity_enrollment]
+  filename   = "${local.identity_enrollment_dir}/orchestrator.json"
+}
+
+resource "kubernetes_secret_v1" "orchestrator_identity" {
   metadata {
     name      = local.orchestrator_identity_secret_name
     namespace = local.ziti_namespace
@@ -123,7 +224,49 @@ resource "kubernetes_secret_v1" "orchestrator_identity_enrollment" {
   type = "Opaque"
 
   data = {
-    enrollmentJwt = ziti_identity.orchestrator.enrollment_token
+    "identity.json" = data.local_file.orchestrator_identity.content
+  }
+}
+
+resource "terraform_data" "runner_identity_enrollment" {
+  triggers_replace = {
+    enrollment_token = ziti_identity.runner.enrollment_token
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+      enrollment_dir="${local.identity_enrollment_dir}"
+      jwt_file="${local.identity_enrollment_dir}/runner.jwt"
+      identity_file="${local.identity_enrollment_dir}/runner.json"
+
+      mkdir -p "$enrollment_dir"
+      printf '%s' "$ZITI_JWT" > "$jwt_file"
+      ziti edge enroll --jwt "$jwt_file" --out "$identity_file"
+    EOT
+
+    environment = {
+      ZITI_JWT = ziti_identity.runner.enrollment_token
+    }
+  }
+}
+
+data "local_file" "runner_identity" {
+  depends_on = [terraform_data.runner_identity_enrollment]
+  filename   = "${local.identity_enrollment_dir}/runner.json"
+}
+
+resource "kubernetes_secret_v1" "runner_identity" {
+  metadata {
+    name      = local.runner_identity_secret_name
+    namespace = local.ziti_namespace
+  }
+
+  type = "Opaque"
+
+  data = {
+    "identity.json" = data.local_file.runner_identity.content
   }
 }
 

--- a/stacks/ziti/outputs.tf
+++ b/stacks/ziti/outputs.tf
@@ -8,6 +8,7 @@ output "identity_ids" {
     gateway         = ziti_identity.gateway.id
     ziti_management = ziti_identity.ziti_management.id
     orchestrator    = ziti_identity.orchestrator.id
+    runner          = ziti_identity.runner.id
   }
   description = "Ziti identity IDs"
 }

--- a/stacks/ziti/versions.tf
+++ b/stacks/ziti/versions.tf
@@ -14,6 +14,10 @@ terraform {
       source  = "hashicorp/helm"
       version = "~> 2.13"
     }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.5"
+    }
   }
 
   backend "local" {


### PR DESCRIPTION
## Summary
- add runner identity and secrets for enrolled identities
- enroll gateway/orchestrator/runner/management identities at apply time
- unpack management identity cert/key/ca into its secret

## Testing
- terraform fmt -check -recursive
- TF_VAR_ziti_admin_password=placeholder terraform -chdir=stacks/ziti validate

Refs #145