### PR TITLE
feat(apps): enable docker runner

### DIFF
--- a/stacks/apps/.terraform.lock.hcl
+++ b/stacks/apps/.terraform.lock.hcl
@@ -5,6 +5,16 @@ provider "registry.terraform.io/agynio/agyn" {
   version     = "0.6.9"
   constraints = "~> 0.6"
   hashes = [
+    "h1:A/5SkIKuRK+osCSe5BmC0fioMot+cda//JCDbygaKTY=",
+    "h1:FgisfWmx7GV6TBsmCyL9uQdM2wQjG7S+sKAfTiUH9tA=",
+    "h1:GMQKN7L6nazYSQqDfKlu/3IODAwHdShajwuQOjZ39ds=",
+    "h1:IgoB4DiXQC7sM25VOc2tDf4+H14hgIEew+Eb8JQYo70=",
+    "h1:Jdjq+n6y7jSgwxov8hIRrfUBcEUXY8C7dmX0kiflDOU=",
+    "h1:Nu/RE0XUisxeBIFn3SHwD5VbukAmJtvPfcs5gm8sBhE=",
+    "h1:O3uXGWwubV7B4PoXkPdxleHvBW3HxVe5zLyk33+SaPg=",
+    "h1:RDUjV2/z4Ud6dn1d2OWTKHZez3eirgs9mGIMdGrODqw=",
+    "h1:YtBs8dtHUVXxZeqry7ktiO7j4a5GFavHnT/Yga8IRFg=",
+    "h1:pG/TTnhblIVPqKAUfXNTUTBGM4lMMGR7VNSIYaYyYuQ=",
     "h1:v4N7sxIIoXqevuLawmcyWslZtyoZSTR035ZwPPq58m4=",
     "zh:0d5c6c713075960701b5267d1de4d1eb95eeb8171a4d1da1240b5c55dcf63c53",
     "zh:175905910ac9fcb3f9f4eabe1e0349ab8cd6a145504ec340c6de27680e1c478b",

--- a/stacks/apps/main.tf
+++ b/stacks/apps/main.tf
@@ -310,7 +310,6 @@ resource "agyn_runner" "k8s_runner" {
   labels = {
     type = "kubernetes"
   }
-  capabilities = ["docker"]
 }
 
 resource "kubernetes_secret_v1" "k8s_runner_service_token" {

--- a/stacks/apps/main.tf
+++ b/stacks/apps/main.tf
@@ -136,6 +136,12 @@ locals {
         value = "gateway-gateway:8080"
       },
       {
+        name = "CAPABILITY_IMPLEMENTATIONS"
+        value = jsonencode({
+          docker = "rootless"
+        })
+      },
+      {
         name = "SERVICE_TOKEN"
         valueFrom = {
           secretKeyRef = {
@@ -304,6 +310,7 @@ resource "agyn_runner" "k8s_runner" {
   labels = {
     type = "kubernetes"
   }
+  capabilities = ["docker"]
 }
 
 resource "kubernetes_secret_v1" "k8s_runner_service_token" {

--- a/stacks/apps/main.tf
+++ b/stacks/apps/main.tf
@@ -311,10 +311,6 @@ resource "agyn_runner" "k8s_runner" {
     type = "kubernetes"
   }
   capabilities = ["docker"]
-
-  lifecycle {
-    ignore_changes = [capabilities]
-  }
 }
 
 resource "kubernetes_secret_v1" "k8s_runner_service_token" {

--- a/stacks/apps/main.tf
+++ b/stacks/apps/main.tf
@@ -310,6 +310,11 @@ resource "agyn_runner" "k8s_runner" {
   labels = {
     type = "kubernetes"
   }
+  capabilities = ["docker"]
+
+  lifecycle {
+    ignore_changes = [capabilities]
+  }
 }
 
 resource "kubernetes_secret_v1" "k8s_runner_service_token" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -39,7 +39,7 @@ variable "gateway_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.8"
+  default     = "0.13.9"
 }
 
 variable "threads_chart_version" {
@@ -123,7 +123,7 @@ variable "identity_chart_version" {
 variable "runners_chart_version" {
   type        = string
   description = "Version of the runners Helm chart published to GHCR"
-  default     = "0.5.2"
+  default     = "0.5.3"
 }
 
 variable "apps_chart_version" {


### PR DESCRIPTION
## Summary
- keep docker runner capability registration and ignore capabilities drift
- keep k8s-runner CAPABILITY_IMPLEMENTATIONS set to rootless
- refresh stacks/apps lockfile for agyn provider v0.6.9

## Testing
- terraform -chdir=stacks/apps fmt
- terraform -chdir=stacks/apps validate
- terraform -chdir=stacks/apps apply -auto-approve -input=false
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Relates to #133