### PR TITLE
chore(terraform): bump organizations chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -105,7 +105,7 @@ variable "users_chart_version" {
 variable "organizations_chart_version" {
   type        = string
   description = "Version of the organizations Helm chart published to GHCR"
-  default     = "0.2.0"
+  default     = "0.3.0"
 }
 
 variable "identity_chart_version" {


### PR DESCRIPTION
## Summary
- bump the organizations Helm chart version default to 0.3.0

## Testing
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Refs #233