### PR TITLE
chore(platform): bump agents-orchestrator v0.6.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -38,7 +38,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.5.0"
+  default     = "0.6.0"
 }
 
 variable "k8s_runner_chart_version" {


### PR DESCRIPTION
Bumps agents-orchestrator from 0.5.0 to 0.6.0.

**Key changes:**
- Ziti-aware defaults: `gateway.ziti:443` and `https://llm-proxy.ziti/v1` when `ZITI_ENABLED=true`
- Sidecar image pinned to `openziti/ziti-tunnel:1.6.14`