### PR TITLE
Bump gateway/chat charts

### DIFF
--- a/.github/scripts/verify_platform_health.sh
+++ b/.github/scripts/verify_platform_health.sh
@@ -24,7 +24,7 @@ if [[ ! -f "$KUBECONFIG_PATH" ]]; then
   exit 1
 fi
 
-REQUIRED_APPS_JSON='["cert-manager","trust-manager","ziti-controller","ziti-management","vault","registry-mirror","minio","platform-db","litellm-db","agent-state-db","threads-db","identity-db","runners-db","litellm","agent-state","identity","authorization","gateway","runners","notifications-redis","notifications","threads","chat","k8s-runner"]'
+REQUIRED_APPS_JSON='["cert-manager","trust-manager","ziti-controller","ziti-management","vault","registry-mirror","minio","platform-db","litellm-db","agent-state-db","threads-db","chat-db","identity-db","runners-db","litellm","agent-state","identity","authorization","gateway","runners","notifications-redis","notifications","threads","chat","k8s-runner"]'
 
 deadline=$((SECONDS + TOTAL_TIMEOUT))
 pod_terminal_failures_streak=0

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -568,6 +568,29 @@ locals {
     }
   })
 
+  chat_db_values = yamlencode({
+    fullnameOverride = "chat-db"
+    postgres = {
+      database = "chat"
+      username = "chat"
+      password = var.chat_db_password
+      pgdata   = "/var/lib/postgresql/data/pgdata"
+    }
+    persistence = {
+      size                    = var.chat_db_pvc_size
+      mountPath               = "/var/lib/postgresql/data"
+      volumeClaimTemplateName = "data"
+    }
+    probes = {
+      readiness = {
+        execCommand = ["pg_isready", "-U", "chat", "-d", "chat"]
+      }
+      liveness = {
+        execCommand = ["pg_isready", "-U", "chat", "-d", "chat"]
+      }
+    }
+  })
+
   tracing_db_values = yamlencode({
     fullnameOverride = "tracing-db"
     postgres = {
@@ -938,6 +961,12 @@ locals {
       tag        = local.resolved_chat_image_tag
       pullPolicy = "IfNotPresent"
     }
+    env = [
+      {
+        name  = "DATABASE_URL"
+        value = format("postgresql://chat:%s@chat-db:5432/chat?sslmode=disable", var.chat_db_password)
+      },
+    ]
   })
 
   secrets_values = yamlencode({
@@ -2721,6 +2750,56 @@ resource "argocd_application" "threads_db" {
   }
 }
 
+resource "argocd_application" "chat_db" {
+  depends_on = [argocd_repository.ghcr]
+  wait       = true
+
+  metadata {
+    name      = "chat-db"
+    namespace = "argocd"
+    annotations = {
+      "argocd.argoproj.io/sync-wave" = "7"
+    }
+  }
+
+  spec {
+    project = "default"
+
+    source {
+      repo_url        = local.postgres_chart_repo_host
+      chart           = local.postgres_chart_name
+      target_revision = var.postgres_chart_version
+
+      helm {
+        values = local.chat_db_values
+      }
+    }
+
+    destination {
+      server    = var.destination_server
+      namespace = var.platform_namespace
+    }
+
+    sync_policy {
+      # DB apps always use automated sync with prune disabled for stateful safety,
+      # independent of var.argocd_automated_sync_enabled.
+      automated {
+        prune       = false
+        self_heal   = true
+        allow_empty = false
+      }
+
+      sync_options = local.postgres_sync_options
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
 resource "argocd_application" "tracing_db" {
   depends_on = [argocd_repository.ghcr]
   wait       = true
@@ -3597,6 +3676,7 @@ resource "argocd_application" "tracing" {
 resource "argocd_application" "chat" {
   depends_on = [
     argocd_repository.ghcr,
+    argocd_application.chat_db,
     argocd_application.threads,
   ]
   metadata {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -33,7 +33,7 @@ variable "ghcr_token" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.19.0"
+  default     = "0.20.0"
 }
 
 variable "agent_state_chart_version" {
@@ -226,7 +226,7 @@ variable "tracing_image_tag" {
 variable "chat_chart_version" {
   type        = string
   description = "Version of the chat Helm chart published to GHCR"
-  default     = "0.2.2"
+  default     = "0.3.0"
 }
 
 variable "chat_image_tag" {
@@ -387,6 +387,13 @@ variable "threads_db_password" {
   sensitive   = true
 }
 
+variable "chat_db_password" {
+  type        = string
+  description = "Password for the chat PostgreSQL database user"
+  default     = "chat"
+  sensitive   = true
+}
+
 variable "tracing_db_password" {
   type        = string
   description = "Password for the tracing PostgreSQL database user"
@@ -427,6 +434,12 @@ variable "apps_db_pvc_size" {
 variable "threads_db_pvc_size" {
   type        = string
   description = "Persistent volume claim size for the threads PostgreSQL primary"
+  default     = "5Gi"
+}
+
+variable "chat_db_pvc_size" {
+  type        = string
+  description = "Persistent volume claim size for the chat PostgreSQL primary"
   default     = "5Gi"
 }
 


### PR DESCRIPTION
## Summary
- bump gateway and chat chart defaults
- add chat-db postgres values and wiring for chat 0.3.0
- include chat-db in platform health verification

## Testing
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh
- terraform fmt -check -recursive

Refs #287