### PR TITLE
chore: bump k8s-runner to 0.8.0

### DIFF
--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -50,7 +50,7 @@ variable "reminders_image_tag" {
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.7.0"
+  default     = "0.8.0"
 }
 
 variable "k8s_runner_image_tag" {


### PR DESCRIPTION
## Summary

Bumps k8s-runner chart/image version from `0.7.0` to `0.8.0`.

`v0.8.0` adds **image pull credential support** — K8s Secret creation, Pod `imagePullSecrets`, and cleanup. This is required for the Private Registry Support feature (agents-orchestrator PR #105 e2e test).

## Changes

- `stacks/apps/variables.tf`: `k8s_runner_chart_version` default `0.7.0` → `0.8.0`