### PR TITLE
chore: bump chat-app to v0.4.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -129,7 +129,7 @@ variable "apps_chart_version" {
 variable "chat_app_chart_version" {
   type        = string
   description = "Version of the chat-app Helm chart published to GHCR"
-  default     = "0.3.0"
+  default     = "0.4.0"
 }
 
 variable "chat_app_image_tag" {


### PR DESCRIPTION
Bumps `chat_app_chart_version` from `0.3.0` to `0.4.0`.

## Changes in chat-app v0.4.0

- Inline media rendering (images, video, audio) in chat messages via markdown
- Service Worker for media proxy auth injection
- `agyn://` protocol URL support through custom `urlTransform`
- Dynamic media proxy URL derivation (`MEDIA_PROXY_URL=auto`)
- Sanitize schema updates for media tags
- E2E tests for inline media rendering

Relates to agynio/chat-app#56, agynio/chat-app#57.