### PR TITLE
chore(platform): bump llm-proxy to 0.12.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -653,7 +653,7 @@ variable "media_proxy_image_tag" {
 variable "llm_proxy_chart_version" {
   type        = string
   description = "Version of the llm-proxy Helm chart published to GHCR"
-  default     = "0.10.2"
+  default     = "0.12.0"
 }
 
 variable "llm_proxy_image_tag" {


### PR DESCRIPTION
Bumps `llm-proxy` chart from `0.10.2` to `0.12.0`.

## Changes in llm-proxy v0.12.0
- Upgrade `openziti/sdk-golang` from v1.4.2 to v1.6.0 (agynio/llm-proxy#44)
- Remove `SourceIdentifier()` fallback from Ziti identity extraction (agynio/llm-proxy#41)