### PR TITLE
chore: bump ziti-management 0.10.5, agents-orchestrator 0.13.2, llm-proxy 0.10.2

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -93,7 +93,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.10.4"
+  default     = "0.10.5"
 }
 
 variable "users_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.1"
+  default     = "0.13.2"
 }
 
 variable "threads_chart_version" {
@@ -699,7 +699,7 @@ variable "media_proxy_image_tag" {
 variable "llm_proxy_chart_version" {
   type        = string
   description = "Version of the llm-proxy Helm chart published to GHCR"
-  default     = "0.10.0"
+  default     = "0.10.2"
 }
 
 variable "llm_proxy_image_tag" {


### PR DESCRIPTION
Version bumps:

| Service | Old | New | Change |
|---------|-----|-----|--------|
| `ziti-management` | 0.10.4 | 0.10.5 | Drop unique constraint on `managed_identities.identity_id`; remove legacy resolve fallback |
| `agents-orchestrator` | 0.13.1 | 0.13.2 | Add agyn CLI to PATH; add gateway URL env |
| `llm-proxy` | 0.10.0 | 0.10.2 | Revert x-api-key header change |