### PR TITLE
Add agents host exposed policy

### DIFF
--- a/stacks/ziti/main.tf
+++ b/stacks/ziti/main.tf
@@ -223,6 +223,13 @@ resource "ziti_service_policy" "gateway_dial_apps" {
   serviceroles  = ["#app-services"]
 }
 
+resource "ziti_service_policy" "agents_host_exposed" {
+  name          = "agents-host-exposed"
+  type          = "Bind"
+  identityroles = ["#agents"]
+  serviceroles  = ["#exposed-services"]
+}
+
 resource "ziti_edge_router_policy" "all_identities_all_routers" {
   name            = "all-identities-all-routers"
   identityroles   = ["#all"]


### PR DESCRIPTION
## Summary
- add agents-host-exposed ziti service policy for exposed services

## Testing
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Refs #284