### PR TITLE
chore: set ziti sidecar image

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1166,6 +1166,10 @@ locals {
         value = "true"
       },
       {
+        name  = "ZITI_SIDECAR_IMAGE"
+        value = "openziti/ziti-tunnel:2.0.0-pre8"
+      },
+      {
         name  = "RUNNER_ADDRESS"
         value = "k8s-runner:50051"
       }


### PR DESCRIPTION
## Summary
- add the ZITI_SIDECAR_IMAGE env override to agents-orchestrator Helm values

## Testing
- terraform fmt -check -recursive
- terraform -chdir=stacks/platform init -backend=false
- terraform -chdir=stacks/platform validate

Closes #194