### PR TITLE
chore(platform): bump gateway to v0.16.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -20,7 +20,7 @@ variable "argocd_admin_password" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.15.0"
+  default     = "0.16.0"
 }
 
 variable "agent_state_chart_version" {


### PR DESCRIPTION
## Summary

Bump gateway version to include GetMe fix:

- **gateway**: `0.15.0` → `0.16.0` — fixes 403 "cluster admin required" on `GetMe` for new OIDC users (calls `users.GetMe` instead of admin-gated `users.GetUser`)

### Related
- agynio/gateway#139 — GetMe fix
- agynio/console-app#11 — Blocked until gateway deploys with this fix