### PR TITLE
chore(platform): bump threads/runners charts

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -480,12 +480,32 @@ locals {
         }
       ]
     }
-    extraEnvVars = [
+    env = [
+      {
+        name  = "GRPC_ADDRESS"
+        value = ":50051"
+      },
       {
         name  = "DATABASE_URL"
         value = format("postgresql://threads:%s@threads-db:5432/threads?sslmode=disable", var.threads_db_password)
       },
+      {
+        name  = "NOTIFICATIONS_ADDRESS"
+        value = "notifications:50051"
+      },
+      {
+        name  = "IDENTITY_ADDRESS"
+        value = "identity:50051"
+      },
+      {
+        name  = "METERING_SERVICE_ADDRESS"
+        value = "metering:50051"
+      },
     ]
+    securityContext = {
+      runAsUser  = 100
+      runAsGroup = 101
+    }
     image = {
       repository = "ghcr.io/agynio/threads"
       tag        = local.resolved_threads_image_tag

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -489,18 +489,6 @@ locals {
         name  = "DATABASE_URL"
         value = format("postgresql://threads:%s@threads-db:5432/threads?sslmode=disable", var.threads_db_password)
       },
-      {
-        name  = "NOTIFICATIONS_ADDRESS"
-        value = "notifications:50051"
-      },
-      {
-        name  = "IDENTITY_ADDRESS"
-        value = "identity:50051"
-      },
-      {
-        name  = "METERING_SERVICE_ADDRESS"
-        value = "metering:50051"
-      },
     ]
     securityContext = {
       runAsUser  = 100

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agents_orchestrator_chart_version" {
 variable "threads_chart_version" {
   type        = string
   description = "Version of the threads Helm chart published to GHCR"
-  default     = "0.4.1"
+  default     = "0.4.2"
 }
 
 variable "metering_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agents_orchestrator_chart_version" {
 variable "threads_chart_version" {
   type        = string
   description = "Version of the threads Helm chart published to GHCR"
-  default     = "0.3.2"
+  default     = "0.4.1"
 }
 
 variable "metering_chart_version" {
@@ -123,7 +123,7 @@ variable "identity_chart_version" {
 variable "runners_chart_version" {
   type        = string
   description = "Version of the runners Helm chart published to GHCR"
-  default     = "0.5.0"
+  default     = "0.5.1"
 }
 
 variable "apps_chart_version" {


### PR DESCRIPTION
## Summary
- bump llm-proxy, threads, and runners chart defaults
- supply threads env vars for grpc/database/service addresses
- set threads container runAs user/group to satisfy runAsNonRoot

## Testing
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Refs agynio/metering#1
Requires @agynio/humans review (CODEOWNERS).