### PR TITLE
Bump users and organizations chart versions

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -99,13 +99,13 @@ variable "ziti_management_chart_version" {
 variable "users_chart_version" {
   type        = string
   description = "Version of the users Helm chart published to GHCR"
-  default     = "0.3.0"
+  default     = "0.4.0"
 }
 
 variable "organizations_chart_version" {
   type        = string
   description = "Version of the organizations Helm chart published to GHCR"
-  default     = "0.3.0"
+  default     = "0.4.0"
 }
 
 variable "identity_chart_version" {


### PR DESCRIPTION
## Summary
- bump users chart version to 0.4.0
- bump organizations chart version to 0.4.0

## Testing
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Closes #235