### PR TITLE
chore(platform): bump llm-proxy v0.5.0 → v0.6.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -598,7 +598,7 @@ variable "openfga_namespace" {
 variable "llm_proxy_chart_version" {
   type        = string
   description = "Version of the llm-proxy Helm chart published to GHCR"
-  default     = "0.5.0"
+  default     = "0.6.0"
 }
 
 variable "llm_proxy_image_tag" {


### PR DESCRIPTION
Bumps llm-proxy chart version to include the `DialerIdentifiable` identity extraction fix.

| Service | From | To | Change |
|---------|------|----|--------|
| llm-proxy | 0.5.0 | 0.6.0 | fix(ziticonn): prefer `GetDialerIdentityId()` over `SourceIdentifier()` ([agynio/llm-proxy#24](https://github.com/agynio/llm-proxy/pull/24)) |

This resolves the remaining `401 Unauthorized: managed identity not found` error when agents connect to llm-proxy via Ziti SDK. The previous v0.5.0 added `ParseManagedIdentityName` fallback, but the root cause was extracting the identity name instead of the identity ID from the Ziti connection.

Ref: agynio/chat-app#45