### PR TITLE
bump chat-app to v0.4.3

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -135,7 +135,7 @@ variable "apps_chart_version" {
 variable "chat_app_chart_version" {
   type        = string
   description = "Version of the chat-app Helm chart published to GHCR"
-  default     = "0.4.2"
+  default     = "0.4.3"
 }
 
 variable "chat_app_image_tag" {


### PR DESCRIPTION
Bumps `chat_app_chart_version` from `0.4.2` to `0.4.3`.

## Changes in [chat-app v0.4.3](https://github.com/agynio/chat-app/releases/tag/v0.4.3)
- fix(auth): support oidc logout (#65) — adds `end_session_endpoint` to OIDC metadata, e2e sign-out test, and post-logout Argos screenshot