### PR TITLE
chore: bump gateway to v0.10.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -26,7 +26,7 @@ variable "platform_chart_version" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.9.0"
+  default     = "0.10.0"
 }
 
 variable "agent_state_chart_version" {


### PR DESCRIPTION
Bump gateway chart version to 0.10.0 — adds LLM gateway handler (provider + model CRUD).