### PR TITLE
chore(platform): bump console-app chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -141,7 +141,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.4.0"
+  default     = "0.5.0"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump console-app chart default to 0.5.0 in platform variables

## Testing
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh
- terraform -chdir=/workspace/bootstrap fmt -check -recursive

Closes #267