### PR TITLE
fix: add fullnameOverride to authorization service

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1162,6 +1162,7 @@ locals {
   })
 
   authorization_values = yamlencode({
+    fullnameOverride = "authorization"
     image = {
       repository = "ghcr.io/agynio/authorization"
       tag        = local.resolved_authorization_image_tag


### PR DESCRIPTION
## Problem

The `authorization_values` block in `stacks/platform/main.tf` is missing `fullnameOverride`, unlike every other platform service. Without it, the Kubernetes service name defaults to `authorization-authorization` (`<release>-<chart>`) instead of `authorization`.

This causes 502 Bad Gateway for any service targeting `authorization:50051` — specifically media-proxy's `authzGrpcTarget`, which fails on all `agyn://file/...` proxy requests because the authorization gRPC call can't connect.

Same class of bug as the `users-users:50051` issue fixed in PR #274.

## Fix

Add `fullnameOverride = "authorization"` to `authorization_values`, matching the convention used by all other services (files, users, media-proxy, etc.).