### PR TITLE
fix: add metering apps to health check

### DIFF
--- a/.github/scripts/verify_platform_health.sh
+++ b/.github/scripts/verify_platform_health.sh
@@ -24,7 +24,7 @@ if [[ ! -f "$KUBECONFIG_PATH" ]]; then
   exit 1
 fi
 
-REQUIRED_APPS_JSON='["cert-manager","trust-manager","ziti-controller","ziti-management","registry-mirror","minio","platform-db","threads-db","chat-db","identity-db","runners-db","identity","authorization","gateway","runners","notifications-redis","notifications","threads","chat","k8s-runner"]'
+REQUIRED_APPS_JSON='["cert-manager","trust-manager","ziti-controller","ziti-management","registry-mirror","minio","platform-db","threads-db","chat-db","identity-db","runners-db","metering-db","identity","authorization","gateway","runners","notifications-redis","notifications","metering","threads","chat","k8s-runner"]'
 
 deadline=$((SECONDS + TOTAL_TIMEOUT))
 pod_terminal_failures_streak=0


### PR DESCRIPTION
## Summary
- add metering-db and metering to required Argo CD apps

## Testing
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh
- ./apply.sh -y (timed out after 300s)
- ./.github/scripts/verify_platform_health.sh

Refs #338