### PR TITLE
feat(platform): add organizations service alias

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1908,6 +1908,30 @@ resource "kubernetes_service_v1" "files_db" {
   }
 }
 
+resource "kubernetes_service_v1" "organizations_alias" {
+  metadata {
+    name      = "organizations"
+    namespace = kubernetes_namespace.platform.metadata[0].name
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+
+  spec {
+    selector = {
+      "app.kubernetes.io/name"     = "organizations"
+      "app.kubernetes.io/instance" = "tenants"
+    }
+
+    port {
+      name        = "grpc"
+      port        = 50051
+      target_port = 50051
+      protocol    = "TCP"
+    }
+  }
+}
+
 resource "kubernetes_stateful_set_v1" "files_db" {
   metadata {
     name      = "files-db"
@@ -4056,7 +4080,7 @@ resource "argocd_application" "gateway" {
             clusterAdminToken       = random_password.cluster_admin_token.result
             clusterAdminIdentityId  = local.cluster_admin_identity_id
             usersGrpcTarget         = "users:50051"
-            organizationsGrpcTarget = "tenants:50051"
+            organizationsGrpcTarget = "organizations:50051"
           }
           env = [
             {

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1926,7 +1926,7 @@ resource "kubernetes_service_v1" "organizations_alias" {
     port {
       name        = "grpc"
       port        = 50051
-      target_port = 50051
+      target_port = "grpc"
       protocol    = "TCP"
     }
   }

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -33,7 +33,7 @@ variable "ghcr_token" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.22.0"
+  default     = "0.22.1"
 }
 
 variable "agents_orchestrator_chart_version" {


### PR DESCRIPTION
## Summary
- add a Terraform-managed `organizations` Service alias targeting the existing tenants/organizations pods
- switch gateway config to `organizations:50051` for org gRPC traffic

## Migration intent
This creates a stable `organizations` DNS name while leaving the Helm-managed `tenants` Service untouched so both `tenants:50051` and `organizations:50051` resolve in-cluster after apply (same selector target). #67

## Testing
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh