### PR TITLE
Make Reminders app public

### DIFF
--- a/stacks/apps/main.tf
+++ b/stacks/apps/main.tf
@@ -184,7 +184,7 @@ resource "agyn_app" "reminders" {
   slug            = "reminders"
   name            = "Reminders"
   description     = "Delayed message delivery to threads"
-  visibility      = "internal"
+  visibility      = "public"
   permissions     = ["thread:write"]
 }
 


### PR DESCRIPTION
## Summary
- set Reminders app visibility to public in stacks/apps/main.tf

## Testing
- terraform fmt -recursive
- terraform fmt -check -recursive
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

## Issue
- #371