### PR TITLE
fix(ziti): preserve admin password on upgrade

### DIFF
--- a/.github/scripts/verify_platform_health.sh
+++ b/.github/scripts/verify_platform_health.sh
@@ -319,10 +319,10 @@ while (( SECONDS < deadline )); do
   if (( ${#outstanding[@]} == 0 )); then
     ziti_overlay_pending=()
     ziti_admin_username=$(kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$ZITI_NAMESPACE" \
-      get secret ziti-controller-admin-secret \
+      get secret ziti-controller-admin-credentials \
       -o go-template='{{index .data "admin-user" | base64decode}}' 2>/dev/null || true)
     ziti_admin_password=$(kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$ZITI_NAMESPACE" \
-      get secret ziti-controller-admin-secret \
+      get secret ziti-controller-admin-credentials \
       -o go-template='{{index .data "admin-password" | base64decode}}' 2>/dev/null || true)
 
     if [[ -z "$ziti_admin_username" || -z "$ziti_admin_password" ]]; then

--- a/README.md
+++ b/README.md
@@ -54,3 +54,15 @@ Default domain and port: `agyn.dev` on `2496`.
 - Argo CD: https://argocd.agyn.dev:2496/
 - OpenFGA API: https://openfga.agyn.dev:2496/
 - OpenFGA Playground: https://openfga-playground.agyn.dev:2496/
+
+## Upgrade notes
+
+### Ziti admin secret migration (Issue #349)
+
+On existing clusters, rerun `./apply.sh -y` after upgrading. It preserves the legacy
+`ziti-controller-admin-secret` password while seeding the new
+`ziti-controller-admin-credentials` secret.
+
+If the legacy secret was already pruned or rotated, recreate it with the correct
+admin password (or reset the controller admin password) and rerun `./apply.sh -y`
+or `TF_VAR_ziti_admin_password_override=... terraform -chdir=stacks/deps apply`.

--- a/apply.sh
+++ b/apply.sh
@@ -373,8 +373,50 @@ step_start "stack:routing"
 run_stack "routing"
 step_end "stack:routing"
 
+ziti_admin_password_override=""
+ziti_xtrace_enabled=false
+if [[ "${-}" == *x* ]]; then
+  ziti_xtrace_enabled=true
+  set +x
+fi
+
+if ! ziti_secret_present=$(kubectl --kubeconfig "${KUBECONFIG_PATH}" -n ziti \
+  get secret ziti-controller-admin-secret --ignore-not-found -o name 2>/dev/null); then
+  echo "Error: failed to check for existing ziti-controller-admin-secret." >&2
+  if [[ "${ziti_xtrace_enabled}" == "true" ]]; then
+    set -x
+  fi
+  exit 1
+fi
+
+if [[ -n "${ziti_secret_present}" ]]; then
+  ziti_admin_password_override=$(kubectl --kubeconfig "${KUBECONFIG_PATH}" -n ziti \
+    get secret ziti-controller-admin-secret \
+    -o go-template='{{index .data "admin-password" | base64decode}}' 2>/dev/null || true)
+  if [[ -z "${ziti_admin_password_override}" ]]; then
+    echo "Error: ziti-controller-admin-secret exists but admin-password is empty." >&2
+    if [[ "${ziti_xtrace_enabled}" == "true" ]]; then
+      set -x
+    fi
+    exit 1
+  fi
+fi
+
+if [[ -z "${ziti_admin_password_override}" && "${ziti_xtrace_enabled}" == "true" ]]; then
+  set -x
+  ziti_xtrace_enabled=false
+fi
+
 step_start "stack:deps"
-run_stack "deps"
+if [[ -n "${ziti_admin_password_override}" ]]; then
+  TF_VAR_ziti_admin_password_override="${ziti_admin_password_override}" run_stack "deps"
+else
+  run_stack "deps"
+fi
+unset ziti_admin_password_override
+if [[ "${ziti_xtrace_enabled}" == "true" ]]; then
+  set -x
+fi
 
 echo "=== Waiting for ArgoCD applications to sync ==="
 for app in cert-manager trust-manager ziti-controller; do

--- a/stacks/deps/main.tf
+++ b/stacks/deps/main.tf
@@ -47,6 +47,7 @@ locals {
     useCustomAdminSecret  = true
     customAdminSecretName = local.ziti_admin_secret_name
   })
+  ziti_admin_password = var.ziti_admin_password_override != "" ? var.ziti_admin_password_override : random_password.ziti_controller_admin.result
 }
 
 resource "random_password" "ziti_controller_admin" {
@@ -64,7 +65,7 @@ resource "kubernetes_secret_v1" "ziti_controller_admin" {
 
   data = {
     "admin-user"     = "admin"
-    "admin-password" = random_password.ziti_controller_admin.result
+    "admin-password" = local.ziti_admin_password
   }
 
   lifecycle {

--- a/stacks/deps/remote_state.tf
+++ b/stacks/deps/remote_state.tf
@@ -21,7 +21,7 @@ locals {
   argocd_namespace        = local.installed_namespaces[4]
   cert_manager_namespace  = local.installed_namespaces[0]
   ziti_namespace          = local.installed_namespaces[1]
-  ziti_admin_secret_name  = "ziti-controller-admin-secret"
+  ziti_admin_secret_name  = "ziti-controller-admin-credentials"
   destination_server      = "https://kubernetes.default.svc"
   istio_gateway_namespace = data.terraform_remote_state.system.outputs.istio_gateway_namespace
 }

--- a/stacks/deps/variables.tf
+++ b/stacks/deps/variables.tf
@@ -17,6 +17,13 @@ variable "argocd_admin_password" {
   sensitive   = true
 }
 
+variable "ziti_admin_password_override" {
+  type        = string
+  description = "Optional override for the Ziti admin password to preserve existing credentials during upgrades"
+  default     = ""
+  sensitive   = true
+}
+
 variable "cert_manager_chart_version" {
   type        = string
   description = "cert-manager chart version"

--- a/stacks/ziti/remote_state.tf
+++ b/stacks/ziti/remote_state.tf
@@ -8,7 +8,7 @@ data "terraform_remote_state" "k8s" {
 
 data "kubernetes_secret_v1" "ziti_admin" {
   metadata {
-    name      = "ziti-controller-admin-secret"
+    name      = "ziti-controller-admin-credentials"
     namespace = "ziti"
   }
 }


### PR DESCRIPTION
## Summary
- Seed the new `ziti-controller-admin-credentials` secret from the legacy admin secret when present (apply.sh override + deps stack variable).
- Point ziti stack and health verification to the new Terraform-owned secret name.
- Document upgrade recovery steps for clusters already impacted by INVALID_AUTH.

## Migration
- Re-run `./apply.sh -y` on existing clusters; it preserves the legacy admin password when `ziti-controller-admin-secret` exists.
- If the legacy secret was pruned/rotated, recreate it (or reset the controller admin password) and rerun `./apply.sh -y` or `TF_VAR_ziti_admin_password_override=... terraform -chdir=stacks/deps apply`.

## Testing
- `./apply.sh -y`
- `./.github/scripts/verify_platform_health.sh`
- `bash -n apply.sh`
- `bash -n .github/scripts/verify_platform_health.sh`
- `shellcheck apply.sh .github/scripts/verify_platform_health.sh`
- `terraform -chdir=stacks/deps fmt -check`
- `terraform -chdir=stacks/deps validate`

Fixes #349