### PR TITLE
chore(platform): bump agents orchestrator chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.2"
+  default     = "0.13.4"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
## Summary
- bump agents-orchestrator chart default to 0.13.4

## Testing
- terraform fmt -check -recursive
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Closes #321