### PR TITLE
chore(platform): bump users to v0.3.0, gateway to v0.15.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -20,7 +20,7 @@ variable "argocd_admin_password" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.13.0"
+  default     = "0.15.0"
 }
 
 variable "agent_state_chart_version" {
@@ -98,7 +98,7 @@ variable "ziti_management_chart_version" {
 variable "users_chart_version" {
   type        = string
   description = "Version of the users Helm chart published to GHCR"
-  default     = "0.2.0"
+  default     = "0.3.0"
 }
 
 variable "organizations_chart_version" {


### PR DESCRIPTION
## Summary

Bump service versions to include console-app handler support:

- **users**: `0.2.0` → `0.3.0` — adds `ListUsers` RPC (required by console-app dashboard)
- **gateway**: `0.13.0` → `0.15.0` — adds identity-aware handlers for `GetMe`, `CreateUser`, `ListMyMemberships`

### Related PRs
- agynio/users#9 — ListUsers implementation
- agynio/gateway#137 — Console-app handler logic
- agynio/console-app#11 — Blocked until these versions are deployed (removes gateway patch)