### PR TITLE
chore: bump console_app_chart_version 0.3.0 → 0.4.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -141,7 +141,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.3.0"
+  default     = "0.4.0"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
Bumps `console_app_chart_version` from `0.3.0` to `0.4.0`.

## console-app v0.4.0 includes:
- Real-time updates, cursor-based pagination, overview counter links
- Workload monitoring (active workloads page, runner detail, overview counter)
- Spec alignment: removed Chat/Tracing buttons, tab bars replaced with sidebar nav + stacked sections

Release: https://github.com/agynio/console-app/releases/tag/v0.4.0