### PR TITLE
feat(platform): upgrade gateway to v0.7.0 and fix chat-app API routing

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1907,6 +1907,9 @@ resource "kubernetes_manifest" "virtualservice_chat_app" {
               }
             }
           ]
+          "rewrite" = {
+            "uri" = "/"
+          }
           "route" = [
             {
               "destination" = {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -26,7 +26,7 @@ variable "platform_chart_version" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.6.0"
+  default     = "0.7.0"
 }
 
 variable "agent_state_chart_version" {


### PR DESCRIPTION
## Summary

Upgrades the Gateway from v0.6.0 to v0.7.0 and fixes the chat-app API routing.

### Gateway v0.7.0

New release includes all changes since v0.6.0:
- **ConnectRPC migration** (PR #76) — replaces chi-router/oapi-codegen with ConnectRPC handlers
- **`/me` endpoint** — returns caller's `identity_id` and `identity_type`
- **OIDC bearer auth** (PR #80) — JWT validation against IdP
- **Identity propagation** (PR #78) — forwards resolved identity in gRPC metadata
- **Identity interceptors** (PR #83)
- **API token auth** (PR #85)

### Chat-App VirtualService Fix

Adds `"rewrite" = { "uri" = "/" }` to the `/api` route on the `chat-app` VirtualService.

The ConnectRPC gateway registers handlers at bare paths (e.g., `/agynio.api.gateway.v1.ChatGateway/CreateChat`, `/me`). Without the URI rewrite, requests arriving as `/api/agynio.api.gateway.v1.ChatGateway/CreateChat` don't match any handler and return 404.

This is consistent with the existing `/apiv2/` route on the platform-ui VirtualService, which already has the rewrite.

### Changes

- `stacks/platform/variables.tf`: `gateway_chart_version` default `0.6.0` → `0.7.0`
- `stacks/platform/main.tf`: add `"rewrite" = { "uri" = "/" }` to chat-app `/api` route