### PR TITLE
Deploy ziti-management and enable Ziti

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -32,10 +32,6 @@ jobs:
         with:
           terraform_version: 1.6.6
 
-      - name: Install OpenZiti CLI
-        run: |
-          curl -sS https://get.openziti.io/install.bash | sudo bash -s -- openziti
-
       - name: Apply all stacks (k8s -> system -> routing -> minio -> platform)
         run: ./apply.sh -y
 

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           terraform_version: 1.6.6
 
+      - name: Install OpenZiti CLI
+        run: |
+          curl -sS https://get.openziti.io/install.bash | sudo bash -s -- openziti
+
       - name: Apply all stacks (k8s -> system -> routing -> minio -> platform)
         run: ./apply.sh -y
 

--- a/apply.sh
+++ b/apply.sh
@@ -457,6 +457,60 @@ if [ "${ZITI_EXIT}" -ne 0 ]; then
 fi
 step_end "stack:ziti"
 
+step_start "enroll-ziti-management"
+if kubectl --kubeconfig "${KUBECONFIG_PATH}" -n platform get secret ziti-certs >/dev/null 2>&1; then
+  echo "ziti-certs secret already exists; skipping ziti-management enrollment."
+  step_end "enroll-ziti-management"
+else
+  if ! command -v ziti >/dev/null 2>&1; then
+    echo "ERROR: ziti CLI not found; install the OpenZiti CLI before running apply.sh." >&2
+    exit 1
+  fi
+
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" create namespace platform --dry-run=client -o yaml | \
+    kubectl --kubeconfig "${KUBECONFIG_PATH}" apply -f -
+
+  tmp_dir="$(mktemp -d)"
+  cleanup_enroll_dir() {
+    rm -rf "${tmp_dir}"
+  }
+  trap cleanup_enroll_dir EXIT
+
+  jwt_file="${tmp_dir}/ziti-management.jwt"
+  identity_file="${tmp_dir}/ziti-management.json"
+
+  jwt_b64=$(kubectl --kubeconfig "${KUBECONFIG_PATH}" \
+    -n ziti get secret ziti-management-enrollment \
+    -o jsonpath='{.data.enrollmentJwt}' 2>/dev/null || true)
+  if [[ -z "${jwt_b64}" ]]; then
+    echo "ERROR: ziti-management enrollment token not found." >&2
+    exit 1
+  fi
+
+  printf '%s' "${jwt_b64}" | base64 --decode >"${jwt_file}"
+
+  ziti edge enroll --jwt "${jwt_file}" --out "${identity_file}"
+
+  tls_key=$(jq -r '.id.key' "${identity_file}" | sed 's/^pem://')
+  tls_cert=$(jq -r '.id.cert' "${identity_file}" | sed 's/^pem://')
+  ca_cert=$(jq -r '.id.ca' "${identity_file}" | sed 's/^pem://')
+
+  if [[ -z "${tls_key}" || -z "${tls_cert}" || -z "${ca_cert}" ]]; then
+    echo "ERROR: failed to extract ziti-management certificates from identity." >&2
+    exit 1
+  fi
+
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" -n platform create secret generic ziti-certs \
+    --from-literal=tls.crt="${tls_cert}" \
+    --from-literal=tls.key="${tls_key}" \
+    --from-literal=ca.crt="${ca_cert}" \
+    --dry-run=client -o yaml | kubectl --kubeconfig "${KUBECONFIG_PATH}" apply -f -
+
+  cleanup_enroll_dir
+  trap - EXIT
+  step_end "enroll-ziti-management"
+fi
+
 step_start "stack:data"
 run_stack "data"
 step_end "stack:data"

--- a/apply.sh
+++ b/apply.sh
@@ -465,58 +465,6 @@ step_start "stack:platform"
 run_stack "platform"
 step_end "stack:platform"
 
