### PR TITLE
chore(terraform): bump gateway chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -33,7 +33,7 @@ variable "ghcr_token" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.21.2"
+  default     = "0.22.0"
 }
 
 variable "agents_orchestrator_chart_version" {


### PR DESCRIPTION
## Summary
- bump the default gateway Helm chart version to 0.22.0

## Related
- https://github.com/agynio/console-app/issues/58

## Testing
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh