### PR TITLE
Bump threads chart version to 0.4.6

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agents_orchestrator_chart_version" {
 variable "threads_chart_version" {
   type        = string
   description = "Version of the threads Helm chart published to GHCR"
-  default     = "0.4.5"
+  default     = "0.4.6"
 }
 
 variable "metering_chart_version" {


### PR DESCRIPTION
## Summary
- bump threads chart default to 0.4.6 in the platform stack

## Testing
- terraform fmt -recursive
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh
- TF_PLUGIN_TIMEOUT=300 ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

## Issue
Refs #367