-step_start "enroll-ziti-management"
-if kubectl --kubeconfig "${KUBECONFIG_PATH}" -n platform get secret ziti-certs >/dev/null 2>&1; then
-  echo "ziti-certs secret already exists; skipping ziti-management enrollment."
-  step_end "enroll-ziti-management"
-else
-  if ! command -v ziti >/dev/null 2>&1; then
-    echo "ERROR: ziti CLI not found; install the OpenZiti CLI before running apply.sh." >&2
-    exit 1
-  fi
-
-  tmp_dir="$(mktemp -d)"
-  cleanup_enroll_dir() {
-    rm -rf "${tmp_dir}"
-  }
-  trap cleanup_enroll_dir EXIT
-
-  jwt_file="${tmp_dir}/ziti-management.jwt"
-  identity_file="${tmp_dir}/ziti-management.json"
-
-  jwt_b64=$(kubectl --kubeconfig "${KUBECONFIG_PATH}" \
-    -n ziti get secret ziti-management-enrollment \
-    -o jsonpath='{.data.enrollmentJwt}' 2>/dev/null || true)
-  if [[ -z "${jwt_b64}" ]]; then
-    echo "ERROR: ziti-management enrollment token not found." >&2
-    exit 1
-  fi
-
-  printf '%s' "${jwt_b64}" | base64 --decode >"${jwt_file}"
-
-  ziti edge enroll --jwt "${jwt_file}" --out "${identity_file}"
-
-  tls_key=$(jq -r '.id.key' "${identity_file}" | sed 's/^pem://')
-  tls_cert=$(jq -r '.id.cert' "${identity_file}" | sed 's/^pem://')
-  ca_cert=$(jq -r '.id.ca' "${identity_file}" | sed 's/^pem://')
-
-  if [[ -z "${tls_key}" || -z "${tls_cert}" || -z "${ca_cert}" ]]; then
-    echo "ERROR: failed to extract ziti-management certificates from identity." >&2
-    exit 1
-  fi
-
-  kubectl --kubeconfig "${KUBECONFIG_PATH}" -n platform create secret generic ziti-certs \
-    --from-literal=tls.crt="${tls_cert}" \
-    --from-literal=tls.key="${tls_key}" \
-    --from-literal=ca.crt="${ca_cert}" \
-    --dry-run=client -o yaml | kubectl --kubeconfig "${KUBECONFIG_PATH}" apply -f -
-
-  cleanup_enroll_dir
-  trap - EXIT
-  step_end "enroll-ziti-management"
-fi
-
-
 
 echo "All stacks applied successfully."
 

--- a/apply.sh
+++ b/apply.sh
@@ -457,6 +457,14 @@ if [ "${ZITI_EXIT}" -ne 0 ]; then
 fi
 step_end "stack:ziti"
 
+step_start "stack:data"
+run_stack "data"
+step_end "stack:data"
+
+step_start "stack:platform"
+run_stack "platform"
+step_end "stack:platform"
+
 step_start "enroll-ziti-management"
 if kubectl --kubeconfig "${KUBECONFIG_PATH}" -n platform get secret ziti-certs >/dev/null 2>&1; then
   echo "ziti-certs secret already exists; skipping ziti-management enrollment."
@@ -466,9 +474,6 @@ else
     echo "ERROR: ziti CLI not found; install the OpenZiti CLI before running apply.sh." >&2
     exit 1
   fi
