### PR TITLE
chore(platform): bump agents-orchestrator v0.5.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -38,7 +38,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.4.0"
+  default     = "0.5.0"
 }
 
 variable "k8s_runner_chart_version" {


### PR DESCRIPTION
Bumps agents-orchestrator from 0.4.0 to 0.5.0.

**Key changes:**
- Disable OIDC on orchestrator Ziti identity (fixes RDM propagation race)
- Add retry with exponential backoff to Ziti dial

This is the last piece needed for end-to-end agent networking over Ziti.