### PR TITLE
fix(platform): bump console app chart to 0.8.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -147,7 +147,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.7.0"
+  default     = "0.8.0"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump console-app Helm chart default to 0.8.0

## Testing
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

## Issue
- #333