### PR TITLE
chore(platform): bump llm-proxy defaults

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -661,11 +661,11 @@ variable "media_proxy_image_tag" {
 variable "llm_proxy_chart_version" {
   type        = string
   description = "Version of the llm-proxy Helm chart published to GHCR"
-  default     = "0.9.0"
+  default     = "0.9.1"
 }
 
 variable "llm_proxy_image_tag" {
   type        = string
   description = "Optional override for the llm-proxy image tag"
-  default     = ""
+  default     = "0.9.1"
 }

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -667,5 +667,5 @@ variable "llm_proxy_chart_version" {
 variable "llm_proxy_image_tag" {
   type        = string
   description = "Optional override for the llm-proxy image tag"
-  default     = "0.9.1"
+  default     = ""
 }


### PR DESCRIPTION
## Summary
- bump llm-proxy chart and image defaults to 0.9.1

## Testing
- terraform fmt -check -recursive
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Refs #269