### PR TITLE
chore(platform): bump agents orchestrator chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.4"
+  default     = "0.13.5"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
## Summary
- rebase with main and resolve agents-orchestrator chart bump
- set agents-orchestrator chart default to 0.13.5

## Testing
- terraform -chdir=stacks/platform init -backend=false -lockfile=readonly
- terraform -chdir=stacks/platform validate
- terraform fmt stacks/platform/variables.tf
- terraform fmt -check -recursive

Refs #316