### PR TITLE
chore: bump chat chart version to 0.2.1

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -7,7 +7,7 @@ locals {
   resolved_k8s_runner_image_tag          = trimspace(var.k8s_runner_image_tag) != "" ? var.k8s_runner_image_tag : var.k8s_runner_chart_version
   resolved_threads_image_tag             = trimspace(var.threads_image_tag) != "" ? var.threads_image_tag : format("v%s", var.threads_chart_version)
   resolved_tracing_image_tag             = trimspace(var.tracing_image_tag) != "" ? var.tracing_image_tag : format("v%s", var.tracing_chart_version)
-  resolved_chat_image_tag                = trimspace(var.chat_image_tag) != "" ? var.chat_image_tag : format("v%s", var.chat_chart_version)
+  resolved_chat_image_tag                = trimspace(var.chat_image_tag) != "" ? var.chat_image_tag : var.chat_chart_version
   resolved_chat_app_image_tag            = trimspace(var.chat_app_image_tag) != "" ? var.chat_app_image_tag : var.chat_app_chart_version
   resolved_tracing_app_image_tag         = trimspace(var.tracing_app_image_tag) != "" ? var.tracing_app_image_tag : var.tracing_app_chart_version
   resolved_files_image_tag               = trimspace(var.files_image_tag) != "" ? var.files_image_tag : var.files_chart_version

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -847,12 +847,6 @@ locals {
 
   chat_values = yamlencode({
     fullnameOverride = "chat"
-    service = {
-      port = 50051
-    }
-    threads = {
-      address = "threads:50051"
-    }
     image = {
       repository = "ghcr.io/agynio/chat"
       tag        = local.resolved_chat_image_tag

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -201,7 +201,7 @@ variable "tracing_image_tag" {
 variable "chat_chart_version" {
   type        = string
   description = "Version of the chat Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "chat_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -68,7 +68,7 @@ variable "token_counting_chart_version" {
 variable "notifications_chart_version" {
   type        = string
   description = "Version of the notifications Helm chart published to GHCR"
-  default     = "0.2.2"
+  default     = "0.2.1"
 }
 
 variable "notifications_redis_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -68,7 +68,7 @@ variable "token_counting_chart_version" {
 variable "notifications_chart_version" {
   type        = string
   description = "Version of the notifications Helm chart published to GHCR"
-  default     = "0.2.1"
+  default     = "0.2.2"
 }
 
 variable "notifications_redis_chart_version" {
@@ -201,7 +201,7 @@ variable "tracing_image_tag" {
 variable "chat_chart_version" {
   type        = string
   description = "Version of the chat Helm chart published to GHCR"
-  default     = "0.2.1"
+  default     = "0.2.2"
 }
 
 variable "chat_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -201,7 +201,7 @@ variable "tracing_image_tag" {
 variable "chat_chart_version" {
   type        = string
   description = "Version of the chat Helm chart published to GHCR"
-  default     = "0.2.0"
+  default     = "0.2.1"
 }
 
 variable "chat_image_tag" {


### PR DESCRIPTION
Bumps `chat_chart_version` from `0.1.0` to `0.2.1`.

## What changed in chat v0.2.x

- **v0.2.0** ([chat#17](https://github.com/agynio/chat/pull/17)): Removed the `x-tenant-id` metadata requirement. Chat now only requires `x-identity-id` and `x-identity-type`, which the gateway already provides.
- **v0.2.1** ([chat#18](https://github.com/agynio/chat/pull/18)): Defaults `chat.threadsAddress` to `threads:50051` in the chart, following the gateway convention where inter-service gRPC targets default to in-cluster DNS names. Removes the `required` check that broke v0.2.0 deployments.

## Bootstrap changes

- Bump `chat_chart_version` default from `0.1.0` to `0.2.1`
- Remove `service.port` and `threads.address` overrides — these were v0.1.0-specific values that no longer apply. The v0.2.1 chart defaults handle service ports (via `service-base` library chart) and the threads address.

## Why

Unblocks real-API e2e tests in [agynio/chat-app#38](https://github.com/agynio/chat-app/pull/38).

**Diagnostic evidence from CI (v0.1.0):**
```
[postConnect] CreateChat - 401 - body: {"code":"unauthenticated","message":"identity: missing required metadata key \"x-tenant-id\""}
```

## Dependency

Requires [agynio/chat#18](https://github.com/agynio/chat/pull/18) to be merged and tagged as `v0.2.1` before this PR's CI can pass.