### PR TITLE
Bump llm proxy chart version

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -699,7 +699,7 @@ variable "media_proxy_image_tag" {
 variable "llm_proxy_chart_version" {
   type        = string
   description = "Version of the llm-proxy Helm chart published to GHCR"
-  default     = "0.10.0"
+  default     = "0.10.1"
 }
 
 variable "llm_proxy_image_tag" {


### PR DESCRIPTION
## Summary
- bump llm-proxy chart default to 0.10.1

## Testing
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh
- terraform fmt -check -recursive

#300