### PR TITLE
Bump console-app chart to 0.7.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -147,7 +147,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.6.0"
+  default     = "0.7.0"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump console-app chart default to 0.7.0 in platform variables

## Testing
- terraform fmt -check -recursive
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Refs #310