### PR TITLE
chore: bump ziti-management chart

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1091,6 +1091,10 @@ locals {
         name  = "ZITI_ENROLLMENT_JWT_FILE"
         value = "/etc/ziti-enrollment/enrollmentJwt"
       },
+      {
+        name  = "ZITI_IDENTITY_NAME_RESOLVE"
+        value = "true"
+      },
     ]
   })
 

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -93,7 +93,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.10.5"
+  default     = "0.10.6"
 }
 
 variable "users_chart_version" {


### PR DESCRIPTION
## Summary
- bump ziti_management_chart_version to 0.10.6
- enable ZITI_IDENTITY_NAME_RESOLVE in ziti-management env values

## Testing
- TF_VAR_ziti_management_chart_version=0.10.5 ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Refs #46