### PR TITLE
chore(platform): bump identity chart version

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -117,7 +117,7 @@ variable "organizations_chart_version" {
 variable "identity_chart_version" {
   type        = string
   description = "Version of the identity Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.2.0"
 }
 
 variable "runners_chart_version" {


### PR DESCRIPTION
## Summary
- bump identity chart default to 0.2.0
- run terraform fmt
- validate platform stack configuration

## Testing
- terraform fmt -recursive
- terraform fmt -check -recursive
- terraform -chdir=stacks/platform validate

Refs #331