### PR TITLE
chore(platform): bump chat-app chart version

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -129,7 +129,7 @@ variable "apps_chart_version" {
 variable "chat_app_chart_version" {
   type        = string
   description = "Version of the chat-app Helm chart published to GHCR"
-  default     = "0.4.0"
+  default     = "0.4.1"
 }
 
 variable "chat_app_image_tag" {


### PR DESCRIPTION
Bump chat-app chart version to 0.4.1.

Fixes #277