### PR TITLE
chore: bump media-proxy to v0.1.4

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -649,7 +649,7 @@ variable "openfga_namespace" {
 variable "media_proxy_chart_version" {
   type        = string
   description = "Version of the media-proxy Helm chart published to GHCR"
-  default     = "0.1.3"
+  default     = "0.1.4"
 }
 
 variable "media_proxy_image_tag" {


### PR DESCRIPTION
Bumps `media_proxy_chart_version` from `0.1.3` to `0.1.4`.

v0.1.4 includes the e2e test suite for the media proxy service.