### PR TITLE
chore(platform): bump chart versions

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -38,13 +38,13 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.6.0"
+  default     = "0.7.0"
 }
 
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.3.1"
+  default     = "0.4.1"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
## Summary
- bump agents-orchestrator chart default to 0.7.0
- bump k8s-runner chart default to 0.4.1
- keep ziti-management and llm-proxy chart defaults at existing published versions

## Testing
- terraform fmt -check -recursive
- terraform -chdir=stacks/k8s apply -var 'domain=agyn.dev' -var 'port=2496' -input=false -auto-approve
- terraform -chdir=stacks/system apply -input=false -auto-approve
- terraform -chdir=stacks/routing apply -input=false -auto-approve
- terraform -chdir=stacks/data apply -input=false -auto-approve
- terraform -chdir=stacks/platform apply -input=false -auto-approve -var 'oidc_issuer_url=https://mockauth.dev/r/301ebb13-15a8-48f4-baac-e3fa25be29fc/oidc' -var 'oidc_client_id=client_MU95KU3gHQf5Ir7p' -var 'oidc_client_secret=XPKka2i9uzISrKZ95zxli8sY51BK4eTJ'
- ./.github/scripts/verify_platform_health.sh

## Notes
- ziti-management 0.6.0 and llm-proxy 0.2.0 charts are not published on GHCR yet, so defaults stay at 0.5.0 and 0.1.4.

Closes #196