### PR TITLE
fix: correct media-proxy usersGrpcTarget + bump to v0.1.4

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1354,7 +1354,7 @@ locals {
       listenAddr        = ":8080"
       oidcIssuerUrl     = var.oidc_issuer_url
       oidcClientId      = var.oidc_client_id
-      usersGrpcTarget   = "users-users:50051"
+      usersGrpcTarget   = "users:50051"
       filesGrpcTarget   = "files:50051"
       authzGrpcTarget   = "authorization:50051"
       corsAllowedOrigin = format("https://chat.%s:%d", local.base_domain, local.ingress_port)


### PR DESCRIPTION
## Changes

1. **Fix `usersGrpcTarget`**: `"users-users:50051"` → `"users:50051"` — root cause of 502 Bad Gateway on all media-proxy requests.
2. **Bump `media_proxy_chart_version`**: `0.1.3` → `0.1.4` — includes e2e test suite + CORS credentials fix + Helm chart template fix.