### PR TITLE
feat: add tracing Ziti service and bump versions

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -528,6 +528,10 @@ locals {
         name  = "DATABASE_URL"
         value = format("postgresql://tracing:%s@tracing-db:5432/tracing?sslmode=disable", var.tracing_db_password)
       },
+      {
+        name  = "ZITI_ENABLED"
+        value = "true"
+      },
     ]
     image = {
       repository = "ghcr.io/agynio/tracing"
@@ -2991,6 +2995,7 @@ resource "argocd_application" "tracing" {
   depends_on = [
     argocd_repository.ghcr,
     argocd_application.tracing_db,
+    argocd_application.ziti_management,
   ]
   metadata {
     name      = "tracing"

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -184,7 +184,7 @@ variable "oidc_client_secret" {
 variable "tracing_app_chart_version" {
   type        = string
   description = "Version of the tracing-app Helm chart published to GHCR"
-  default     = "0.3.0"
+  default     = "0.2.1"
 }
 
 variable "tracing_app_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -39,7 +39,7 @@ variable "gateway_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.5"
+  default     = "0.13.6"
 }
 
 variable "threads_chart_version" {
@@ -57,7 +57,7 @@ variable "metering_chart_version" {
 variable "tracing_chart_version" {
   type        = string
   description = "Version of the tracing Helm chart published to GHCR"
-  default     = "0.2.1"
+  default     = "0.3.0"
 }
 
 variable "token_counting_chart_version" {
@@ -93,7 +93,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.10.6"
+  default     = "0.10.7"
 }
 
 variable "users_chart_version" {
@@ -184,7 +184,7 @@ variable "oidc_client_secret" {
 variable "tracing_app_chart_version" {
   type        = string
   description = "Version of the tracing-app Helm chart published to GHCR"
-  default     = "0.2.1"
+  default     = "0.3.0"
 }
 
 variable "tracing_app_image_tag" {

--- a/stacks/ziti/main.tf
+++ b/stacks/ziti/main.tf
@@ -195,6 +195,38 @@ resource "ziti_service_policy" "agents_dial_llm_proxy" {
   serviceroles  = [format("@%s", ziti_service.llm_proxy.id)]
 }
 
+resource "ziti_intercept_v1_config" "tracing_intercept" {
+  name      = "tracing-intercept-v1"
+  addresses = ["tracing.ziti"]
+  protocols = ["tcp"]
+  port_ranges = [
+    {
+      low  = 443
+      high = 443
+    }
+  ]
+}
+
+resource "ziti_service" "tracing" {
+  name            = "tracing"
+  configs         = [ziti_intercept_v1_config.tracing_intercept.id]
+  role_attributes = ["tracing"]
+}
+
+resource "ziti_service_policy" "tracing_bind" {
+  name          = "tracing-bind"
+  type          = "Bind"
+  identityroles = ["#tracing-hosts"]
+  serviceroles  = [format("@%s", ziti_service.tracing.id)]
+}
+
+resource "ziti_service_policy" "agents_dial_tracing" {
+  name          = "agents-dial-tracing"
+  type          = "Dial"
+  identityroles = ["#agents"]
+  serviceroles  = [format("@%s", ziti_service.tracing.id)]
+}
+
 resource "ziti_service_policy" "runners_bind" {
   name          = "runners-bind"
   type          = "Bind"


### PR DESCRIPTION
Closes agynio/tracing#10

## Platform stack
- Bump `tracing` 0.2.1 → 0.3.0
- Bump `ziti-management` 0.10.6 → 0.10.7
- Bump `agents-orchestrator` 0.13.5 → 0.13.6
- Enable `ZITI_ENABLED=true` for tracing service
- Add `ziti_management` dependency to tracing ArgoCD app

## Ziti stack
- Add `tracing` intercept config (`tracing.ziti:443`)
- Add `tracing` service
- Add `tracing-bind` policy (`#tracing-hosts`)
- Add `agents-dial-tracing` policy (`#agents`)