### PR TITLE
Bump k8s-runner chart to 0.4.2

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1096,10 +1096,6 @@ locals {
         value = "agyn-workloads"
       },
       {
-        name  = "RUNNER_ID"
-        value = "6cf635bb-825f-4885-b94b-a0e6ab1fdb64"
-      },
-      {
         name  = "ZITI_ENABLED"
         value = "true"
       },

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1096,6 +1096,10 @@ locals {
         value = "agyn-workloads"
       },
       {
+        name  = "RUNNER_ID"
+        value = "6cf635bb-825f-4885-b94b-a0e6ab1fdb64"
+      },
+      {
         name  = "ZITI_ENABLED"
         value = "true"
       },

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -38,7 +38,7 @@ variable "agents_orchestrator_chart_version" {
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.4.2"
+  default     = "0.4.3"
 }
 
 variable "threads_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -38,7 +38,7 @@ variable "agents_orchestrator_chart_version" {
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.4.1"
+  default     = "0.4.2"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
## Summary
- bump `k8s_runner_chart_version` to 0.4.2 in `stacks/platform/variables.tf`

## Testing
- `NIXPKGS_ALLOW_UNFREE=1 SSL_CERT_FILE=local-certs/ca-agyn-dev.pem nix shell --impure nixpkgs#terraform nixpkgs#kubectl nixpkgs#k3d nixpkgs#kubernetes-helm nixpkgs#jq -c terraform -chdir=stacks/platform apply -var 'oidc_issuer_url=https://mockauth.dev/r/301ebb13-15a8-48f4-baac-e3fa25be29fc/oidc' -var 'oidc_client_id=client_MU95KU3gHQf5Ir7p' -var 'oidc_client_secret=XPKka2i9uzISrKZ95zxli8sY51BK4eTJ' -input=false -auto-approve`
- `NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform fmt -check -recursive`

Closes #201