### PR TITLE
chore(ziti): bump controller/router charts

### DIFF
--- a/stacks/apps/.terraform.lock.hcl
+++ b/stacks/apps/.terraform.lock.hcl
@@ -1,0 +1,58 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/agynio/agyn" {
+  version     = "0.6.7"
+  constraints = "~> 0.5"
+  hashes = [
+    "h1:acvPJPW4rVLABhaEWh/ohDxHknKJVtmw+9Zq2F8xi6k=",
+    "zh:26de16a4ae795bd1b897e182bc672d4e08dc290e51f2632f0e05c522da3d5a2b",
+    "zh:2d6cf54915b823faef4dcae897cb87c017df2e3e7caa08c0a90876062cbeeee0",
+    "zh:34215d299aaf38b057735563ac713b8d6f7a147d394586d1778d8ced8b32cdc8",
+    "zh:375cb8315e1a9a9c1d18776c14ad99b9eb48594210c9178cfd2029467b779194",
+    "zh:3fc8e27ba9c4f01048df9ae7fbd2f584c44e7e150f956982b87de79f361e0bb3",
+    "zh:4f8bc5bb3399236347b033fb3c447d0567c376d32902bcdb45dafbd1c6fe5911",
+    "zh:6f197cbf0c658e8d354f7c7e75e9c28c3f5315a2d804481760849f4c4cc2eee2",
+    "zh:ba355da675bca720baa9cdd9eb71054d7ee8637d9e9aefe01e2a786a868be01a",
+    "zh:d510d2462032337cdf8a0773e6505aa0f7f41248a569dc1dc4ccab89711de3ee",
+    "zh:f64f5c0cec535d02d398460699ca26676f470a59a7c3b6d0a81be0222afbd5ee",
+  ]
+}
+
+provider "registry.terraform.io/argoproj-labs/argocd" {
+  version     = "7.15.3"
+  constraints = "~> 7.14"
+  hashes = [
+    "h1:ZCIcaDzTy2WN2iaaMA9puR1khbGetdesJDYNEgshfZE=",
+    "zh:1a754d97259b9d2e9e624703eec655278bff20ca829b9d48ee9aae9591af2681",
+    "zh:3728ed3654f426d745d624d6895631651ebd8e84d594fe475849f2ad02c5c027",
+    "zh:4261e504831d8744de39e583a3b6931ced1ca6b67b2363448243197548cb6fd1",
+    "zh:57693d73351452ab6171d7cd929f41c666e7d6720ec57d2c5a9eb9081e6ba8d4",
+    "zh:67e23102766d21548b80ed484ac2173ce0ed94db89f3aa0fa7f1cde80f0179d5",
+    "zh:b2f7408bf945d8ad18b65574d036db4e742d600adc4270c6876fe19a5b62b464",
+    "zh:be4cdc723e4782655f79d125b7c67d84798c0ab450e37c4a8ca809027c92ccac",
+    "zh:c6c102f04d1873c1182502c10120411c344a1ee9af93b1d8086e7e28696c0689",
+    "zh:c8797aef8ed8d548a17cda9ddfc321231c73654d37b43c7e3e5d3e096544fa7d",
+    "zh:cc64b231c45c638448b9e1b8a8dd67b8430d2c5f1401123cc114676efca5e9e4",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.33"
+  hashes = [
+    "h1:5CkveFo5ynsLdzKk+Kv+r7+U9rMrNjfZPT3a0N/fhgE=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
+  ]
+}

--- a/stacks/deps/main.tf
+++ b/stacks/deps/main.tf
@@ -21,6 +21,9 @@ locals {
   })
 
   ziti_controller_values = yamlencode({
+    cluster = {
+      mode = "standalone"
+    }
     clientApi = {
       advertisedHost = "ziti.${local.base_domain}"
       advertisedPort = local.ingress_port

--- a/stacks/deps/variables.tf
+++ b/stacks/deps/variables.tf
@@ -32,5 +32,5 @@ variable "trust_manager_chart_version" {
 variable "ziti_controller_chart_version" {
   type        = string
   description = "OpenZiti controller chart version"
-  default     = "2.1.2"
+  default     = "3.2.0-pre6"
 }

--- a/stacks/ziti/main.tf
+++ b/stacks/ziti/main.tf
@@ -9,7 +9,7 @@ locals {
   router_values = yamlencode({
     ctrl = {
       # Use controller service port (ingress advertised port), not container 1280.
-      endpoint = "ziti-controller-client.ziti.svc:${local.ingress_port}"
+      endpoint = "ziti.${local.base_domain}:${local.ingress_port}"
     }
     edge = {
       advertisedHost = "ziti-router.${local.base_domain}"

--- a/stacks/ziti/variables.tf
+++ b/stacks/ziti/variables.tf
@@ -19,5 +19,5 @@ variable "ziti_admin_password" {
 variable "ziti_router_chart_version" {
   type        = string
   description = "OpenZiti router chart version"
-  default     = "2.1.0"
+  default     = "3.0.0-pre5"
 }


### PR DESCRIPTION
## Summary
- bump Ziti controller/router chart defaults
- add controller cluster mode override and route router ctrl endpoint via ingress
- refresh Terraform provider lockfile for apps stack

## Testing
- terraform fmt -check -recursive
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

## Issue
- #317