-
-  kubectl --kubeconfig "${KUBECONFIG_PATH}" create namespace platform --dry-run=client -o yaml | \
-    kubectl --kubeconfig "${KUBECONFIG_PATH}" apply -f -
 
   tmp_dir="$(mktemp -d)"
   cleanup_enroll_dir() {
@@ -511,13 +516,7 @@ else
   step_end "enroll-ziti-management"
 fi
 
-step_start "stack:data"
-run_stack "data"
-step_end "stack:data"
 
-step_start "stack:platform"
-run_stack "platform"
-step_end "stack:platform"
 
 echo "All stacks applied successfully."
 

--- a/stacks/deps/main.tf
+++ b/stacks/deps/main.tf
@@ -258,8 +258,8 @@ resource "argocd_application" "ziti_controller" {
 # CoreDNS rewrite rules for OpenZiti in-cluster resolution.
 # The controller bakes ziti.<domain> into enrollment JWTs as the issuer URL.
 # Router pods must resolve this hostname during enrollment; without the rewrite
-# it resolves to loopback and enrollment fails. The ziti-mgmt and ziti-router
-# hostnames are only used by external clients or host-side tooling, so they do
+# it resolves to loopback and enrollment fails. The ziti-router
+# hostname is only used by external clients or host-side tooling, so it does
 # not need in-cluster rewrites.
 resource "kubernetes_config_map_v1_data" "coredns_ziti_rewrites" {
   metadata {
@@ -279,6 +279,9 @@ resource "kubernetes_config_map_v1_data" "coredns_ziti_rewrites" {
           # Router pods must contact this URL to enroll. Without the rewrite it
           # resolves to 127.0.0.1 (loopback) and enrollment fails.
           rewrite name ziti.${local.base_domain} ziti-controller-client.${local.ziti_namespace}.svc.cluster.local
+          # ziti-management runs in the platform namespace and must reach the
+          # controller management API during startup for cert-based auth.
+          rewrite name ziti-mgmt.${local.base_domain} ziti-controller-mgmt.${local.ziti_namespace}.svc.cluster.local
           rewrite name chat.${local.base_domain} istio-ingressgateway.${local.istio_gateway_namespace}.svc.cluster.local
           rewrite name tracing.${local.base_domain} istio-ingressgateway.${local.istio_gateway_namespace}.svc.cluster.local
           kubernetes cluster.local in-addr.arpa ip6.arpa {

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -853,6 +853,20 @@ locals {
       tag        = local.resolved_ziti_management_image_tag
       pullPolicy = "IfNotPresent"
     }
+    securityContext = {
+      enabled                  = true
+      runAsNonRoot             = true
+      runAsUser                = 100
+      runAsGroup               = 101
+      readOnlyRootFilesystem   = true
+      allowPrivilegeEscalation = false
+      capabilities = {
+        drop = ["ALL"]
+      }
+      seccompProfile = {
+        type = "RuntimeDefault"
+      }
+    }
     env = [
       {
         name  = "DATABASE_URL"

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -4052,12 +4052,20 @@ resource "argocd_application" "gateway" {
             tag = local.resolved_gateway_image_tag
           }
           gateway = {
-            oidcIssuerUrl            = var.oidc_issuer_url
-            oidcClientId             = var.oidc_client_id
-            usersGrpcTarget          = "users:50051"
-            zitiEnabled              = true
-            zitiManagementGrpcTarget = "ziti-management:50051"
+            oidcIssuerUrl   = var.oidc_issuer_url
+            oidcClientId    = var.oidc_client_id
+            usersGrpcTarget = "users:50051"
           }
+          env = [
+            {
+              name  = "ZITI_ENABLED"
+              value = "true"
+            },
+            {
+              name  = "ZITI_MANAGEMENT_GRPC_TARGET"
+              value = "ziti-management:50051"
+            },
+          ]
         })
       }
     }

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -4087,10 +4087,6 @@ resource "argocd_application" "gateway" {
               name  = "ZITI_ENABLED"
               value = "true"
             },
-            {
-              name  = "ZITI_MANAGEMENT_GRPC_TARGET"
-              value = "ziti-management:50051"
-            },
           ]
         })
       }

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -15,6 +15,7 @@ locals {
   resolved_token_counting_image_tag      = trimspace(var.token_counting_image_tag) != "" ? var.token_counting_image_tag : format("v%s", var.token_counting_chart_version)
   resolved_notifications_image_tag       = trimspace(var.notifications_image_tag) != "" ? var.notifications_image_tag : var.notifications_chart_version
   resolved_agents_image_tag              = trimspace(var.agents_image_tag) != "" ? var.agents_image_tag : var.agents_chart_version
+  resolved_ziti_management_image_tag     = trimspace(var.ziti_management_image_tag) != "" ? var.ziti_management_image_tag : var.ziti_management_chart_version
   resolved_users_image_tag               = trimspace(var.users_image_tag) != "" ? var.users_image_tag : var.users_chart_version
   resolved_tenants_image_tag             = trimspace(var.tenants_image_tag) != "" ? var.tenants_image_tag : var.tenants_chart_version
   resolved_authorization_image_tag       = trimspace(var.authorization_image_tag) != "" ? var.authorization_image_tag : format("v%s", var.authorization_chart_version)
@@ -51,6 +52,7 @@ locals {
   notifications_chart_name       = "agynio/charts/notifications"
   redis_chart_name               = "redis"
   agents_chart_name              = "agynio/charts/agents"
+  ziti_management_chart_name     = "agynio/charts/ziti-management"
   users_chart_name               = "agynio/charts/users"
   tenants_chart_name             = "agynio/charts/tenants"
   authorization_chart_name       = "agynio/charts/authorization"
@@ -623,6 +625,29 @@ locals {
     }
   })
 
