### PR TITLE
chore(platform): bump auth module

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1720,11 +1720,11 @@ locals {
   })
 }
 
-# NOTE: The module ref (v0.3.0) must be updated in lockstep with
+# NOTE: The module ref (v0.4.0) must be updated in lockstep with
 # var.authorization_chart_version to ensure the provisioned FGA model
 # matches the model expected by the deployed Helm chart.
 module "openfga_authorization" {
-  source          = "github.com/agynio/authorization//terraform?ref=v0.3.0"
+  source          = "github.com/agynio/authorization//terraform?ref=v0.4.0"
   openfga_api_url = local.openfga_api_url_external
 }
 


### PR DESCRIPTION
## Summary
- bump the OpenFGA authorization terraform module ref to v0.4.0
- keep the module/version note in sync with the new ref

## Testing
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Refs #239