### PR TITLE
Bump agents orchestrator chart version

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -39,7 +39,7 @@ variable "gateway_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.7"
+  default     = "0.13.8"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
## Summary
- bump agents_orchestrator_chart_version default to 0.13.8

## Testing
- terraform fmt -check -recursive
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

## Issue
- #356