+  ziti_management_db_values = yamlencode({
+    fullnameOverride = "ziti-management-db"
+    postgres = {
+      database = "ziti_management"
+      username = "ziti_management"
+      password = var.ziti_management_db_password
+      pgdata   = "/var/lib/postgresql/data/pgdata"
+    }
+    persistence = {
+      size                    = var.ziti_management_db_pvc_size
+      mountPath               = "/var/lib/postgresql/data"
+      volumeClaimTemplateName = "data"
+    }
+    probes = {
+      readiness = {
+        execCommand = ["pg_isready", "-U", "ziti_management", "-d", "ziti_management"]
+      }
+      liveness = {
+        execCommand = ["pg_isready", "-U", "ziti_management", "-d", "ziti_management"]
+      }
+    }
+  })
+
   users_db_values = yamlencode({
     fullnameOverride = "users-db"
     postgres = {
@@ -817,6 +842,25 @@ locals {
       {
         name  = "DATABASE_URL"
         value = format("postgresql://agents:%s@agents-db:5432/agents?sslmode=disable", var.agents_db_password)
+      },
+    ]
+  })
+
+  ziti_management_values = yamlencode({
+    fullnameOverride = "ziti-management"
+    image = {
+      repository = "ghcr.io/agynio/ziti-management"
+      tag        = local.resolved_ziti_management_image_tag
+      pullPolicy = "IfNotPresent"
+    }
+    env = [
+      {
+        name  = "DATABASE_URL"
+        value = format("postgresql://ziti_management:%s@ziti-management-db:5432/ziti_management?sslmode=disable", var.ziti_management_db_password)
+      },
+      {
+        name  = "ZITI_CONTROLLER_URL"
+        value = format("https://ziti-mgmt.%s:%d/edge/management/v1", local.base_domain, local.ingress_port)
       },
     ]
   })
@@ -2680,6 +2724,56 @@ resource "argocd_application" "agents_db" {
   }
 }
 
