### PR TITLE
fix(platform): fix chat-app VirtualService /api rewrite double-slash

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1903,7 +1903,12 @@ resource "kubernetes_manifest" "virtualservice_chat_app" {
           "match" = [
             {
               "uri" = {
-                "prefix" = "/api"
+                "prefix" = "/api/"
+              }
+            },
+            {
+              "uri" = {
+                "exact" = "/api"
               }
             }
           ]


### PR DESCRIPTION
## Problem

The chat-app VirtualService prefix match `"/api"` (without trailing slash) combined with `rewrite.uri: "/"` produces a double-slash path:

```
/api/agynio.api.gateway.v1.ChatGateway/CreateChat
  → rewrite replaces "/api" with "/"
  → //agynio.api.gateway.v1.ChatGateway/CreateChat  ← double slash
```

Go's `http.ServeMux` path-cleans `//` → sends 301 redirect → Node.js `fetch` follows with GET (standard 301 behavior) → request escapes the `/api` route scope → hits SPA catch-all → returns `index.html` instead of JSON.

## Fix

Change the match to `prefix: "/api/"` (with trailing slash) plus `exact: "/api"`, matching the working pattern used by the platform-ui VirtualService with `"/apiv2/"`:

```hcl
"match" = [
  { "uri" = { "prefix" = "/api/" } },
  { "uri" = { "exact"  = "/api"  } }
]
"rewrite" = { "uri" = "/" }
```

This ensures `/api/` is replaced with `/` (single slash) ✅

## Related

- Follows up on PR #149 which introduced the rewrite
- Unblocks chat-app PR agynio/chat-app#31 e2e tests