### PR TITLE
chore(bootstrap): bump chart versions

### DIFF
--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -50,7 +50,7 @@ variable "reminders_image_tag" {
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.9.0"
+  default     = "0.10.1"
 }
 
 variable "k8s_runner_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -33,7 +33,7 @@ variable "ghcr_token" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.20.0"
+  default     = "0.21.0"
 }
 
 variable "agent_state_chart_version" {
@@ -45,7 +45,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.1"
+  default     = "0.13.0"
 }
 
 variable "threads_chart_version" {
@@ -87,7 +87,7 @@ variable "postgres_chart_version" {
 variable "agents_chart_version" {
   type        = string
   description = "Version of the agents Helm chart published to GHCR"
-  default     = "0.6.1"
+  default     = "0.7.0"
 }
 
 variable "ziti_management_chart_version" {
@@ -123,7 +123,7 @@ variable "identity_chart_version" {
 variable "runners_chart_version" {
   type        = string
   description = "Version of the runners Helm chart published to GHCR"
-  default     = "0.4.0"
+  default     = "0.5.0"
 }
 
 variable "apps_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.0"
+  default     = "0.13.1"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
## Summary
- bump platform chart defaults for gateway, agents-orchestrator, agents, and runners.
- bump apps stack default for k8s-runner chart.

## Testing
- terraform fmt -recursive
- terraform -chdir=stacks/k8s apply -input=false -auto-approve
- terraform -chdir=stacks/system apply -input=false -auto-approve
- ./install-ca-cert.sh -y "$(pwd)/local-certs/ca-agyn-dev.pem"
- terraform -chdir=stacks/routing apply -input=false -auto-approve
- terraform -chdir=stacks/deps apply -input=false -auto-approve
- ZITI_ADMIN_PASSWORD="$(kubectl --kubeconfig stacks/k8s/.kube/agyn-local-kubeconfig.yaml -n ziti get secret ziti-controller-admin-secret -o go-template='{{index .data \"admin-password\" | base64decode}}')" && terraform -chdir=stacks/ziti apply -input=false -auto-approve -var "ziti_admin_password=${ZITI_ADMIN_PASSWORD}"
- terraform -chdir=stacks/data apply -input=false -auto-approve
- terraform -chdir=stacks/platform apply -input=false -auto-approve -var "oidc_issuer_url=https://mockauth.dev/r/301ebb13-15a8-48f4-baac-e3fa25be29fc/oidc" -var "oidc_client_id=client_MU95KU3gHQf5Ir7p" -var "oidc_client_secret=XPKka2i9uzISrKZ95zxli8sY51BK4eTJ" -var "ghcr_username=" -var "ghcr_token="
- terraform -chdir=stacks/apps init -input=false
- terraform -chdir=stacks/apps apply -input=false -auto-approve
- ./.github/scripts/verify_platform_health.sh

Fixes #305