### PR TITLE
feat(apps): update reminders app config

### DIFF
--- a/stacks/apps/.terraform.lock.hcl
+++ b/stacks/apps/.terraform.lock.hcl
@@ -1,0 +1,58 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/agynio/agyn" {
+  version     = "0.5.0"
+  constraints = "~> 0.5"
+  hashes = [
+    "h1:I0s+k5xer/nhWMLt9cO+qMArKyNcf91XsOo6z2LUq0o=",
+    "zh:04591039e7c447c22c1f56fe2dd4f467951def9546ac9d9ab03d51295578312c",
+    "zh:3ebd5b3ab9f1ae520e6fbe30cf4212039ef0b12399e34ce09bf7058f243a3be2",
+    "zh:8a7ccc6d08e66a9f03c325c4c7afd98ab04776efa63f2d796101222c8f993169",
+    "zh:8bedfbe6a6f471a7505668b54c9badafcc0caf4953b526ad33d59f884d47c439",
+    "zh:ca41c14813d53bfd14444ab8ff4de4454b33f28596896568f7bbc508d1988a1f",
+    "zh:d39431c1fc6a199886f574bccee48a492856b476b8652d2f10949553bdb5d89f",
+    "zh:e40e6d2cca38881bcb01fbf2446dfe92a557b35f523ed2b772f42180c257740e",
+    "zh:e6cdeddac91699e5d0c44d5806d98aab2b1a24ff8027c047120c5349a98df4d3",
+    "zh:ea2dc0daac0c9843b7dc38ce3cdaf4452fcee45909ca34713446abed29a6bb34",
+    "zh:f907148237de29eebf59b32eee4edfc95e986df8ec4c6e734a554811c18b06a6",
+  ]
+}
+
+provider "registry.terraform.io/argoproj-labs/argocd" {
+  version     = "7.15.3"
+  constraints = "~> 7.14"
+  hashes = [
+    "h1:ZCIcaDzTy2WN2iaaMA9puR1khbGetdesJDYNEgshfZE=",
+    "zh:1a754d97259b9d2e9e624703eec655278bff20ca829b9d48ee9aae9591af2681",
+    "zh:3728ed3654f426d745d624d6895631651ebd8e84d594fe475849f2ad02c5c027",
+    "zh:4261e504831d8744de39e583a3b6931ced1ca6b67b2363448243197548cb6fd1",
+    "zh:57693d73351452ab6171d7cd929f41c666e7d6720ec57d2c5a9eb9081e6ba8d4",
+    "zh:67e23102766d21548b80ed484ac2173ce0ed94db89f3aa0fa7f1cde80f0179d5",
+    "zh:b2f7408bf945d8ad18b65574d036db4e742d600adc4270c6876fe19a5b62b464",
+    "zh:be4cdc723e4782655f79d125b7c67d84798c0ab450e37c4a8ca809027c92ccac",
+    "zh:c6c102f04d1873c1182502c10120411c344a1ee9af93b1d8086e7e28696c0689",
+    "zh:c8797aef8ed8d548a17cda9ddfc321231c73654d37b43c7e3e5d3e096544fa7d",
+    "zh:cc64b231c45c638448b9e1b8a8dd67b8430d2c5f1401123cc114676efca5e9e4",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.33"
+  hashes = [
+    "h1:5CkveFo5ynsLdzKk+Kv+r7+U9rMrNjfZPT3a0N/fhgE=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
+  ]
+}

--- a/stacks/apps/main.tf
+++ b/stacks/apps/main.tf
@@ -166,10 +166,17 @@ locals {
   })
 }
 
+resource "agyn_organization" "platform" {
+  name = "Platform"
+}
+
 resource "agyn_app" "reminders" {
-  slug        = "reminders"
-  name        = "Reminders"
-  description = "Delayed message delivery to threads"
+  organization_id = agyn_organization.platform.id
+  slug            = "reminders"
+  name            = "Reminders"
+  description     = "Delayed message delivery to threads"
+  permissions     = ["thread:write"]
+  visibility      = "internal"
 }
 
 resource "kubernetes_secret_v1" "reminders_service_token" {

--- a/stacks/apps/versions.tf
+++ b/stacks/apps/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     agyn = {
       source  = "agynio/agyn"
-      version = "~> 0.4"
+      version = "~> 0.5"
     }
     argocd = {
       source  = "argoproj-labs/argocd"

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -123,7 +123,7 @@ variable "runners_chart_version" {
 variable "apps_chart_version" {
   type        = string
   description = "Version of the apps Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "chat_app_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -33,7 +33,7 @@ variable "ghcr_token" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.17.0"
+  default     = "0.18.0"
 }
 
 variable "agent_state_chart_version" {


### PR DESCRIPTION
## Summary
- bump agyn provider constraint to ~> 0.5 for the apps stack
- add the Platform organization and associate the reminders app with internal visibility
- set reminders app permissions and refresh the apps stack lockfile

## Testing
- TF_VAR_gateway_image_tag=local-dev TF_VAR_apps_image_tag=local-dev ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Fixes #245