### PR TITLE
chore(platform): bump orchestrator chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -39,7 +39,7 @@ variable "gateway_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.7"
+  default     = "0.13.8"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
## Summary
- bump agents-orchestrator Helm chart version default to 0.13.8

## Testing
- terraform fmt -check -recursive
- terraform -chdir=stacks/platform validate

Refs #355
