### PR TITLE
fix: pass k8s_runner_identity_id in apply.sh

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -44,6 +44,7 @@ variable "k8s_runner_chart_version" {
 variable "k8s_runner_identity_id" {
   type        = string
   description = "Stable UUID identifying the singleton k8s-runner instance for Ziti identity management"
+  default     = "439e0da2-88cd-46d7-bb9c-56c723c15606"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
## Summary
- add default k8s runner identity ID handling in apply.sh
- pass k8s_runner_identity_id to the platform terraform apply

## Testing
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Fixes #216