+resource "argocd_application" "ziti_management_db" {
+  depends_on = [argocd_repository.litellm_repo]
+  wait       = true
+
+  metadata {
+    name      = "ziti-management-db"
+    namespace = "argocd"
+    annotations = {
+      "argocd.argoproj.io/sync-wave" = "8"
+    }
+  }
+
+  spec {
+    project = "default"
+
+    source {
+      repo_url        = local.postgres_chart_repo_host
+      chart           = local.postgres_chart_name
+      target_revision = var.postgres_chart_version
+
+      helm {
+        values = local.ziti_management_db_values
+      }
+    }
+
+    destination {
+      server    = var.destination_server
+      namespace = var.platform_namespace
+    }
+
+    sync_policy {
+      # DB apps always use automated sync with prune disabled for stateful safety,
+      # independent of var.argocd_automated_sync_enabled.
+      automated {
+        prune       = false
+        self_heal   = true
+        allow_empty = false
+      }
+
+      sync_options = local.postgres_sync_options
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
 resource "argocd_application" "users_db" {
   depends_on = [argocd_repository.litellm_repo]
   wait       = true
@@ -3377,6 +3471,53 @@ resource "argocd_application" "agents" {
   }
 }
 
+resource "argocd_application" "ziti_management" {
+  depends_on = [
+    argocd_repository.litellm_repo,
+    argocd_application.ziti_management_db,
+  ]
+
+  metadata {
+    name      = "ziti-management"
+    namespace = "argocd"
+    annotations = {
+      "argocd.argoproj.io/sync-wave" = "17"
+    }
+  }
+
+  spec {
+    project = "default"
+
+    source {
+      repo_url        = local.platform_chart_repo_host
+      chart           = local.ziti_management_chart_name
+      target_revision = var.ziti_management_chart_version
+
+      helm {
+        values = local.ziti_management_values
+      }
+    }
+
+    destination {
+      server    = var.destination_server
+      namespace = var.platform_namespace
+    }
+
+    sync_policy {
+      dynamic "automated" {
+        for_each = var.argocd_automated_sync_enabled ? [1] : []
+        content {
+          prune       = var.argocd_prune_enabled
+          self_heal   = var.argocd_self_heal_enabled
+          allow_empty = false
+        }
+      }
+
+      sync_options = local.default_sync_options
+    }
+  }
+}
+
 resource "argocd_application" "users" {
   depends_on = [
     argocd_repository.litellm_repo,
@@ -3887,7 +4028,7 @@ resource "argocd_application" "tracing_app" {
 }
 
 resource "argocd_application" "gateway" {
-  depends_on = [argocd_application.llm]
+  depends_on = [argocd_application.llm, argocd_application.ziti_management]
   metadata {
     name      = "gateway"
     namespace = "argocd"
@@ -3911,9 +4052,11 @@ resource "argocd_application" "gateway" {
             tag = local.resolved_gateway_image_tag
           }
           gateway = {
-            oidcIssuerUrl   = var.oidc_issuer_url
-            oidcClientId    = var.oidc_client_id
-            usersGrpcTarget = "users:50051"
+            oidcIssuerUrl            = var.oidc_issuer_url
+            oidcClientId             = var.oidc_client_id
+            usersGrpcTarget          = "users:50051"
+            zitiEnabled              = true
+            zitiManagementGrpcTarget = "ziti-management:50051"
           }
         })
       }

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -876,6 +876,18 @@ locals {
         name  = "ZITI_CONTROLLER_URL"
         value = format("https://ziti-mgmt.%s:%d/edge/management/v1", local.base_domain, local.ingress_port)
       },
+      {
+        name  = "ZITI_CERT_FILE"
+        value = "/etc/ziti/tls.crt"
+      },
+      {
+        name  = "ZITI_KEY_FILE"
+        value = "/etc/ziti/tls.key"
+      },
+      {
+        name  = "ZITI_CA_FILE"
+        value = "/etc/ziti/ca.crt"
+      },
     ]
   })
 

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -853,6 +853,9 @@ locals {
       tag        = local.resolved_ziti_management_image_tag
       pullPolicy = "IfNotPresent"
     }
+    updateStrategy = {
+      type = "Recreate"
+    }
     securityContext = {
       enabled                  = true
       runAsNonRoot             = true
@@ -867,6 +870,20 @@ locals {
         type = "RuntimeDefault"
       }
     }
+    persistence = {
+      enabled     = true
+      accessMode  = "ReadWriteOnce"
+      size        = "10Mi"
+    }
+    configMounts = [
+      {
+        name       = "ziti-enrollment"
+        sourceName = "ziti-management-enrollment"
+        type       = "secret"
+        mountPath  = "/etc/ziti-enrollment"
+        readOnly   = true
+      },
+    ]
     env = [
       {
         name  = "DATABASE_URL"
@@ -878,15 +895,19 @@ locals {
       },
       {
         name  = "ZITI_CERT_FILE"
-        value = "/etc/ziti/tls.crt"
+        value = "/var/lib/ziti/tls.crt"
       },
       {
         name  = "ZITI_KEY_FILE"
-        value = "/etc/ziti/tls.key"
+        value = "/var/lib/ziti/tls.key"
       },
       {
         name  = "ZITI_CA_FILE"
-        value = "/etc/ziti/ca.crt"
+        value = "/var/lib/ziti/ca.crt"
+      },
+      {
+        name  = "ZITI_ENROLLMENT_JWT_FILE"
+        value = "/etc/ziti-enrollment/enrollmentJwt"
       },
     ]
   })
