### PR TITLE
Bump k8s-runner chart to 0.10.4

### DIFF
--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -61,7 +61,7 @@ variable "reminders_image_tag" {
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.10.3"
+  default     = "0.10.4"
 }
 
 variable "k8s_runner_image_tag" {


### PR DESCRIPTION
## Summary
- bump k8s-runner chart default to 0.10.4

## Testing
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Refs agynio/architecture#133
#133