### PR TITLE
chore(platform): bump chart versions

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -93,7 +93,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.10.1"
+  default     = "0.10.2"
 }
 
 variable "users_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -93,13 +93,13 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.10.0"
+  default     = "0.10.1"
 }
 
 variable "users_chart_version" {
   type        = string
   description = "Version of the users Helm chart published to GHCR"
-  default     = "0.5.0"
+  default     = "0.5.1"
 }
 
 variable "expose_chart_version" {


### PR DESCRIPTION
## Summary
- bump users and ziti-management chart versions in stacks/platform/variables.tf

## Testing
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Closes #297