### PR TITLE
chore: bump k8s-runner to 0.8.1

### DIFF
--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -50,7 +50,7 @@ variable "reminders_image_tag" {
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.8.0"
+  default     = "0.8.1"
 }
 
 variable "k8s_runner_image_tag" {


### PR DESCRIPTION
## Summary

Bumps k8s-runner from `0.8.0` to `0.8.1`.

`v0.8.1` adds missing RBAC rule for `secrets` (`create`, `delete`) required by the image pull credential feature introduced in `v0.8.0`. Without this, the runner gets `Forbidden` when creating docker config secrets for image pull credentials.

## Changes

- `stacks/apps/variables.tf`: `k8s_runner_chart_version` default `0.8.0` → `0.8.1`