### PR TITLE
chore(platform): bump gateway v0.12.0, agents v0.5.0, llm-proxy v0.5.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -20,7 +20,7 @@ variable "argocd_admin_password" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.11.1"
+  default     = "0.12.0"
 }
 
 variable "agent_state_chart_version" {
@@ -80,7 +80,7 @@ variable "postgres_chart_version" {
 variable "agents_chart_version" {
   type        = string
   description = "Version of the agents Helm chart published to GHCR"
-  default     = "0.4.1"
+  default     = "0.5.0"
 }
 
 variable "ziti_management_chart_version" {
@@ -598,7 +598,7 @@ variable "openfga_namespace" {
 variable "llm_proxy_chart_version" {
   type        = string
   description = "Version of the llm-proxy Helm chart published to GHCR"
-  default     = "0.1.4"
+  default     = "0.5.0"
 }
 
 variable "llm_proxy_image_tag" {


### PR DESCRIPTION
Bumps platform service chart versions to include fixes required for agent e2e tests:

| Service | From | To | Change |
|---------|------|----|--------|
| gateway | 0.11.1 | 0.12.0 | fix(ziti): managed identity resolution ([#123](https://github.com/agynio/gateway/pull/123)) |
| agents | 0.4.1 | 0.5.0 | feat(authz): agent org membership tuples ([#30](https://github.com/agynio/agents/pull/30)) |
| llm-proxy | 0.1.4 | 0.5.0 | fix(identity): managed identity parsing ([#22](https://github.com/agynio/llm-proxy/pull/22)) |

These three fixes together resolve the `managed identity not found` error that caused agent workload pods to fail in chat-app e2e tests.

Ref: agynio/chat-app#45, agynio/agynd-cli#39