### PR TITLE
chore: bump users chart to 0.5.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -129,7 +129,7 @@ variable "apps_chart_version" {
 variable "chat_app_chart_version" {
   type        = string
   description = "Version of the chat-app Helm chart published to GHCR"
-  default     = "0.5.0"
+  default     = "0.4.1"
 }
 
 variable "chat_app_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -99,7 +99,7 @@ variable "ziti_management_chart_version" {
 variable "users_chart_version" {
   type        = string
   description = "Version of the users Helm chart published to GHCR"
-  default     = "0.4.1"
+  default     = "0.5.0"
 }
 
 variable "organizations_chart_version" {
@@ -129,7 +129,7 @@ variable "apps_chart_version" {
 variable "chat_app_chart_version" {
   type        = string
   description = "Version of the chat-app Helm chart published to GHCR"
-  default     = "0.4.1"
+  default     = "0.5.0"
 }
 
 variable "chat_app_image_tag" {


### PR DESCRIPTION
Bumps the users Helm chart from `0.4.1` to `0.5.0`.

**Users v0.5.0** includes:
- `CreateDevice`, `ListDevices`, `DeleteDevice` RPCs with `user_devices` table migration (Port Exposure)
- Admin user RPCs, token management, and various fixes

Required for the console e2e device tests — the Users service backend needs to support the device management RPCs.

Refs: https://github.com/agynio/users/releases/tag/v0.5.0