### PR TITLE
chore: bump ziti-management 0.10.4, agents-orchestrator 0.13.1, expose 0.1.1

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.12.1"
+  default     = "0.13.1"
 }
 
 variable "threads_chart_version" {
@@ -93,7 +93,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.10.3"
+  default     = "0.10.4"
 }
 
 variable "users_chart_version" {
@@ -105,7 +105,7 @@ variable "users_chart_version" {
 variable "expose_chart_version" {
   type        = string
   description = "Version of the expose Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.1.1"
 }
 
 variable "organizations_chart_version" {


### PR DESCRIPTION
Version bumps for the Ziti identity collision fix (agynio/agents-orchestrator#124):

| Service | Old | New | Change |
|---------|-----|-----|--------|
| `ziti-management` | 0.10.3 | 0.10.4 | `externalId` = workloadId, `workload-<workloadId>` role attr |
| `agents-orchestrator` | 0.12.1 | 0.13.1 | Generate workloadId, pass to CreateAgentIdentity |
| `expose` | 0.1.0 | 0.1.1 | Bind policy scoped to `#workload-<workloadId>` |

**Deploy together** — ziti-management and orchestrator should roll out at the same time to avoid request format mismatch.