### PR TITLE
fix(platform): update organizations refs

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -56,12 +56,13 @@ locals {
   agents_chart_name              = "agynio/charts/agents"
   ziti_management_chart_name     = "agynio/charts/ziti-management"
   users_chart_name               = "agynio/charts/users"
-  organizations_chart_name       = "agynio/charts/tenants"
-  authorization_chart_name       = "agynio/charts/authorization"
-  istio_gateway_namespace        = data.terraform_remote_state.system.outputs.istio_gateway_namespace
-  istio_gateway_tls_secret_name  = data.terraform_remote_state.system.outputs.wildcard_tls_gateway_secret_name
-  openfga_api_url_external       = format("https://openfga.%s:%d", local.base_domain, local.ingress_port)
-  openfga_api_url_internal       = format("http://openfga.%s.svc.cluster.local:8080", var.openfga_namespace)
+  # TODO: update to "agynio/charts/organizations" once the organizations repo publishes its first release
+  organizations_chart_name      = "agynio/charts/tenants"
+  authorization_chart_name      = "agynio/charts/authorization"
+  istio_gateway_namespace       = data.terraform_remote_state.system.outputs.istio_gateway_namespace
+  istio_gateway_tls_secret_name = data.terraform_remote_state.system.outputs.wildcard_tls_gateway_secret_name
+  openfga_api_url_external      = format("https://openfga.%s:%d", local.base_domain, local.ingress_port)
+  openfga_api_url_internal      = format("http://openfga.%s.svc.cluster.local:8080", var.openfga_namespace)
   # Deterministic v5 UUID for the cluster admin identity.
   # This is a synthetic identity used only during bootstrap;
   # it does not correspond to a user record in the Users DB.
@@ -972,6 +973,7 @@ locals {
   organizations_values = yamlencode({
     fullnameOverride = "tenants"
     image = {
+      # TODO: update to "ghcr.io/agynio/organizations" once the first release is published
       repository = "ghcr.io/agynio/tenants"
       tag        = local.resolved_organizations_image_tag
       pullPolicy = "IfNotPresent"

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -18,7 +18,7 @@ locals {
   resolved_agents_image_tag              = trimspace(var.agents_image_tag) != "" ? var.agents_image_tag : var.agents_chart_version
   resolved_ziti_management_image_tag     = trimspace(var.ziti_management_image_tag) != "" ? var.ziti_management_image_tag : var.ziti_management_chart_version
   resolved_users_image_tag               = trimspace(var.users_image_tag) != "" ? var.users_image_tag : var.users_chart_version
-  resolved_tenants_image_tag             = trimspace(var.tenants_image_tag) != "" ? var.tenants_image_tag : var.tenants_chart_version
+  resolved_organizations_image_tag       = trimspace(var.organizations_image_tag) != "" ? var.organizations_image_tag : var.organizations_chart_version
   resolved_authorization_image_tag       = trimspace(var.authorization_image_tag) != "" ? var.authorization_image_tag : format("v%s", var.authorization_chart_version)
 
   postgres_image                 = "postgres:16.6-alpine"
@@ -56,7 +56,7 @@ locals {
   agents_chart_name              = "agynio/charts/agents"
   ziti_management_chart_name     = "agynio/charts/ziti-management"
   users_chart_name               = "agynio/charts/users"
-  tenants_chart_name             = "agynio/charts/tenants"
+  organizations_chart_name       = "agynio/charts/organizations"
   authorization_chart_name       = "agynio/charts/authorization"
   istio_gateway_namespace        = data.terraform_remote_state.system.outputs.istio_gateway_namespace
   istio_gateway_tls_secret_name  = data.terraform_remote_state.system.outputs.wildcard_tls_gateway_secret_name
@@ -969,11 +969,11 @@ locals {
     ]
   })
 
-  tenants_values = yamlencode({
+  organizations_values = yamlencode({
     fullnameOverride = "tenants"
     image = {
-      repository = "ghcr.io/agynio/tenants"
-      tag        = local.resolved_tenants_image_tag
+      repository = "ghcr.io/agynio/organizations"
+      tag        = local.resolved_organizations_image_tag
       pullPolicy = "IfNotPresent"
     }
     env = [
@@ -3799,11 +3799,11 @@ resource "argocd_application" "tenants" {
 
     source {
       repo_url        = local.platform_chart_repo_host
-      chart           = local.tenants_chart_name
-      target_revision = var.tenants_chart_version
+      chart           = local.organizations_chart_name
+      target_revision = var.organizations_chart_version
 
       helm {
-        values = local.tenants_values
+        values = local.organizations_values
       }
     }
 
@@ -4268,11 +4268,12 @@ resource "argocd_application" "gateway" {
             tag = local.resolved_gateway_image_tag
           }
           gateway = {
-            oidcIssuerUrl          = var.oidc_issuer_url
-            oidcClientId           = var.oidc_client_id
-            clusterAdminToken      = random_password.cluster_admin_token.result
-            clusterAdminIdentityId = local.cluster_admin_identity_id
-            usersGrpcTarget        = "users:50051"
+            oidcIssuerUrl           = var.oidc_issuer_url
+            oidcClientId            = var.oidc_client_id
+            clusterAdminToken       = random_password.cluster_admin_token.result
+            clusterAdminIdentityId  = local.cluster_admin_identity_id
+            usersGrpcTarget         = "users:50051"
+            organizationsGrpcTarget = "tenants:50051"
           }
           env = [
             {

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -56,13 +56,12 @@ locals {
   agents_chart_name              = "agynio/charts/agents"
   ziti_management_chart_name     = "agynio/charts/ziti-management"
   users_chart_name               = "agynio/charts/users"
-  # TODO: update to "agynio/charts/organizations" once the organizations repo publishes its first release
-  organizations_chart_name      = "agynio/charts/tenants"
-  authorization_chart_name      = "agynio/charts/authorization"
-  istio_gateway_namespace       = data.terraform_remote_state.system.outputs.istio_gateway_namespace
-  istio_gateway_tls_secret_name = data.terraform_remote_state.system.outputs.wildcard_tls_gateway_secret_name
-  openfga_api_url_external      = format("https://openfga.%s:%d", local.base_domain, local.ingress_port)
-  openfga_api_url_internal      = format("http://openfga.%s.svc.cluster.local:8080", var.openfga_namespace)
+  organizations_chart_name       = "agynio/charts/organizations"
+  authorization_chart_name       = "agynio/charts/authorization"
+  istio_gateway_namespace        = data.terraform_remote_state.system.outputs.istio_gateway_namespace
+  istio_gateway_tls_secret_name  = data.terraform_remote_state.system.outputs.wildcard_tls_gateway_secret_name
+  openfga_api_url_external       = format("https://openfga.%s:%d", local.base_domain, local.ingress_port)
+  openfga_api_url_internal       = format("http://openfga.%s.svc.cluster.local:8080", var.openfga_namespace)
   # Deterministic v5 UUID for the cluster admin identity.
   # This is a synthetic identity used only during bootstrap;
   # it does not correspond to a user record in the Users DB.
@@ -973,8 +972,7 @@ locals {
   organizations_values = yamlencode({
     fullnameOverride = "tenants"
     image = {
-      # TODO: update to "ghcr.io/agynio/organizations" once the first release is published
-      repository = "ghcr.io/agynio/tenants"
+      repository = "ghcr.io/agynio/organizations"
       tag        = local.resolved_organizations_image_tag
       pullPolicy = "IfNotPresent"
     }

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -56,7 +56,7 @@ locals {
   agents_chart_name              = "agynio/charts/agents"
   ziti_management_chart_name     = "agynio/charts/ziti-management"
   users_chart_name               = "agynio/charts/users"
-  organizations_chart_name       = "agynio/charts/organizations"
+  organizations_chart_name       = "agynio/charts/tenants"
   authorization_chart_name       = "agynio/charts/authorization"
   istio_gateway_namespace        = data.terraform_remote_state.system.outputs.istio_gateway_namespace
   istio_gateway_tls_secret_name  = data.terraform_remote_state.system.outputs.wildcard_tls_gateway_secret_name
@@ -972,7 +972,7 @@ locals {
   organizations_values = yamlencode({
     fullnameOverride = "tenants"
     image = {
-      repository = "ghcr.io/agynio/organizations"
+      repository = "ghcr.io/agynio/tenants"
       tag        = local.resolved_organizations_image_tag
       pullPolicy = "IfNotPresent"
     }

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -26,7 +26,7 @@ variable "platform_chart_version" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.7.0"
+  default     = "0.9.0"
 }
 
 variable "agent_state_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -104,7 +104,7 @@ variable "users_chart_version" {
 variable "organizations_chart_version" {
   type        = string
   description = "Version of the organizations Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "chat_app_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -101,9 +101,9 @@ variable "users_chart_version" {
   default     = "0.2.0"
 }
 
-variable "tenants_chart_version" {
+variable "organizations_chart_version" {
   type        = string
-  description = "Version of the tenants Helm chart published to GHCR"
+  description = "Version of the organizations Helm chart published to GHCR"
   default     = "0.1.0"
 }
 
@@ -240,9 +240,9 @@ variable "users_image_tag" {
   default     = ""
 }
 
-variable "tenants_image_tag" {
+variable "organizations_image_tag" {
   type        = string
-  description = "Optional override for the tenants image tag"
+  description = "Optional override for the organizations image tag"
   default     = ""
 }
 


### PR DESCRIPTION
## Summary
- update organizations chart/image references to published artifacts
- keep organizations values wired into the tenants Argo CD app
- add organizations gRPC target to gateway helm values
- bump gateway chart version for organizations handler

## Testing
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform fmt -check -recursive
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/platform validate

Ref #159