### PR TITLE
chore: bump gateway chart version to 0.7.1

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -26,7 +26,7 @@ variable "platform_chart_version" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.7.0"
+  default     = "0.7.1"
 }
 
 variable "agent_state_chart_version" {


### PR DESCRIPTION
Bumps `gateway_chart_version` from `0.7.0` to `0.7.1`.

Picks up [fix(oidc): remove access token aud check](https://github.com/agynio/gateway/pull/96) — the gateway was incorrectly applying an ID-token-style `aud == client_id` check to access tokens, causing all authenticated API calls to return 401 in the e2e cluster.

This unblocks real-API e2e tests in [agynio/chat-app#38](https://github.com/agynio/chat-app/pull/38).