### PR TITLE
Default k8s runner identity

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -33,8 +33,6 @@ jobs:
           terraform_version: 1.6.6
 
       - name: Apply all stacks (k8s -> system -> routing -> minio -> platform)
-        env:
-          TF_VAR_k8s_runner_identity_id: 439e0da2-88cd-46d7-bb9c-56c723c15606
         run: ./apply.sh -y
 
       - name: Verify platform workloads and Argo CD health

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -44,6 +44,7 @@ variable "k8s_runner_chart_version" {
 variable "k8s_runner_identity_id" {
   type        = string
   description = "Stable UUID identifying the singleton k8s-runner instance for Ziti identity management"
+  default     = "439e0da2-88cd-46d7-bb9c-56c723c15606"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
## Summary
- default k8s runner identity id in platform variables
- remove TF_VAR_k8s_runner_identity_id from bootstrap workflow

## Testing
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Refs #222