### PR TITLE
chore: bump k8s-runner to 0.9.0

### DIFF
--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -50,7 +50,7 @@ variable "reminders_image_tag" {
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.8.1"
+  default     = "0.9.0"
 }
 
 variable "k8s_runner_image_tag" {


### PR DESCRIPTION
## Summary

Bumps k8s-runner from `0.8.1` to `0.9.0`.

`v0.9.0` includes improved error logging in `grpcErrorFromKube` — Kubernetes API error details are now included in gRPC responses instead of generic messages like `"permission denied"`. This makes diagnosing RBAC, not-found, and conflict errors significantly easier from the caller side (e.g., orchestrator logs).

## Changes

- `stacks/apps/variables.tf`: `k8s_runner_chart_version` default `0.8.1` → `0.9.0`