### PR TITLE
chore: bump k8s-runner chart to 0.3.1

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -44,7 +44,7 @@ variable "agents_orchestrator_chart_version" {
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.3.0"
+  default     = "0.3.1"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
## Summary
- bump k8s-runner chart version to 0.3.1 in platform stack

## Testing
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform fmt -check -recursive
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform nixpkgs#kubectl nixpkgs#k3d nixpkgs#kubernetes-helm nixpkgs#jq -c terraform -chdir=stacks/k8s apply -var 'domain=agyn.dev' -var 'port=2496' -input=false -auto-approve
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform nixpkgs#kubectl nixpkgs#k3d nixpkgs#kubernetes-helm nixpkgs#jq -c terraform -chdir=stacks/system apply -input=false -auto-approve
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform nixpkgs#kubectl nixpkgs#k3d nixpkgs#kubernetes-helm nixpkgs#jq -c terraform -chdir=stacks/routing apply -input=false -auto-approve
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform nixpkgs#kubectl nixpkgs#k3d nixpkgs#kubernetes-helm nixpkgs#jq -c terraform -chdir=stacks/data apply -input=false -auto-approve
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform nixpkgs#kubectl nixpkgs#k3d nixpkgs#kubernetes-helm nixpkgs#jq -c terraform -chdir=stacks/platform apply -var 'oidc_issuer_url=https://mockauth.dev/r/301ebb13-15a8-48f4-baac-e3fa25be29fc/oidc' -var 'oidc_client_id=client_MU95KU3gHQf5Ir7p' -var 'oidc_client_secret=XPKka2i9uzISrKZ95zxli8sY51BK4eTJ' -input=false -auto-approve
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#kubectl nixpkgs#jq -c ./.github/scripts/verify_platform_health.sh

Fixes #186