### PR TITLE
Update agents-orchestrator env defaults

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1143,7 +1143,11 @@ locals {
       },
       {
         name  = "DEFAULT_INIT_IMAGE"
-        value = "alpine:3.21"
+        value = "ghcr.io/agynio/agent-init-codex:0.1.0"
+      },
+      {
+        name  = "AGENT_LLM_BASE_URL"
+        value = "https://testllm.dev/v1/org/agynio/suite/agn"
       },
       {
         name  = "POLL_INTERVAL"

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1143,11 +1143,7 @@ locals {
       },
       {
         name  = "DEFAULT_INIT_IMAGE"
-        value = "ghcr.io/agynio/agent-init-codex:0.1.0"
-      },
-      {
-        name  = "AGENT_LLM_BASE_URL"
-        value = "https://testllm.dev/v1/org/agynio/suite/agn"
+        value = "ghcr.io/agynio/agent-init-codex:0.5.0"
       },
       {
         name  = "POLL_INTERVAL"


### PR DESCRIPTION
## Summary
- bump DEFAULT_INIT_IMAGE to ghcr.io/agynio/agent-init-codex:0.5.0
- drop AGENT_LLM_BASE_URL from agents-orchestrator env

## Testing
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform fmt -check -recursive
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/platform init -backend=false
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/platform validate

Closes #163