### PR TITLE
chore(platform): bump expose chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -105,7 +105,7 @@ variable "users_chart_version" {
 variable "expose_chart_version" {
   type        = string
   description = "Version of the expose Helm chart published to GHCR"
-  default     = "0.1.3"
+  default     = "0.1.4"
 }
 
 variable "organizations_chart_version" {


### PR DESCRIPTION
## Summary
- update the platform stack expose chart default to 0.1.4

## Testing
- terraform fmt -check -recursive
- terraform -chdir=stacks/platform validate

Refs #354