@@ -1768,6 +1789,21 @@ resource "kubernetes_namespace" "platform" {
 resource "kubernetes_namespace_v1" "agyn_workloads" {
   metadata {
     name = "agyn-workloads"
+  }
+}
+
+# Enrollment JWT for ziti-management self-enrollment at startup.
+# The token is created by the ziti stack and passed via remote state.
+resource "kubernetes_secret_v1" "ziti_management_enrollment" {
+  metadata {
+    name      = "ziti-management-enrollment"
+    namespace = kubernetes_namespace.platform.metadata[0].name
+  }
+
+  type = "Opaque"
+
+  data = {
+    enrollmentJwt = data.terraform_remote_state.ziti.outputs.ziti_management_enrollment_token
   }
 }
 

--- a/stacks/platform/remote_state.tf
+++ b/stacks/platform/remote_state.tf
@@ -18,3 +18,11 @@ locals {
   base_domain  = data.terraform_remote_state.k8s.outputs.domain
   ingress_port = data.terraform_remote_state.k8s.outputs.ingress_port
 }
+
+data "terraform_remote_state" "ziti" {
+  backend = "local"
+
+  config = {
+    path = "../ziti/state/terraform.tfstate"
+  }
+}

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -86,7 +86,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "users_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -408,8 +408,8 @@ variable "agents_db_pvc_size" {
 
 variable "ziti_management_db_pvc_size" {
   type        = string
-  description = "PVC size for the ziti-management database"
-  default     = "1Gi"
+  description = "Persistent volume claim size for the ziti-management PostgreSQL primary"
+  default     = "5Gi"
 }
 
 variable "users_db_password" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -83,6 +83,12 @@ variable "agents_chart_version" {
   default     = "0.3.0"
 }
 
+variable "ziti_management_chart_version" {
+  type        = string
+  description = "Version of the ziti-management Helm chart published to GHCR"
+  default     = "0.1.0"
+}
+
 variable "users_chart_version" {
   type        = string
   description = "Version of the users Helm chart published to GHCR"
@@ -207,6 +213,12 @@ variable "notifications_image_tag" {
 variable "agents_image_tag" {
   type        = string
   description = "Optional override for the agents image tag"
+  default     = ""
+}
+
+variable "ziti_management_image_tag" {
+  type        = string
+  description = "Optional override for the ziti-management container image tag"
   default     = ""
 }
 
@@ -374,6 +386,13 @@ variable "agents_db_password" {
   sensitive   = true
 }
 
+variable "ziti_management_db_password" {
+  type        = string
+  description = "Password for the ziti-management PostgreSQL database user"
+  default     = "ziti_management"
+  sensitive   = true
+}
+
 variable "tenants_db_password" {
   type        = string
   description = "Password for the tenants PostgreSQL database user"
@@ -385,6 +404,12 @@ variable "agents_db_pvc_size" {
   type        = string
   description = "Persistent volume claim size for the agents PostgreSQL primary"
   default     = "5Gi"
+}
+
+variable "ziti_management_db_pvc_size" {
+  type        = string
+  description = "PVC size for the ziti-management database"
+  default     = "1Gi"
 }
 
 variable "users_db_password" {

--- a/stacks/ziti/outputs.tf
+++ b/stacks/ziti/outputs.tf
@@ -19,3 +19,9 @@ output "service_ids" {
   }
   description = "Ziti service IDs"
 }
+
+output "ziti_management_enrollment_token" {
+  value       = ziti_identity.ziti_management.enrollment_token
+  description = "Enrollment JWT for the ziti-management identity"
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary
- add ziti-management variables, locals, and Helm values in platform stack
- deploy ziti-management db and app Argo CD applications
- enable Ziti settings for the gateway chart

## Testing
- ./apply.sh -y *(fails: GHCR access denied for agynio/charts/ziti-management:0.1.0)*
- terraform fmt -check -recursive stacks

Closes #152