### PR TITLE
feat(platform): provision secrets key

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -928,6 +928,21 @@ locals {
       tag        = local.resolved_secrets_image_tag
       pullPolicy = "IfNotPresent"
     }
+    configMounts = [
+      {
+        name       = "encryption-key"
+        sourceName = "secrets-encryption-key"
+        type       = "secret"
+        mountPath  = "/etc/secrets-encryption"
+        readOnly   = true
+      },
+    ]
+    env = [
+      {
+        name  = "ENCRYPTION_KEY_FILE"
+        value = "/etc/secrets-encryption/encryptionKey"
+      },
+    ]
   })
 
   agents_values = yamlencode({
@@ -1788,6 +1803,19 @@ resource "kubernetes_secret" "litellm_master_key" {
   }
 
   type = "Opaque"
+}
+
+resource "kubernetes_secret_v1" "secrets_encryption_key" {
+  metadata {
+    name      = "secrets-encryption-key"
+    namespace = kubernetes_namespace.platform.metadata[0].name
+  }
+
+  type = "Opaque"
+
+  data = {
+    encryptionKey = var.secrets_encryption_key
+  }
 }
 
 resource "kubernetes_config_map_v1" "vault_auto_init" {

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -928,21 +928,10 @@ locals {
       tag        = local.resolved_secrets_image_tag
       pullPolicy = "IfNotPresent"
     }
-    configMounts = [
-      {
-        name       = "encryption-key"
-        sourceName = "secrets-encryption-key"
-        type       = "secret"
-        mountPath  = "/etc/secrets-encryption"
-        readOnly   = true
-      },
-    ]
-    env = [
-      {
-        name  = "ENCRYPTION_KEY_FILE"
-        value = "/etc/secrets-encryption/encryptionKey"
-      },
-    ]
+    secrets = {
+      encryptionKeyFile       = "/etc/secrets-encryption/encryptionKey"
+      encryptionKeySecretName = "secrets-encryption-key"
+    }
   })
 
   agents_values = yamlencode({

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -601,6 +601,13 @@ variable "secrets_db_pvc_size" {
   default     = "5Gi"
 }
 
+variable "secrets_encryption_key" {
+  type        = string
+  description = "Symmetric encryption key for locally-stored secret values in the Secrets service"
+  default     = "dev-encryption-key-32bytes!!@#$%"
+  sensitive   = true
+}
+
 variable "authorization_chart_version" {
   type        = string
   description = "Version of the authorization Helm chart published to GHCR"


### PR DESCRIPTION
## Summary
- add the secrets encryption key variable for platform deployments
- provision a Kubernetes Secret for the encryption key
- mount the encryption key and env var into the secrets chart values

## Testing
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh
- terraform fmt -check -recursive

Closes #229