### PR TITLE
Update Ziti runner policies

### DIFF
--- a/.github/scripts/verify_platform_health.sh
+++ b/.github/scripts/verify_platform_health.sh
@@ -16,7 +16,8 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
 readonly KUBECONFIG_PATH="$REPO_ROOT/stacks/k8s/.kube/agyn-local-kubeconfig.yaml"
 ZITI_MGMT_ENDPOINT=${ZITI_MGMT_ENDPOINT:-}
-ZITI_OVERLAY_SERVICES=(gateway runner)
+ZITI_OVERLAY_SERVICES=(gateway)
+ZITI_OVERLAY_ROLE_CHECKS=("runner-services")
 
 if [[ ! -f "$KUBECONFIG_PATH" ]]; then
   printf 'Unable to locate kubeconfig at %s\n' "$KUBECONFIG_PATH" >&2
@@ -357,6 +358,37 @@ while (( SECONDS < deadline )); do
             ziti_overlay_pending+=("${service_name} terminators")
           elif (( ziti_terminator_count < 1 )); then
             ziti_overlay_pending+=("${service_name} terminators")
+          fi
+        done
+
+        for role_attr in "${ZITI_OVERLAY_ROLE_CHECKS[@]}"; do
+          if ! ziti_services_json=$(ziti_api_get "$ziti_token" \
+            "/services?filter=anyOf(roleAttributes)%3D%22${role_attr}%22"); then
+            ziti_overlay_pending+=("${role_attr} services")
+            continue
+          fi
+
+          ziti_service_count=$(jq -r '[.data[]?] | length' \
+            <<<"$ziti_services_json" 2>/dev/null || true)
+          if ! [[ "$ziti_service_count" =~ ^[0-9]+$ ]] || (( ziti_service_count < 1 )); then
+            ziti_overlay_pending+=("${role_attr} services")
+            continue
+          fi
+
+          role_has_terminator=false
+          while IFS= read -r svc_name; do
+            if ziti_term_json=$(ziti_api_get "$ziti_token" \
+              "/terminators?filter=service.name%3D%22${svc_name}%22"); then
+              term_count=$(jq -r '[.data[]?] | length' <<<"$ziti_term_json" 2>/dev/null || true)
+              if [[ "$term_count" =~ ^[0-9]+$ ]] && (( term_count >= 1 )); then
+                role_has_terminator=true
+                break
+              fi
+            fi
+          done < <(jq -r '.data[]?.name // empty' <<<"$ziti_services_json")
+
+          if [[ "$role_has_terminator" != "true" ]]; then
+            ziti_overlay_pending+=("${role_attr} terminators")
           fi
         done
       fi

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -33,6 +33,8 @@ jobs:
           terraform_version: 1.6.6
 
       - name: Apply all stacks (k8s -> system -> routing -> minio -> platform)
+        env:
+          TF_VAR_k8s_runner_identity_id: 439e0da2-88cd-46d7-bb9c-56c723c15606
         run: ./apply.sh -y
 
       - name: Verify platform workloads and Argo CD health

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1076,6 +1076,10 @@ locals {
         name  = "AUTHORIZATION_ADDRESS"
         value = "authorization:50051"
       },
+      {
+        name  = "ZITI_MANAGEMENT_ADDRESS"
+        value = "ziti-management:50051"
+      },
     ]
   })
 

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1113,6 +1113,10 @@ locals {
       {
         name  = "ZITI_MANAGEMENT_ADDRESS"
         value = "ziti-management:50051"
+      },
+      {
+        name  = "RUNNER_ID"
+        value = var.k8s_runner_identity_id
       }
     ]
     containerPorts = [

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1068,18 +1068,6 @@ locals {
         name  = "DATABASE_URL"
         value = format("postgresql://runners:%s@runners-db:5432/runners?sslmode=disable", var.runners_db_password)
       },
-      {
-        name  = "IDENTITY_ADDRESS"
-        value = "identity:50051"
-      },
-      {
-        name  = "AUTHORIZATION_ADDRESS"
-        value = "authorization:50051"
-      },
-      {
-        name  = "ZITI_MANAGEMENT_ADDRESS"
-        value = "ziti-management:50051"
-      },
     ]
   })
 
