### PR TITLE
chore(platform): bump threads chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agents_orchestrator_chart_version" {
 variable "threads_chart_version" {
   type        = string
   description = "Version of the threads Helm chart published to GHCR"
-  default     = "0.4.4"
+  default     = "0.4.5"
 }
 
 variable "metering_chart_version" {


### PR DESCRIPTION
## Summary
- bump threads chart default to 0.4.5 in platform stack variables

## Testing
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh
- TF_PLUGIN_TIMEOUT=300 ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Fixes #360