### PR TITLE
Bump runners chart version to 0.5.2

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -123,7 +123,7 @@ variable "identity_chart_version" {
 variable "runners_chart_version" {
   type        = string
   description = "Version of the runners Helm chart published to GHCR"
-  default     = "0.5.1"
+  default     = "0.5.2"
 }
 
 variable "apps_chart_version" {


### PR DESCRIPTION
## Summary
- bump the default runners chart version to 0.5.2

## Testing
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh
- terraform -chdir=stacks/platform fmt
- terraform -chdir=stacks/platform validate
- ./apply.sh -y
- .github/scripts/verify_platform_health.sh

Fixes #346