### PR TITLE
chore(platform): bump console app chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -141,7 +141,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump console-app Helm chart version to 0.2.0 in stacks/platform/variables.tf

## Testing
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh
- terraform fmt -check -recursive

Refs #250