### PR TITLE
chore(platform): bump files chart version

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -439,7 +439,7 @@ variable "tracing_db_pvc_size" {
 variable "files_chart_version" {
   type        = string
   description = "Version of the files Helm chart published to GHCR"
-  default     = "0.1.2"
+  default     = "0.1.3"
 }
 
 variable "files_image_tag" {


### PR DESCRIPTION
## Summary
- bump files chart default to 0.1.3

## Testing
- terraform fmt -check -recursive
- terraform -chdir=stacks/k8s apply -input=false -auto-approve -var 'domain=agyn.dev' -var 'port=2496'
- terraform -chdir=stacks/system apply -input=false -auto-approve
- ./install-ca-cert.sh -y ./local-certs/ca-agyn-dev.pem
- terraform -chdir=stacks/routing apply -input=false -auto-approve
- terraform -chdir=stacks/deps apply -input=false -auto-approve
- terraform -chdir=stacks/ziti apply -input=false -auto-approve -var "ziti_admin_password=$ZITI_ADMIN_PASSWORD" (using ziti admin secret from cluster)
- terraform -chdir=stacks/data apply -input=false -auto-approve
- terraform -chdir=stacks/platform apply -input=false -auto-approve (fails: GHCR files chart 0.1.3 not found)
- terraform -chdir=stacks/apps apply -input=false -auto-approve
- ./.github/scripts/verify_platform_health.sh

Refs #263