### PR TITLE
chore(platform): enable Ziti agent networking

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1143,11 +1143,7 @@ locals {
       },
       {
         name  = "DEFAULT_INIT_IMAGE"
-        value = "ghcr.io/agynio/agent-init-codex:0.5.0"
-      },
-      {
-        name  = "AGENT_LLM_BASE_URL"
-        value = "http://llm-proxy:8080/v1"
+        value = "ghcr.io/agynio/agent-init-codex:0.6.0"
       },
       {
         name  = "POLL_INTERVAL"
@@ -1158,8 +1154,8 @@ locals {
         value = "30s"
       },
       {
-        name  = "DOCKER_RUNNER_SHARED_SECRET"
-        value = "unused-docker-runner-removed"
+        name  = "ZITI_ENABLED"
+        value = "true"
       },
       {
         name  = "RUNNER_ADDRESS"
@@ -1665,10 +1661,6 @@ locals {
       {
         name  = "OPENAI_API_KEY"
         value = var.litellm_master_key
-      },
-      {
-        name  = "DOCKER_RUNNER_SHARED_SECRET"
-        value = "unused-docker-runner-removed"
       },
       {
         name  = "VAULT_ENABLED"

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -38,13 +38,13 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.2.0"
+  default     = "0.3.0"
 }
 
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.2.0"
+  default     = "0.3.0"
 }
 
 variable "threads_chart_version" {
@@ -86,13 +86,13 @@ variable "postgres_chart_version" {
 variable "agents_chart_version" {
   type        = string
   description = "Version of the agents Helm chart published to GHCR"
-  default     = "0.4.0"
+  default     = "0.4.1"
 }
 
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.2.0"
+  default     = "0.4.0"
 }
 
 variable "users_chart_version" {


### PR DESCRIPTION
Enable full OpenZiti networking for agent pods.

## Version Bumps
| Service | From | To | Key Change |
|---------|------|----|------------|
| agents-orchestrator | 0.2.0 | 0.3.0 | Ziti sidecar assembly into agent pods |
| k8s-runner | 0.2.0 | 0.3.0 | DnsConfig, required_capabilities, native sidecar init containers |
| ziti-management | 0.2.0 | 0.4.0 | `ServiceTypeLLMProxy` support (llm-proxy can now self-enroll) |
| agents | 0.4.0 | 0.4.1 | Latest fix |
| agent-init-codex | 0.5.0 | 0.6.0 | agynd v0.5.0 — defaults to `gateway.ziti:443` and `http://llm-proxy.ziti:443/v1` |

## Orchestrator Config Changes
- **Add** `ZITI_ENABLED=true` — orchestrator assembles Ziti sidecar container into agent pods
- **Remove** `AGENT_LLM_BASE_URL` — agynd defaults to Ziti hostname; orchestrator default is unused
- **Remove** `DOCKER_RUNNER_SHARED_SECRET` — dead config (`unused-docker-runner-removed`)
- **Bump** `DEFAULT_INIT_IMAGE` → `agent-init-codex:0.6.0`

## Architecture Alignment
With these changes, agent pods will have:
1. A **Ziti sidecar** init container (restart policy `Always` = native sidecar) that enrolls the agent's OpenZiti identity and sets up DNS + TPROXY
2. **DNS config** pointing to `127.0.0.1` (sidecar DNS) + cluster DNS fallback
3. `agynd` connecting to `gateway.ziti:443` and `llm-proxy.ziti:443` — transparently intercepted by the sidecar

Closes #183