### PR TITLE
Remove dead orchestrator env vars

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1133,14 +1133,6 @@ locals {
         value = format("postgresql://orchestrator:%s@agents-orchestrator-db:5432/orchestrator?sslmode=disable", var.agents_orchestrator_db_password)
       },
       {
-        name  = "DEFAULT_AGENT_IMAGE"
-        value = "alpine:3.21"
-      },
-      {
-        name  = "DEFAULT_INIT_IMAGE"
-        value = "ghcr.io/agynio/agent-init-codex:0.6.0"
-      },
-      {
         name  = "POLL_INTERVAL"
         value = "5s"
       },

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.10.1"
+  default     = "0.11.0"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
## Summary
- remove unused DEFAULT_AGENT_IMAGE/DEFAULT_INIT_IMAGE entries from the agents-orchestrator Helm values

## Testing
- terraform fmt -check -recursive
- TF_VAR_agents_orchestrator_image_tag=local-dev ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Refs #256