### PR TITLE
feat(apps): add platform org install

### DIFF
--- a/stacks/apps/main.tf
+++ b/stacks/apps/main.tf
@@ -166,10 +166,23 @@ locals {
   })
 }
 
+resource "agyn_organization" "platform" {
+  name = "Platform"
+}
+
 resource "agyn_app" "reminders" {
-  slug        = "reminders"
-  name        = "Reminders"
-  description = "Delayed message delivery to threads"
+  organization_id = agyn_organization.platform.id
+  slug            = "reminders"
+  name            = "Reminders"
+  description     = "Delayed message delivery to threads"
+  visibility      = "internal"
+  permissions     = ["thread:write"]
+}
+
+resource "agyn_app_installation" "reminders" {
+  app_id          = agyn_app.reminders.id
+  organization_id = agyn_organization.platform.id
+  slug            = "reminders"
 }
 
 resource "kubernetes_secret_v1" "reminders_service_token" {

--- a/stacks/apps/outputs.tf
+++ b/stacks/apps/outputs.tf
@@ -1,3 +1,15 @@
+output "bootstrap_organization_id" {
+  description = "Platform organization ID"
+  value       = agyn_organization.platform.id
+}
+
+output "app_installation_ids" {
+  description = "App installation IDs keyed by slug"
+  value = {
+    reminders = agyn_app_installation.reminders.id
+  }
+}
+
 output "app_ids" {
   description = "App IDs keyed by slug"
   value = {

--- a/stacks/apps/versions.tf
+++ b/stacks/apps/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     agyn = {
       source  = "agynio/agyn"
-      version = "~> 0.4"
+      version = "~> 0.5"
     }
     argocd = {
       source  = "argoproj-labs/argocd"

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1720,11 +1720,11 @@ locals {
   })
 }
 
-# NOTE: The module ref (v0.3.0) must be updated in lockstep with
+# NOTE: The module ref (v0.4.0) must be updated in lockstep with
 # var.authorization_chart_version to ensure the provisioned FGA model
 # matches the model expected by the deployed Helm chart.
 module "openfga_authorization" {
-  source          = "github.com/agynio/authorization//terraform?ref=v0.3.0"
+  source          = "github.com/agynio/authorization//terraform?ref=v0.4.0"
   openfga_api_url = local.openfga_api_url_external
 }
 

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.10.0"
+  default     = "0.10.1"
 }
 
 variable "threads_chart_version" {
@@ -87,7 +87,7 @@ variable "postgres_chart_version" {
 variable "agents_chart_version" {
   type        = string
   description = "Version of the agents Helm chart published to GHCR"
-  default     = "0.6.0"
+  default     = "0.6.1"
 }
 
 variable "ziti_management_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -33,7 +33,7 @@ variable "ghcr_token" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.17.0"
+  default     = "0.18.0"
 }
 
 variable "agent_state_chart_version" {
@@ -123,7 +123,7 @@ variable "runners_chart_version" {
 variable "apps_chart_version" {
   type        = string
   description = "Version of the apps Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "chat_app_chart_version" {


### PR DESCRIPTION
## Summary
- bump agyn provider constraint to ~> 0.5 in stacks/apps
- add platform organization, reminders app fields, installation wiring, and outputs
- bump gateway/apps chart defaults to 0.18.0/0.2.0 for required RPCs

## Testing
- `terraform fmt -check -recursive`
- `./apply.sh -y`

Refs: #241