### PR TITLE
Remove agents host bind policy

### DIFF
--- a/stacks/ziti/main.tf
+++ b/stacks/ziti/main.tf
@@ -255,13 +255,6 @@ resource "ziti_service_policy" "gateway_dial_apps" {
   serviceroles  = ["#app-services"]
 }
 
-resource "ziti_service_policy" "agents_host_exposed" {
-  name          = "agents-host-exposed"
-  type          = "Bind"
-  identityroles = ["#agents"]
-  serviceroles  = ["#exposed-services"]
-}
-
 resource "ziti_edge_router_policy" "all_identities_all_routers" {
   name            = "all-identities-all-routers"
   identityroles   = ["#all"]


### PR DESCRIPTION
## Summary
- remove the broad agents-host-exposed bind policy from the Ziti stack

## Testing
- terraform fmt -recursive
- terraform -chdir=stacks/ziti validate
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh
- setsid env TF_PLUGIN_TIMEOUT=300 ./apply.sh -y > /tmp/bootstrap_apply_post.log 2>&1 &
- ./.github/scripts/verify_platform_health.sh

Refs #344