### PR TITLE
fix: bump media-proxy to v0.1.3 + fix usersGrpcTarget

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -649,7 +649,7 @@ variable "openfga_namespace" {
 variable "media_proxy_chart_version" {
   type        = string
   description = "Version of the media-proxy Helm chart published to GHCR"
-  default     = "0.1.2"
+  default     = "0.1.3"
 }
 
 variable "media_proxy_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -649,7 +649,7 @@ variable "openfga_namespace" {
 variable "media_proxy_chart_version" {
   type        = string
   description = "Version of the media-proxy Helm chart published to GHCR"
-  default     = "0.1.1"
+  default     = "0.1.2"
 }
 
 variable "media_proxy_image_tag" {


### PR DESCRIPTION
## Changes

1. **Bumps `media_proxy_chart_version`** from `0.1.1` to `0.1.3`
   - v0.1.2: Adds `AllowCredentials: true` to CORS config
   - v0.1.3: Fixes Helm chart lint failure (split templates)

2. **Fixes `usersGrpcTarget`** from `"users-users:50051"` → `"users:50051"`
   - Root cause of **502 Bad Gateway** on all media-proxy requests
   - The users K8s service is named `users` (via `fullnameOverride`), not `users-users`
   - DNS resolution failed → gRPC transport error → 502
   - Gateway already uses the correct `"users:50051"` for the same service

Fixes agynio/media-proxy#5, agynio/media-proxy#8.