### PR TITLE
chore: bump agents chart to v0.6.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -80,7 +80,7 @@ variable "postgres_chart_version" {
 variable "agents_chart_version" {
   type        = string
   description = "Version of the agents Helm chart published to GHCR"
-  default     = "0.5.0"
+  default     = "0.6.0"
 }
 
 variable "ziti_management_chart_version" {


### PR DESCRIPTION
Bump agents service Helm chart from v0.5.0 to v0.6.0.

v0.6.0 includes `feat(mcp): add name field (#32)` — required for the orchestrator's MCP port allocation and E2E test (`agynio/agents-orchestrator#87`).

Release: https://github.com/agynio/agents/releases/tag/v0.6.0