### PR TITLE
chore: bump llm-proxy to v0.8.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -649,11 +649,11 @@ variable "openfga_namespace" {
 variable "llm_proxy_chart_version" {
   type        = string
   description = "Version of the llm-proxy Helm chart published to GHCR"
-  default     = "0.7.0"
+  default     = "0.8.0"
 }
 
 variable "llm_proxy_image_tag" {
   type        = string
   description = "Optional override for the llm-proxy image tag"
-  default     = "0.4.0"
+  default     = "0.8.0"
 }


### PR DESCRIPTION
Bumps `llm-proxy` chart and image to v0.8.0.

## Changes in v0.8.0
- Add request/response logging to proxy handler (agynio/llm-proxy#28)
- Fix proto drift: `IDENTITY_TYPE_CHANNEL` → `IDENTITY_TYPE_APP`

Release: https://github.com/agynio/llm-proxy/releases/tag/v0.8.0