### PR TITLE
Bump secrets chart version to 0.2.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -599,7 +599,7 @@ variable "registry_mirror_pvc_size" {
 variable "secrets_chart_version" {
   type        = string
   description = "Version of the secrets Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "secrets_image_tag" {


### PR DESCRIPTION
## Summary
- bump secrets chart default to 0.2.0 in the platform stack

## Testing
- terraform fmt -check -recursive
- terraform -chdir=stacks/k8s apply -input=false -auto-approve -var 'domain=agyn.dev' -var 'port=2496'
- terraform -chdir=stacks/system apply -input=false -auto-approve
- terraform -chdir=stacks/routing apply -input=false -auto-approve
- terraform -chdir=stacks/deps apply -input=false -auto-approve
- terraform -chdir=stacks/ziti apply -input=false -auto-approve -var 'ziti_admin_password=qfmNM1DAQ3i4fcA4OIVQ2XXGpIM60Wmt'
- terraform -chdir=stacks/data apply -input=false -auto-approve
- terraform -chdir=stacks/platform apply -input=false -auto-approve -var 'oidc_issuer_url=https://mockauth.dev/r/301ebb13-15a8-48f4-baac-e3fa25be29fc/oidc' -var 'oidc_client_id=client_MU95KU3gHQf5Ir7p' -var 'oidc_client_secret=XPKka2i9uzISrKZ95zxli8sY51BK4eTJ' -var 'ghcr_username=' -var 'ghcr_token='
- terraform -chdir=stacks/apps apply -input=false -auto-approve
- ./.github/scripts/verify_platform_health.sh

Ref #247