### PR TITLE
chore: bump chat-app to v0.3.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -129,7 +129,7 @@ variable "apps_chart_version" {
 variable "chat_app_chart_version" {
   type        = string
   description = "Version of the chat-app Helm chart published to GHCR"
-  default     = "0.2.0"
+  default     = "0.3.0"
 }
 
 variable "chat_app_image_tag" {


### PR DESCRIPTION
## Summary

Bumps `chat_app_chart_version` from `0.2.0` → `0.3.0` to pick up the latest [chat-app v0.3.0 release](https://github.com/agynio/chat-app/releases/tag/v0.3.0).

### Notable changes in chat-app v0.3.0

- **Fixed file uploads** — replaced broken REST multipart endpoint with raw Connect protocol envelope-based upload
- Real upload progress reporting via XHR
- Added e2e test for file upload with Argos screenshots
- Added `data-status` attribute to attachment chips for testability
- Removed unused ConnectRPC dependencies