### PR TITLE
Add console app bootstrap deployment

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -7,6 +7,7 @@ locals {
   resolved_tracing_image_tag             = trimspace(var.tracing_image_tag) != "" ? var.tracing_image_tag : format("v%s", var.tracing_chart_version)
   resolved_chat_image_tag                = trimspace(var.chat_image_tag) != "" ? var.chat_image_tag : var.chat_chart_version
   resolved_chat_app_image_tag            = trimspace(var.chat_app_image_tag) != "" ? var.chat_app_image_tag : var.chat_app_chart_version
+  resolved_console_app_image_tag         = trimspace(var.console_app_image_tag) != "" ? var.console_app_image_tag : var.console_app_chart_version
   resolved_tracing_app_image_tag         = trimspace(var.tracing_app_image_tag) != "" ? var.tracing_app_image_tag : var.tracing_app_chart_version
   resolved_files_image_tag               = trimspace(var.files_image_tag) != "" ? var.files_image_tag : var.files_chart_version
   resolved_llm_image_tag                 = trimspace(var.llm_image_tag) != "" ? var.llm_image_tag : format("v%s", var.llm_chart_version)
@@ -45,6 +46,7 @@ locals {
   tracing_chart_name             = "agynio/charts/tracing"
   chat_chart_name                = "agynio/charts/chat"
   chat_app_chart_name            = "agynio/charts/chat-app"
+  console_app_chart_name         = "agynio/charts/console-app"
   tracing_app_chart_name         = "agynio/charts/tracing-app"
   files_chart_name               = "agynio/charts/files"
   llm_chart_name                 = "agynio/charts/llm"
@@ -1591,6 +1593,81 @@ locals {
     ]
   })
 
+  console_app_values = yamlencode({
+    replicaCount     = 1
+    fullnameOverride = "console-app"
+    image = {
+      repository = "ghcr.io/agynio/console-app"
+      tag        = local.resolved_console_app_image_tag
+      pullPolicy = "IfNotPresent"
+    }
+    service = {
+      type = "ClusterIP"
+      ports = [
+        {
+          name       = "http"
+          port       = 3000
+          targetPort = "http"
+          protocol   = "TCP"
+        }
+      ]
+    }
+    extraVolumes = [
+      {
+        name     = "console-app-cache"
+        emptyDir = {}
+      },
+      {
+        name     = "console-app-run"
+        emptyDir = {}
+      },
+      {
+        name     = "console-app-tmp"
+        emptyDir = {}
+      },
+      {
+        name     = "console-app-conf"
+        emptyDir = {}
+      }
+    ]
+    extraVolumeMounts = [
+      {
+        name      = "console-app-cache"
+        mountPath = "/var/cache/nginx"
+      },
+      {
+        name      = "console-app-run"
+        mountPath = "/var/run"
+      },
+      {
+        name      = "console-app-tmp"
+        mountPath = "/tmp"
+      },
+      {
+        name      = "console-app-conf"
+        mountPath = "/etc/nginx/conf.d"
+      }
+    ]
+    env = [
+      {
+        name  = "OIDC_AUTHORITY"
+        value = var.oidc_issuer_url
+      },
+      {
+        name  = "OIDC_CLIENT_ID"
+        value = var.oidc_client_id
+      },
+      {
+        name  = "OIDC_SCOPE"
+        value = "openid profile email"
+      },
+      {
+        name  = "API_BASE_URL"
+        value = "/api"
+      }
+    ]
+  })
+
   tracing_app_values = yamlencode({
     replicaCount     = 1
     fullnameOverride = "tracing-app"
@@ -1845,6 +1922,97 @@ resource "kubernetes_manifest" "virtualservice_chat_app" {
             {
               "destination" = {
                 "host" = "chat-app.platform.svc.cluster.local"
+                "port" = {
+                  "number" = 3000
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  computed_fields = [
+    "metadata.annotations",
+    "metadata.labels",
+  ]
+
+  depends_on = [
+    data.terraform_remote_state.system,
+  ]
+}
+
+resource "kubernetes_manifest" "virtualservice_console_app" {
+  manifest = {
+    "apiVersion" = "networking.istio.io/v1beta1"
+    "kind"       = "VirtualService"
+    "metadata" = {
+      "name"      = "console-app"
+      "namespace" = local.istio_gateway_namespace
+    }
+    "spec" = {
+      "hosts"    = ["console.${local.base_domain}"]
+      "gateways" = ["platform-gateway"]
+      "http" = [
+        {
+          "match" = [
+            {
+              "uri" = {
+                "prefix" = "/api/"
+              }
+            },
+            {
+              "uri" = {
+                "exact" = "/api"
+              }
+            }
+          ]
+          "rewrite" = {
+            "uri" = "/"
+          }
+          "route" = [
+            {
+              "destination" = {
+                "host" = "gateway-gateway.platform.svc.cluster.local"
+                "port" = {
+                  "number" = 8080
+                }
+              }
+            }
+          ]
+        },
+        {
+          "match" = [
+            {
+              "uri" = {
+                "prefix" = "/socket.io"
+              }
+            }
+          ]
+          "route" = [
+            {
+              "destination" = {
+                "host" = "gateway-gateway.platform.svc.cluster.local"
+                "port" = {
+                  "number" = 8080
+                }
+              }
+            }
+          ]
+        },
+        {
+          "match" = [
+            {
+              "uri" = {
+                "prefix" = "/"
+              }
+            }
+          ]
+          "route" = [
+            {
+              "destination" = {
+                "host" = "console-app.platform.svc.cluster.local"
                 "port" = {
                   "number" = 3000
                 }
@@ -4052,6 +4220,49 @@ resource "argocd_application" "chat_app" {
 
       helm {
         values = local.chat_app_values
+      }
+    }
+
+    destination {
+      server    = var.destination_server
+      namespace = var.platform_namespace
+    }
+
+    sync_policy {
+      dynamic "automated" {
+        for_each = var.argocd_automated_sync_enabled ? [1] : []
+        content {
+          prune       = var.argocd_prune_enabled
+          self_heal   = var.argocd_self_heal_enabled
+          allow_empty = false
+        }
+      }
+
+      sync_options = local.default_sync_options
+    }
+  }
+}
+
+resource "argocd_application" "console_app" {
+  depends_on = [argocd_repository.litellm_repo]
+  metadata {
+    name      = "console-app"
+    namespace = "argocd"
+    annotations = {
+      "argocd.argoproj.io/sync-wave" = "25"
+    }
+  }
+
+  spec {
+    project = "default"
+
+    source {
+      repo_url        = local.platform_chart_repo_host
+      chart           = local.console_app_chart_name
+      target_revision = var.console_app_chart_version
+
+      helm {
+        values = local.console_app_values
       }
     }
 

--- a/stacks/platform/outputs.tf
+++ b/stacks/platform/outputs.tf
@@ -18,6 +18,7 @@ output "platform_app_names" {
     argocd_application.files.metadata[0].name,
     argocd_application.k8s_runner.metadata[0].name,
     argocd_application.chat_app.metadata[0].name,
+    argocd_application.console_app.metadata[0].name,
     argocd_application.tracing_app.metadata[0].name,
   ]
 }
@@ -42,6 +43,7 @@ output "platform_app_ids" {
     argocd_application.files.id,
     argocd_application.k8s_runner.id,
     argocd_application.chat_app.id,
+    argocd_application.console_app.id,
     argocd_application.tracing_app.id,
   ]
 }

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -130,6 +130,18 @@ variable "chat_app_image_tag" {
   default     = ""
 }
 
+variable "console_app_chart_version" {
+  type        = string
+  description = "Version of the console-app Helm chart published to GHCR"
+  default     = "0.1.0"
+}
+
+variable "console_app_image_tag" {
+  type        = string
+  description = "Optional override for the console-app container image tag"
+  default     = ""
+}
+
 variable "oidc_issuer_url" {
   type        = string
   description = "OIDC issuer URL (authority) for frontend apps"

--- a/stacks/routing/main.tf
+++ b/stacks/routing/main.tf
@@ -7,6 +7,7 @@ locals {
     local.base_domain,
     "argocd.${local.base_domain}",
     "chat.${local.base_domain}",
+    "console.${local.base_domain}",
     "gateway.${local.base_domain}",
     "litellm.${local.base_domain}",
     "llm.${local.base_domain}",


### PR DESCRIPTION
## Summary
- add console app chart/image variables and Helm values
- route console traffic through Istio and register Argo CD app
- include console app outputs alongside platform apps

## Testing
- terraform fmt -check -recursive
- TF_VAR_k8s_runner_identity_id=439e0da2-88cd-46d7-bb9c-56c723c15606 ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Refs #218