### PR TITLE
chore(platform): bump files chart version to 0.1.4

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -439,7 +439,7 @@ variable "tracing_db_pvc_size" {
 variable "files_chart_version" {
   type        = string
   description = "Version of the files Helm chart published to GHCR"
-  default     = "0.1.3"
+  default     = "0.1.4"
 }
 
 variable "files_image_tag" {


### PR DESCRIPTION
Bumps the files service Helm chart from `0.1.3` to `0.1.4`.

## What's in v0.1.4
- **Fix**: Dockerfile now copies `buf.lock`, preventing BuildKit from serving stale proto stubs (fixes `GetFileContent` UNIMPLEMENTED error)
- **Fix**: e2e infrastructure aligned with chat repo pattern

Ref: agynio/files#31, agynio/files#32