### PR TITLE
chore: bump agents-orchestrator to v0.1.9 (llm-proxy URL fix)

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1146,6 +1146,10 @@ locals {
         value = "ghcr.io/agynio/agent-init-codex:0.5.0"
       },
       {
+        name  = "AGENT_LLM_BASE_URL"
+        value = "http://llm-proxy:8080/v1"
+      },
+      {
         name  = "POLL_INTERVAL"
         value = "5s"
       },

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -38,7 +38,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.1.8"
+  default     = "0.1.9"
 }
 
 variable "k8s_runner_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -38,7 +38,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.1.9"
+  default     = "0.1.8"
 }
 
 variable "k8s_runner_chart_version" {


### PR DESCRIPTION
## Summary
- set AGENT_LLM_BASE_URL for agents-orchestrator
- revert agents-orchestrator chart version to 0.1.8

## Testing
- `terraform fmt -check -recursive`
- `terraform -chdir=stacks/platform init -backend=false`
- `terraform -chdir=stacks/platform validate`

Refs #173