### PR TITLE
Bump metering chart to 0.1.1

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -51,7 +51,7 @@ variable "threads_chart_version" {
 variable "metering_chart_version" {
   type        = string
   description = "Version of the metering Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.1.1"
 }
 
 variable "tracing_chart_version" {


### PR DESCRIPTION
## Summary
- bump metering Helm chart default to 0.1.1
- run terraform fmt on platform variables

## Testing
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh
- ./apply.sh -y (via background setsid)
- ./.github/scripts/verify_platform_health.sh

Refs #342