### PR TITLE
chore(platform): bump ziti-management 0.5.1 → 0.5.2

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -86,7 +86,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.5.1"
+  default     = "0.5.2"
 }
 
 variable "users_chart_version" {


### PR DESCRIPTION
Fixes `parseManagedIdentityID` which was misidentifying Ziti controller UUIDs as domain identity IDs, causing `managed identity not found` for all agent workloads connecting via Ziti.

| Service | From | To |
|---------|------|----|
| ziti-management | 0.5.1 | 0.5.2 |

Ref: agynio/ziti-management#26, agynio/chat-app#45