### PR TITLE
fix(platform): add ziti management dependency

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -4216,6 +4216,7 @@ resource "argocd_application" "agents_orchestrator" {
   depends_on = [
     argocd_repository.ghcr,
     argocd_application.agents_orchestrator_db,
+    argocd_application.ziti_management,
     argocd_application.threads,
     argocd_application.notifications,
     argocd_application.agents,

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -99,7 +99,7 @@ variable "ziti_management_chart_version" {
 variable "users_chart_version" {
   type        = string
   description = "Version of the users Helm chart published to GHCR"
-  default     = "0.4.0"
+  default     = "0.4.1"
 }
 
 variable "organizations_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -99,13 +99,13 @@ variable "ziti_management_chart_version" {
 variable "users_chart_version" {
   type        = string
   description = "Version of the users Helm chart published to GHCR"
-  default     = "0.3.0"
+  default     = "0.4.0"
 }
 
 variable "organizations_chart_version" {
   type        = string
   description = "Version of the organizations Helm chart published to GHCR"
-  default     = "0.3.0"
+  default     = "0.4.0"
 }
 
 variable "identity_chart_version" {


### PR DESCRIPTION
## Summary
- add ziti-management to agents-orchestrator dependencies

## Testing
- terraform fmt -recursive -check
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Closes #237