### PR TITLE
chore: bump chat-app to 0.2.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -116,7 +116,7 @@ variable "runners_chart_version" {
 variable "chat_app_chart_version" {
   type        = string
   description = "Version of the chat-app Helm chart published to GHCR"
-  default     = "0.1.6"
+  default     = "0.2.0"
 }
 
 variable "chat_app_image_tag" {


### PR DESCRIPTION
## Summary

Bumps `chat_app_chart_version` from `0.1.6` → `0.2.0` to pick up the latest [chat-app v0.2.0 release](https://github.com/agynio/chat-app/releases/tag/v0.2.0).

### Notable changes in chat-app v0.2.0
- Organization switching
- Org-aware agents
- Conversations UI alignment
- Participant identity resolution fix
- Prevent solo chats
- E2E test coverage improvements