### PR TITLE
chore(platform): bump chat-app to 0.4.2

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -135,7 +135,7 @@ variable "apps_chart_version" {
 variable "chat_app_chart_version" {
   type        = string
   description = "Version of the chat-app Helm chart published to GHCR"
-  default     = "0.4.1"
+  default     = "0.4.2"
 }
 
 variable "chat_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump chat-app chart default to 0.4.2

## Testing
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh
- terraform fmt -check -recursive

Closes #295