### PR TITLE
chore: bump ziti-management chart to 0.10.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -93,7 +93,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.9.0"
+  default     = "0.10.0"
 }
 
 variable "users_chart_version" {


### PR DESCRIPTION
Bumps ziti-management Helm chart from `0.9.0` to `0.10.0`.

**ziti-management v0.10.0** includes:
- `CreateDeviceIdentity`, `DeleteIdentity`, `CreateService`, `DeleteService`, `CreateServicePolicy` RPCs (Port Exposure)

Required for device creation — the Users service calls `CreateDeviceIdentity` on ziti-management when creating a device.

Refs: https://github.com/agynio/ziti-management/releases/tag/v0.10.0