### PR TITLE
chore: bump console-app to v0.3.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -141,7 +141,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.2.0"
+  default     = "0.3.0"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
Bumps `console_app_chart_version` from `0.2.0` → `0.3.0`.

## Console-app v0.3.0 Changelog

- **Pending Invites & Published Apps** (#23)
- **UI Migration** to shadcn/ui with dark/light/system theme (#25)
- **Profile Editing, Image Pull Secrets, Sorting & Search, Context Switcher Refactor** (#27)

Release: https://github.com/agynio/console-app/releases/tag/v0.3.0