### PR TITLE
chore(platform): bump tracing chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -57,7 +57,7 @@ variable "threads_chart_version" {
 variable "tracing_chart_version" {
   type        = string
   description = "Version of the tracing Helm chart published to GHCR"
-  default     = "0.2.0"
+  default     = "0.2.1"
 }
 
 variable "token_counting_chart_version" {


### PR DESCRIPTION
## Summary
- bump tracing Helm chart default to 0.2.1 for bootstrap platform stack

## Testing
- ./apply.sh -y (fails: tracing chart 0.2.1 not found in GHCR)
- TF_VAR_tracing_chart_version=0.2.0 ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Closes #279