### PR TITLE
chore: bump console-app chart to 0.6.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -147,7 +147,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.5.0"
+  default     = "0.6.0"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
Bumps console-app Helm chart from `0.5.0` to `0.6.0`.

**console-app v0.6.0** includes:
- Device management page (create/delete devices, JWT enrollment)
- OIDC sign-out flow
- E2e tests for devices page
- Query key disambiguation fix

Refs: https://github.com/agynio/console-app/releases/tag/v0.6.0