### PR TITLE
fix(platform): enable Ziti on k8s-runner

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1098,6 +1098,14 @@ locals {
       {
         name  = "KUBE_NAMESPACE"
         value = "agyn-workloads"
+      },
+      {
+        name  = "ZITI_ENABLED"
+        value = "true"
+      },
+      {
+        name  = "ZITI_MANAGEMENT_ADDRESS"
+        value = "ziti-management:50051"
       }
     ]
     containerPorts = [


### PR DESCRIPTION
## Problem

Bootstrap PR #184 set `ZITI_ENABLED=true` on the orchestrator to enable Ziti sidecar injection into agent pods. However, `ZITI_ENABLED=true` also switches the orchestrator's **own** gRPC connection to k8s-runner from plain K8s DNS to Ziti overlay (`zitiCtx.Dial("runner")`).

k8s-runner was not configured with `ZITI_ENABLED=true`, so it never called `RequestServiceIdentity(SERVICE_TYPE_RUNNER)` and never bound the `runner` Ziti service. The orchestrator's dial attempts timed out:

```
unable to dial service 'runner' (no edge routers connected in time: context deadline exceeded)
```

This broke the agent reconciler — no agent pods could be created.

## Fix

Add `ZITI_ENABLED=true` and `ZITI_MANAGEMENT_ADDRESS=ziti-management:50051` to k8s-runner's env. k8s-runner already supports Ziti (code in v0.3.0):
- Calls `RequestServiceIdentity(SERVICE_TYPE_RUNNER)` → gets identity with `#runners` role
- Binds the `runner` Ziti service via `ListenWithOptions("runner", ...)`
- Ziti terraform already has the `runner` service + `runners_bind` + `orchestrators_dial_runners` policies

## Related
- Fixes the agent e2e failure in chat-app PR #45
- Continues #183 / PR #184