@@ -1109,10 +1097,6 @@ locals {
       {
         name  = "ZITI_ENABLED"
         value = "true"
-      },
-      {
-        name  = "ZITI_MANAGEMENT_ADDRESS"
-        value = "ziti-management:50051"
       },
       {
         name  = "RUNNER_ID"

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -86,7 +86,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.5.2"
+  default     = "0.7.0"
 }
 
 variable "users_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -38,7 +38,13 @@ variable "agents_orchestrator_chart_version" {
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.5.1"
+  default     = "0.6.0"
+}
+
+variable "k8s_runner_identity_id" {
+  type        = string
+  description = "Stable UUID identifying the singleton k8s-runner instance for Ziti identity management"
+  default     = "439e0da2-88cd-46d7-bb9c-56c723c15606"
 }
 
 variable "threads_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -44,7 +44,6 @@ variable "k8s_runner_chart_version" {
 variable "k8s_runner_identity_id" {
   type        = string
   description = "Stable UUID identifying the singleton k8s-runner instance for Ziti identity management"
-  default     = "439e0da2-88cd-46d7-bb9c-56c723c15606"
 }
 
 variable "threads_chart_version" {

--- a/stacks/ziti/main.tf
+++ b/stacks/ziti/main.tf
@@ -89,11 +89,6 @@ resource "ziti_service" "gateway" {
   role_attributes = ["gateway"]
 }
 
-resource "ziti_service" "runner" {
-  name            = "runner"
-  role_attributes = ["runner"]
-}
-
 resource "ziti_service" "llm_proxy" {
   name            = "llm-proxy"
   configs         = [ziti_intercept_v1_config.llm_proxy_intercept.id]
@@ -165,18 +160,18 @@ resource "ziti_service_policy" "agents_dial_gateway" {
   serviceroles  = [format("@%s", ziti_service.gateway.id)]
 }
 
-resource "ziti_service_policy" "channels_dial_gateway" {
-  name          = "channels-dial-gateway"
-  type          = "Dial"
-  identityroles = ["#channels"]
-  serviceroles  = [format("@%s", ziti_service.gateway.id)]
-}
-
 resource "ziti_service_policy" "orchestrators_dial_runners" {
   name          = "orchestrators-dial-runners"
   type          = "Dial"
   identityroles = ["#orchestrators"]
-  serviceroles  = [format("@%s", ziti_service.runner.id)]
+  serviceroles  = ["#runner-services"]
+}
+
+resource "ziti_service_policy" "terminal_proxy_dial_runners" {
+  name          = "terminal-proxy-dial-runners"
+  type          = "Dial"
+  identityroles = ["#terminal-proxy-hosts"]
+  serviceroles  = ["#runner-services"]
 }
 
 resource "ziti_service_policy" "gateway_bind" {
@@ -204,7 +199,7 @@ resource "ziti_service_policy" "runners_bind" {
   name          = "runners-bind"
   type          = "Bind"
   identityroles = ["#runners"]
-  serviceroles  = [format("@%s", ziti_service.runner.id)]
+  serviceroles  = ["#runner-services"]
 }
 
 resource "ziti_service_policy" "apps_dial_gateway" {

--- a/stacks/ziti/outputs.tf
+++ b/stacks/ziti/outputs.tf
@@ -15,7 +15,6 @@ output "identity_ids" {
 output "service_ids" {
   value = {
     gateway = ziti_service.gateway.id
-    runner  = ziti_service.runner.id
   }
   description = "Ziti service IDs"
 }


### PR DESCRIPTION
## Summary
- remove the static runner service and unused channels gateway policy
- switch runner service policies to the #runner-services role
- add terminal proxy dial runners policy and update outputs

## Testing
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform fmt -recursive
- NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#terraform -c terraform -chdir=stacks/ziti validate

Closes #211