### PR TITLE
fix(platform): wire agent gateway env

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1147,7 +1147,15 @@ locals {
       },
       {
         name  = "AGENT_LLM_BASE_URL"
-        value = "http://llm-proxy:8080/v1"
+        value = "http://llm-proxy-llm-proxy.platform.svc.cluster.local:8080/v1"
+      },
+      {
+        name  = "AGENT_GATEWAY_ADDRESS"
+        value = "gateway-gateway.platform.svc.cluster.local:8080"
+      },
+      {
+        name  = "AGENT_AUTH_TOKEN"
+        value = random_password.cluster_admin_token.result
       },
       {
         name  = "POLL_INTERVAL"


### PR DESCRIPTION
## Summary
- add gateway address and auth token env vars for the agents orchestrator
- update the orchestrator LLM base URL to the cluster-local address

## Testing
- terraform fmt -check -recursive
- terraform -chdir=stacks/platform validate

Closes #179