### PR TITLE
chore(terraform): bump console chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -147,7 +147,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.8.0"
+  default     = "0.9.0"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump console_app_chart_version default to 0.9.0

## Related
- #351

## Testing
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh