### PR TITLE
feat(platform): add console OIDC client

### DIFF
--- a/stacks/deps/main.tf
+++ b/stacks/deps/main.tf
@@ -284,6 +284,7 @@ resource "kubernetes_config_map_v1_data" "coredns_ziti_rewrites" {
           rewrite name ziti-router.${local.base_domain} ziti-router-edge.${local.ziti_namespace}.svc.cluster.local
           rewrite name chat.${local.base_domain} istio-ingressgateway.${local.istio_gateway_namespace}.svc.cluster.local
           rewrite name tracing.${local.base_domain} istio-ingressgateway.${local.istio_gateway_namespace}.svc.cluster.local
+          rewrite name console.${local.base_domain} istio-ingressgateway.${local.istio_gateway_namespace}.svc.cluster.local
           kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             fallthrough in-addr.arpa ip6.arpa

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1655,7 +1655,7 @@ locals {
       },
       {
         name  = "OIDC_CLIENT_ID"
-        value = var.oidc_client_id
+        value = var.console_app_oidc_client_id
       },
       {
         name  = "OIDC_SCOPE"

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -154,6 +154,12 @@ variable "oidc_client_id" {
   default     = "client_MU95KU3gHQf5Ir7p"
 }
 
+variable "console_app_oidc_client_id" {
+  type        = string
+  description = "OIDC client ID for the console-app (public client)"
+  default     = "client_4XUh4_1VfUzpfYkN"
+}
+
 variable "oidc_client_secret" {
   type        = string
   description = "OIDC client secret (dev/QA only - production should use a K8s Secret)"


### PR DESCRIPTION
## Summary
- add console-app OIDC client ID variable for platform stack
- wire console-app OIDC_CLIENT_ID to the new variable

## Testing
- terraform fmt -check -recursive
- TF_VAR_k8s_runner_identity_id=439e0da2-88cd-46d7-bb9c-56c723c15606 ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Refs #220