### PR TITLE
fix(platform): bump agents charts

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.10.0"
+  default     = "0.10.1"
 }
 
 variable "threads_chart_version" {
@@ -87,7 +87,7 @@ variable "postgres_chart_version" {
 variable "agents_chart_version" {
   type        = string
   description = "Version of the agents Helm chart published to GHCR"
-  default     = "0.6.0"
+  default     = "0.6.1"
 }
 
 variable "ziti_management_chart_version" {


### PR DESCRIPTION
## Summary
- bump agents chart default to 0.6.1
- bump agents-orchestrator chart default to 0.10.1

## Testing
- terraform fmt -recursive -check
- GHCR_USERNAME=$(gh api user -q .login) GHCR_TOKEN=$(gh auth token) TF_VAR_agents_chart_version=0.6.0 ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

## Notes
- GHCR does not list agents chart 0.6.1 yet, so apply was run with TF_VAR_agents_chart_version=0.6.0.

Closes #242