### PR TITLE
chore: bump gateway chart to 0.20.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -33,7 +33,7 @@ variable "ghcr_token" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.19.0"
+  default     = "0.20.0"
 }
 
 variable "agent_state_chart_version" {


### PR DESCRIPTION
Bumps the gateway Helm chart from `0.19.0` to `0.20.0`.

**Gateway v0.20.0** includes:
- `ExposeGateway` with `ListExposures` and `RemoveExposure` RPCs
- `UsersGateway` extensions: `CreateDevice`, `ListDevices`, `DeleteDevice`
- `UpdateChat` handler

This is required for the Port Exposure e2e tests to pass (devices API endpoints need to be deployed).

Refs: https://github.com/agynio/gateway/releases/tag/v0.20.0