### PR TITLE
chore(platform): bump chat chart version to 0.2.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -32,7 +32,7 @@ variable "gateway_chart_version" {
 variable "agent_state_chart_version" {
   type        = string
   description = "Version of the agent-state Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "agents_orchestrator_chart_version" {
@@ -44,7 +44,7 @@ variable "agents_orchestrator_chart_version" {
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "threads_chart_version" {
@@ -86,13 +86,13 @@ variable "agents_chart_version" {
 variable "users_chart_version" {
   type        = string
   description = "Version of the users Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "tenants_chart_version" {
   type        = string
   description = "Version of the tenants Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "chat_app_chart_version" {
@@ -183,7 +183,7 @@ variable "threads_image_tag" {
 variable "chat_chart_version" {
   type        = string
   description = "Version of the chat Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "chat_image_tag" {
@@ -345,7 +345,7 @@ variable "files_db_pvc_size" {
 variable "llm_chart_version" {
   type        = string
   description = "Version of the llm Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "llm_image_tag" {
@@ -467,7 +467,7 @@ variable "registry_mirror_pvc_size" {
 variable "secrets_chart_version" {
   type        = string
   description = "Version of the secrets Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "secrets_image_tag" {


### PR DESCRIPTION
## Summary

Bumps `chat_chart_version` from `0.1.0` to `0.2.0`.

## Why

Chat v0.1.0 requires `x-tenant-id` gRPC metadata on every request, but gateway v0.7.0 only propagates `x-identity-id` and `x-identity-type`. This causes all ConnectRPC chat calls to fail with:

```
HTTP 401: {"code":"unauthenticated","message":"identity: missing required metadata key \"x-tenant-id\""}
```

Chat v0.2.0 ([release](https://github.com/agynio/chat/releases/tag/v0.2.0)) removes the legacy `x-tenant-id` requirement, aligning with the gateway's identity model.

## Related

- Chat service PR: agynio/chat#17
- Unblocks chat-app PR: agynio/chat-app#31