### PR TITLE
chore(platform): bump chart versions

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.12.0"
+  default     = "0.12.1"
 }
 
 variable "threads_chart_version" {
@@ -184,7 +184,7 @@ variable "oidc_client_secret" {
 variable "tracing_app_chart_version" {
   type        = string
   description = "Version of the tracing-app Helm chart published to GHCR"
-  default     = "0.2.0"
+  default     = "0.2.1"
 }
 
 variable "tracing_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump agents-orchestrator chart default to 0.12.1
- bump tracing-app chart default to 0.2.1
- verified GHCR chart tags exist for agents-orchestrator:0.12.1 and tracing-app:0.2.1

## Testing
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Fixes #303