### PR TITLE
chore(platform): bump ziti chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -93,7 +93,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.10.2"
+  default     = "0.10.3"
 }
 
 variable "users_chart_version" {


### PR DESCRIPTION
## Summary
- bump ziti-management chart version to 0.10.3

## Testing
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh
- terraform fmt -check -recursive

Closes #297