### PR TITLE
chore(platform): bump chart defaults

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -528,6 +528,10 @@ locals {
         name  = "DATABASE_URL"
         value = format("postgresql://tracing:%s@tracing-db:5432/tracing?sslmode=disable", var.tracing_db_password)
       },
+      {
+        name  = "ZITI_ENABLED"
+        value = "true"
+      },
     ]
     image = {
       repository = "ghcr.io/agynio/tracing"
@@ -2991,6 +2995,7 @@ resource "argocd_application" "tracing" {
   depends_on = [
     argocd_repository.ghcr,
     argocd_application.tracing_db,
+    argocd_application.ziti_management,
   ]
   metadata {
     name      = "tracing"

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -33,7 +33,13 @@ variable "ghcr_token" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.21.1"
+  default     = "0.21.2"
+}
+
+variable "agent_state_chart_version" {
+  type        = string
+  description = "Version of the agent-state Helm chart published to GHCR"
+  default     = "0.1.0"
 }
 
 variable "agents_orchestrator_chart_version" {
@@ -105,7 +111,7 @@ variable "users_chart_version" {
 variable "expose_chart_version" {
   type        = string
   description = "Version of the expose Helm chart published to GHCR"
-  default     = "0.1.1"
+  default     = "0.1.2"
 }
 
 variable "organizations_chart_version" {
@@ -476,7 +482,7 @@ variable "files_db_pvc_size" {
 variable "llm_chart_version" {
   type        = string
   description = "Version of the llm Helm chart published to GHCR"
-  default     = "0.4.1"
+  default     = "0.4.2"
 }
 
 variable "llm_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agent_state_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.5"
+  default     = "0.13.6"
 }
 
 variable "threads_chart_version" {
@@ -63,7 +63,7 @@ variable "metering_chart_version" {
 variable "tracing_chart_version" {
   type        = string
   description = "Version of the tracing Helm chart published to GHCR"
-  default     = "0.2.1"
+  default     = "0.3.0"
 }
 
 variable "token_counting_chart_version" {
@@ -99,7 +99,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.10.6"
+  default     = "0.10.7"
 }
 
 variable "users_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -153,7 +153,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.7.0"
+  default     = "0.8.0"
 }
 
 variable "console_app_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -36,12 +36,6 @@ variable "gateway_chart_version" {
   default     = "0.21.2"
 }
 
-variable "agent_state_chart_version" {
-  type        = string
-  description = "Version of the agent-state Helm chart published to GHCR"
-  default     = "0.1.0"
-}
-
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"

--- a/stacks/ziti/main.tf
+++ b/stacks/ziti/main.tf
@@ -195,6 +195,38 @@ resource "ziti_service_policy" "agents_dial_llm_proxy" {
   serviceroles  = [format("@%s", ziti_service.llm_proxy.id)]
 }
 
+resource "ziti_intercept_v1_config" "tracing_intercept" {
+  name      = "tracing-intercept-v1"
+  addresses = ["tracing.ziti"]
+  protocols = ["tcp"]
+  port_ranges = [
+    {
+      low  = 443
+      high = 443
+    }
+  ]
+}
+
+resource "ziti_service" "tracing" {
+  name            = "tracing"
+  configs         = [ziti_intercept_v1_config.tracing_intercept.id]
+  role_attributes = ["tracing"]
+}
+
+resource "ziti_service_policy" "tracing_bind" {
+  name          = "tracing-bind"
+  type          = "Bind"
+  identityroles = ["#tracing-hosts"]
+  serviceroles  = [format("@%s", ziti_service.tracing.id)]
+}
+
+resource "ziti_service_policy" "agents_dial_tracing" {
+  name          = "agents-dial-tracing"
+  type          = "Dial"
+  identityroles = ["#agents"]
+  serviceroles  = [format("@%s", ziti_service.tracing.id)]
+}
+
 resource "ziti_service_policy" "runners_bind" {
   name          = "runners-bind"
   type          = "Bind"


### PR DESCRIPTION
## Summary
- bump gateway, expose, and llm chart default versions in platform stack variables

## Testing
- terraform -chdir=stacks/platform fmt
- terraform -chdir=stacks/platform validate
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Refs: #336