### PR TITLE
chore: bump k8s-runner to 0.2.0, add DEFAULT_INIT_IMAGE env var

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1052,6 +1052,10 @@ locals {
         value = "alpine:3.21"
       },
       {
+        name  = "DEFAULT_INIT_IMAGE"
+        value = "alpine:3.21"
+      },
+      {
         name  = "POLL_INTERVAL"
         value = "5s"
       },

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -44,7 +44,7 @@ variable "agents_orchestrator_chart_version" {
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
Two changes for the agents-orchestrator init container support:

1. **Bump k8s-runner chart version** from `0.1.0` to `0.2.0`
   - v0.2.0 adds init container support (k8s-runner#15), which the orchestrator now requires
   - Without this, `StartWorkloadRequest.InitContainers` is silently dropped by the old runner

2. **Add `DEFAULT_INIT_IMAGE` env var** to orchestrator deployment
   - The orchestrator HEAD config reads `DEFAULT_INIT_IMAGE` (renamed from `DEFAULT_AGENT_IMAGE` in agents-orchestrator#49)
   - Both old (`DEFAULT_AGENT_IMAGE`) and new (`DEFAULT_INIT_IMAGE`) env vars are kept for backward compatibility with the current deployed orchestrator v0.1.8 image
   - Once a new orchestrator release is cut, the old `DEFAULT_AGENT_IMAGE` can be removed

Both changes are required for the orchestrator E2E CI to pass (see agents-orchestrator#52).