### PR TITLE
chore(platform): bump gateway, k8s-runner, agents-orchestrator, llm-proxy

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -86,7 +86,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.5.0"
+  default     = "0.5.1"
 }
 
 variable "users_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -20,7 +20,7 @@ variable "argocd_admin_password" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.12.0"
+  default     = "0.13.0"
 }
 
 variable "agent_state_chart_version" {
@@ -32,13 +32,13 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.8.0"
+  default     = "0.9.0"
 }
 
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.4.3"
+  default     = "0.5.0"
 }
 
 variable "threads_chart_version" {
@@ -598,7 +598,7 @@ variable "openfga_namespace" {
 variable "llm_proxy_chart_version" {
   type        = string
   description = "Version of the llm-proxy Helm chart published to GHCR"
-  default     = "0.6.0"
+  default     = "0.7.0"
 }
 
 variable "llm_proxy_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -38,7 +38,7 @@ variable "agents_orchestrator_chart_version" {
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.5.0"
+  default     = "0.5.1"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
Bumps 4 platform service chart versions for startup retry and auth hardening:

| Service | From | To | Changes |
|---------|------|----|---------|
| gateway | 0.12.0 | 0.13.0 | Remove SourceIdentifier from auth ([#125](https://github.com/agynio/gateway/pull/125)), startup retry ([#127](https://github.com/agynio/gateway/pull/127)) |
| k8s-runner | 0.4.1 | 0.5.0 | Startup retry ([#32](https://github.com/agynio/k8s-runner/pull/32)) |
| agents-orchestrator | 0.8.0 | 0.9.0 | Startup retry ([#86](https://github.com/agynio/agents-orchestrator/pull/86)) |
| llm-proxy | 0.6.0 | 0.7.0 | Remove SourceIdentifier from auth ([#26](https://github.com/agynio/llm-proxy/pull/26)) |

**Startup retry:** All services that call `RequestServiceIdentity()` now retry with exponential backoff (1s→15s, 2m timeout) when ziti-management isn't ready, eliminating the CrashLoopBackOff race condition.

**Auth hardening:** Gateway and llm-proxy auth flows now only use trusted router-injected `GetDialerIdentityId()`, removing the client-asserted `SourceIdentifier()` fallback.

Ref: agynio/chat-app#45