### PR TITLE
feat(platform): expose llm http port

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1215,11 +1215,6 @@ locals {
         name          = "grpc"
         containerPort = 50051
         protocol      = "TCP"
-      },
-      {
-        name          = "http"
-        containerPort = 8080
-        protocol      = "TCP"
       }
     ]
     service = {
@@ -1230,12 +1225,6 @@ locals {
           name       = "grpc"
           port       = 50051
           targetPort = "grpc"
-          protocol   = "TCP"
-        },
-        {
-          name       = "http"
-          port       = 8080
-          targetPort = "http"
           protocol   = "TCP"
         }
       ]

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1215,6 +1215,11 @@ locals {
         name          = "grpc"
         containerPort = 50051
         protocol      = "TCP"
+      },
+      {
+        name          = "http"
+        containerPort = 8080
+        protocol      = "TCP"
       }
     ]
     service = {
@@ -1225,6 +1230,12 @@ locals {
           name       = "grpc"
           port       = 50051
           targetPort = "grpc"
+          protocol   = "TCP"
+        },
+        {
+          name       = "http"
+          port       = 8080
+          targetPort = "http"
           protocol   = "TCP"
         }
       ]

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -432,7 +432,7 @@ variable "files_db_pvc_size" {
 variable "llm_chart_version" {
   type        = string
   description = "Version of the llm Helm chart published to GHCR"
-  default     = "0.2.0"
+  default     = "0.2.1"
 }
 
 variable "llm_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -432,7 +432,7 @@ variable "files_db_pvc_size" {
 variable "llm_chart_version" {
   type        = string
   description = "Version of the llm Helm chart published to GHCR"
-  default     = "0.2.1"
+  default     = "0.3.0"
 }
 
 variable "llm_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -432,7 +432,7 @@ variable "files_db_pvc_size" {
 variable "llm_chart_version" {
   type        = string
   description = "Version of the llm Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "llm_image_tag" {


### PR DESCRIPTION
## Summary
- bump llm chart version to 0.2.0
- expose llm HTTP container/service port 8080 alongside gRPC

## Testing
- terraform fmt -check -recursive
- terraform -chdir=stacks/platform init -backend=false
- terraform -chdir=stacks/platform validate

Fixes #171