### PR TITLE
fix(deps): add CoreDNS rewrite for ziti-router

### DIFF
--- a/stacks/deps/main.tf
+++ b/stacks/deps/main.tf
@@ -282,6 +282,11 @@ resource "kubernetes_config_map_v1_data" "coredns_ziti_rewrites" {
           # ziti-management runs in the platform namespace and must reach the
           # controller management API during startup for cert-based auth.
           rewrite name ziti-mgmt.${local.base_domain} ziti-controller-mgmt.${local.ziti_namespace}.svc.cluster.local
+          # The edge router advertises ziti-router.<domain>:<port> in session info.
+          # SDK clients inside the cluster (orchestrator, k8s-runner) must reach
+          # the router directly; without this rewrite the public wildcard DNS
+          # resolves to 127.0.0.1 and connections fail.
+          rewrite name ziti-router.${local.base_domain} ziti-router-edge.${local.ziti_namespace}.svc.cluster.local
           rewrite name chat.${local.base_domain} istio-ingressgateway.${local.istio_gateway_namespace}.svc.cluster.local
           rewrite name tracing.${local.base_domain} istio-ingressgateway.${local.istio_gateway_namespace}.svc.cluster.local
           kubernetes cluster.local in-addr.arpa ip6.arpa {

--- a/stacks/deps/main.tf
+++ b/stacks/deps/main.tf
@@ -257,10 +257,9 @@ resource "argocd_application" "ziti_controller" {
 
 # CoreDNS rewrite rules for OpenZiti in-cluster resolution.
 # The controller bakes ziti.<domain> into enrollment JWTs as the issuer URL.
-# Router pods must resolve this hostname during enrollment; without the rewrite
-# it resolves to loopback and enrollment fails. The ziti-router
-# hostname is only used by external clients or host-side tooling, so it does
-# not need in-cluster rewrites.
+# Router pods and SDK clients (orchestrator, k8s-runner) must resolve these
+# hostnames to reach the controller and edge router; without the rewrites
+# they resolve to 127.0.0.1 (public wildcard DNS) and connections fail.
 resource "kubernetes_config_map_v1_data" "coredns_ziti_rewrites" {
   metadata {
     name      = "coredns"

--- a/stacks/deps/main.tf
+++ b/stacks/deps/main.tf
@@ -281,10 +281,6 @@ resource "kubernetes_config_map_v1_data" "coredns_ziti_rewrites" {
           # ziti-management runs in the platform namespace and must reach the
           # controller management API during startup for cert-based auth.
           rewrite name ziti-mgmt.${local.base_domain} ziti-controller-mgmt.${local.ziti_namespace}.svc.cluster.local
-          # The edge router advertises ziti-router.<domain>:<port> in session info.
-          # SDK clients inside the cluster (orchestrator, k8s-runner) must reach
-          # the router directly; without this rewrite the public wildcard DNS
-          # resolves to 127.0.0.1 and connections fail.
           rewrite name ziti-router.${local.base_domain} ziti-router-edge.${local.ziti_namespace}.svc.cluster.local
           rewrite name chat.${local.base_domain} istio-ingressgateway.${local.istio_gateway_namespace}.svc.cluster.local
           rewrite name tracing.${local.base_domain} istio-ingressgateway.${local.istio_gateway_namespace}.svc.cluster.local


### PR DESCRIPTION
## Problem

The Ziti edge router advertises `ziti-router.agyn.dev:2496` in session info. Inside the cluster, public DNS resolves `*.agyn.dev` to `127.0.0.1` (wildcard A record). When the Ziti SDK in orchestrator or k8s-runner pods tries to connect to the edge router, it dials `127.0.0.1:2496` — the pod's own loopback — and gets `connection refused`.

```
dial tcp 127.0.0.1:2496: connect: connection refused (router=edge-router-1)
```

## Fix

Add a CoreDNS rewrite rule for `ziti-router.<domain>` → `ziti-router-edge.ziti.svc.cluster.local`, routing in-cluster traffic directly to the router's edge K8s Service. This matches the existing pattern for `ziti.agyn.dev` (controller) and `ziti-mgmt.agyn.dev` (management API).

## Verification

- Confirmed `ziti-router.agyn.dev` resolves to `127.0.0.1` via public DNS (wildcard `*.agyn.dev`)
- Confirmed `ziti-router-edge.ziti.svc.cluster.local` is the correct target from `stacks/routing/main.tf` (Istio VirtualService destination)
- Confirmed the rewrite pattern matches existing CoreDNS config in `stacks/deps/main.tf`