### PR TITLE
chore(platform): bump agents-orchestrator v0.4.0, ziti-management v0.5.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -38,7 +38,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.3.0"
+  default     = "0.4.0"
 }
 
 variable "k8s_runner_chart_version" {
@@ -92,7 +92,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.4.0"
+  default     = "0.5.0"
 }
 
 variable "users_chart_version" {


### PR DESCRIPTION
## Version bumps

| Service | From | To | Key changes |
|---------|------|----|-------------|
| agents-orchestrator | 0.3.0 | 0.4.0 | Fix `ZITI_ENROLL_TOKEN` env var name + add `/netfoundry` volume mount |
| ziti-management | 0.4.0 | 0.5.0 | Idempotent `CreateAgentIdentity` (stale identity cleanup) |

These two fixes together resolve the agent pod init failures:
1. Stale identity from prior failed attempt → ziti-management now cleans up before creating
2. Wrong env var name → sidecar now receives the enrollment token correctly
3. Missing volume → sidecar now has writable storage for identity persistence