### PR TITLE
chore: bump llm to v0.4.0 and llm-proxy to v0.10.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -464,7 +464,7 @@ variable "files_db_pvc_size" {
 variable "llm_chart_version" {
   type        = string
   description = "Version of the llm Helm chart published to GHCR"
-  default     = "0.3.0"
+  default     = "0.4.0"
 }
 
 variable "llm_image_tag" {
@@ -661,7 +661,7 @@ variable "media_proxy_image_tag" {
 variable "llm_proxy_chart_version" {
   type        = string
   description = "Version of the llm-proxy Helm chart published to GHCR"
-  default     = "0.9.1"
+  default     = "0.10.0"
 }
 
 variable "llm_proxy_image_tag" {


### PR DESCRIPTION
## Summary

Bump platform chart versions for Claude Code agent support:

| Service | Old Version | New Version | Change |
|---------|-------------|-------------|--------|
| `llm` | `0.3.0` | `0.4.0` | Protocol support (`PROTOCOL_ANTHROPIC_MESSAGES`), `AUTH_METHOD_X_API_KEY` |
| `llm-proxy` | `0.9.1` | `0.10.0` | `POST /v1/messages` endpoint, protocol validation, auth method dispatch |

## Related PRs

- agynio/llm#40 (merged)
- agynio/llm-proxy#35 (merged)

## Releases

- [agynio/llm v0.4.0](https://github.com/agynio/llm/releases/tag/v0.4.0)
- [agynio/llm-proxy v0.10.0](https://github.com/agynio/llm-proxy/releases/tag/v0.10.0)