### PR TITLE
chore(platform): bump chart defaults

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -33,7 +33,7 @@ variable "ghcr_token" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.21.0"
+  default     = "0.21.1"
 }
 
 variable "agent_state_chart_version" {
@@ -514,7 +514,7 @@ variable "files_db_pvc_size" {
 variable "llm_chart_version" {
   type        = string
   description = "Version of the llm Helm chart published to GHCR"
-  default     = "0.4.0"
+  default     = "0.4.1"
 }
 
 variable "llm_image_tag" {


### PR DESCRIPTION
## Summary
- bump gateway chart default to 0.21.1
- bump llm chart default to 0.4.1
- note: local apply required TF_VAR_llm_chart_version=0.4.0 because ghcr.io/agynio/charts/llm:0.4.1 is not published yet

## Testing
- terraform fmt -check -recursive
- TF_VAR_llm_chart_version=0.4.0 GHCR_USERNAME=casey-brooks GHCR_TOKEN=*** ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Refs #327