### PR TITLE
chore: bump tracing v0.2.0, gateway v0.11.0, tracing-app v0.2.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -26,7 +26,7 @@ variable "platform_chart_version" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.11.0"
+  default     = "0.11.1"
 }
 
 variable "agent_state_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -26,7 +26,7 @@ variable "platform_chart_version" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.10.0"
+  default     = "0.11.0"
 }
 
 variable "agent_state_chart_version" {
@@ -56,7 +56,7 @@ variable "threads_chart_version" {
 variable "tracing_chart_version" {
   type        = string
   description = "Version of the tracing Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "token_counting_chart_version" {
@@ -153,7 +153,7 @@ variable "oidc_client_secret" {
 variable "tracing_app_chart_version" {
   type        = string
   description = "Version of the tracing-app Helm chart published to GHCR"
-  default     = "0.1.2"
+  default     = "0.2.0"
 }
 
 variable "tracing_app_image_tag" {


### PR DESCRIPTION
## Summary

Bump platform service chart versions to include the tracing API integration work:

| Service | Previous | New | Changes |
|---|---|---|---|
| **gateway** | `0.10.0` | `0.11.0` | Pass-through handlers for `GetTraceSummary` / `GetTraceSpanTotals` RPCs ([PR #116](https://github.com/agynio/gateway/pull/116)) |
| **tracing** | `0.1.0` | `0.2.0` | `GetTraceSummary`, `GetTraceSpanTotals` RPCs, extended `ListSpans` filtering ([PR #5](https://github.com/agynio/tracing/pull/5)) |
| **tracing-app** | `0.1.2` | `0.2.0` | Wired to real tracing API via ConnectRPC, replaced all mock data ([PR #17](https://github.com/agynio/tracing-app/pull/17)) |

## Changes

- `stacks/platform/variables.tf`: Updated `gateway_chart_version`, `tracing_chart_version`, and `tracing_app_chart_version` defaults.

No new Helm values or config changes required — the new RPCs are additive and the tracing-app changes are purely client-side.