### PR TITLE
chore: bump media-proxy to v0.1.5

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1357,7 +1357,6 @@ locals {
       oidcClientId      = var.oidc_client_id
       usersGrpcTarget   = "users:50051"
       filesGrpcTarget   = "files:50051"
-      authzGrpcTarget   = "authorization:50051"
       corsAllowedOrigin = format("https://chat.%s:%d", local.base_domain, local.ingress_port)
     }
   })

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -649,7 +649,7 @@ variable "openfga_namespace" {
 variable "media_proxy_chart_version" {
   type        = string
   description = "Version of the media-proxy Helm chart published to GHCR"
-  default     = "0.1.4"
+  default     = "0.1.5"
 }
 
 variable "media_proxy_image_tag" {


### PR DESCRIPTION
Bumps `media_proxy_chart_version` from `0.1.4` to `0.1.5` and removes `authzGrpcTarget` from media-proxy values (no longer used).

**media-proxy v0.1.5 changes:**
- Removed file authorization check (OpenFGA `file` type to be added later)
- Removed `AUTHZ_GRPC_TARGET` from config, Helm chart, and templates
- Mapped gRPC `PermissionDenied` → 403 and `Unauthenticated` → 401 in file proxy
- Wired e2e tests into CI pipeline