### PR TITLE
chore: bump ziti-management, runners, apps for re-enrollment changes

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -93,7 +93,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.7.0"
+  default     = "0.8.0"
 }
 
 variable "users_chart_version" {
@@ -117,13 +117,13 @@ variable "identity_chart_version" {
 variable "runners_chart_version" {
   type        = string
   description = "Version of the runners Helm chart published to GHCR"
-  default     = "0.3.0"
+  default     = "0.4.0"
 }
 
 variable "apps_chart_version" {
   type        = string
   description = "Version of the apps Helm chart published to GHCR"
-  default     = "0.2.0"
+  default     = "0.3.0"
 }
 
 variable "chat_app_chart_version" {


### PR DESCRIPTION
## Version Bumps

| Service | Previous | New | Release |
|---------|----------|-----|---------|
| ziti-management | 0.7.0 | 0.8.0 | [v0.8.0](https://github.com/agynio/ziti-management/releases/tag/v0.8.0) |
| runners | 0.3.0 | 0.4.0 | [v0.4.0](https://github.com/agynio/runners/releases/tag/v0.4.0) |
| apps | 0.2.0 | 0.3.0 | [v0.3.0](https://github.com/agynio/apps/releases/tag/v0.3.0) |

## Deployment Order
**ziti-management → runners → apps**

Runners and apps depend on the new `CreateService` RPC in ziti-management, so it must be deployed first.

## Context
These releases implement the runner/app re-enrollment changes from the architecture change doc `2026-04-06-runner-app-re-enrollment.md`:
- Idempotent `CreateRunnerIdentity`/`CreateAppIdentity` (clean up previous identity)
- OpenZiti service creation moved from enrollment to registration
- Missing RPCs added (`CreateService`, updated `Delete*Identity`)
- Cleanup on deletion