### PR TITLE
feat(apps): add telegram connector

### DIFF
--- a/stacks/apps/main.tf
+++ b/stacks/apps/main.tf
@@ -1,12 +1,14 @@
 locals {
-  resolved_reminders_image_tag  = trimspace(var.reminders_image_tag) != "" ? var.reminders_image_tag : format("v%s", var.reminders_chart_version)
-  resolved_k8s_runner_image_tag = trimspace(var.k8s_runner_image_tag) != "" ? var.k8s_runner_image_tag : var.k8s_runner_chart_version
-  admin_oidc_subject            = trimspace(var.admin_oidc_subject)
-  platform_chart_repo_host      = "ghcr.io"
-  postgres_chart_repo_host      = "ghcr.io"
-  postgres_chart_name           = "agynio/charts/postgres-helm"
-  reminders_chart_name          = "agynio/charts/reminders"
-  k8s_runner_chart_name         = "agynio/charts/k8s-runner"
+  resolved_reminders_image_tag          = trimspace(var.reminders_image_tag) != "" ? var.reminders_image_tag : format("v%s", var.reminders_chart_version)
+  resolved_k8s_runner_image_tag         = trimspace(var.k8s_runner_image_tag) != "" ? var.k8s_runner_image_tag : var.k8s_runner_chart_version
+  resolved_telegram_connector_image_tag = trimspace(var.telegram_connector_image_tag) != "" ? var.telegram_connector_image_tag : var.telegram_connector_chart_version
+  admin_oidc_subject                    = trimspace(var.admin_oidc_subject)
+  platform_chart_repo_host              = "ghcr.io"
+  postgres_chart_repo_host              = "ghcr.io"
+  postgres_chart_name                   = "agynio/charts/postgres-helm"
+  reminders_chart_name                  = "agynio/charts/reminders"
+  telegram_connector_chart_name         = "agynio/charts/telegram-connector"
+  k8s_runner_chart_name                 = "agynio/charts/k8s-runner"
 
   default_sync_options = [
     "CreateNamespace=true",
@@ -104,6 +106,102 @@ locals {
     ]
   })
 
+  telegram_connector_db_values = yamlencode({
+    fullnameOverride = "telegram-connector-db"
+    postgres = {
+      database = "telegram"
+      username = "telegram"
+      password = var.telegram_connector_db_password
+      pgdata   = "/var/lib/postgresql/data/pgdata"
+    }
+    persistence = {
+      size                    = var.telegram_connector_db_pvc_size
+      mountPath               = "/var/lib/postgresql/data"
+      volumeClaimTemplateName = "data"
+    }
+    probes = {
+      readiness = {
+        execCommand = ["pg_isready", "-U", "telegram", "-d", "telegram"]
+      }
+      liveness = {
+        execCommand = ["pg_isready", "-U", "telegram", "-d", "telegram"]
+      }
+    }
+  })
+
+  telegram_connector_values = yamlencode({
+    replicaCount     = 1
+    fullnameOverride = "telegram-connector"
+    image = {
+      repository = "ghcr.io/agynio/telegram-connector"
+      tag        = local.resolved_telegram_connector_image_tag
+      pullPolicy = "IfNotPresent"
+    }
+    securityContext = {
+      runAsNonRoot = false
+    }
+    extraVolumes = [
+      {
+        name     = "ziti-identity"
+        emptyDir = {}
+      }
+    ]
+    extraVolumeMounts = [
+      {
+        name      = "ziti-identity"
+        mountPath = "/ziti"
+        readOnly  = false
+      }
+    ]
+    env = [
+      {
+        name  = "HTTP_ADDRESS"
+        value = ":8080"
+      },
+      {
+        name  = "DATABASE_URL"
+        value = format("postgresql://telegram:%s@telegram-connector-db:5432/telegram?sslmode=disable", var.telegram_connector_db_password)
+      },
+      {
+        name  = "ZITI_IDENTITY_FILE"
+        value = "/ziti/identity.json"
+      },
+      {
+        name = "SERVICE_TOKEN"
+        valueFrom = {
+          secretKeyRef = {
+            name = "telegram-connector-service-token"
+            key  = "token"
+          }
+        }
+      },
+      {
+        name  = "GATEWAY_URL"
+        value = "http://gateway-gateway.platform.svc.cluster.local:8080"
+      },
+      {
+        name  = "ZITI_SERVICE_NAME"
+        value = "app-telegram"
+      },
+      {
+        name  = "GATEWAY_SERVICE_NAME"
+        value = "gateway"
+      },
+      {
+        name  = "APP_ID"
+        value = tostring(agyn_app.telegram.id)
+      },
+      {
+        name  = "TELEGRAM_BASE_URL"
+        value = "https://api.telegram.org"
+      },
+      {
+        name  = "TELEGRAM_POLL_TIMEOUT"
+        value = "25s"
+      },
+    ]
+  })
+
   k8s_runner_values = yamlencode({
     replicaCount     = 1
     fullnameOverride = "k8s-runner"
@@ -194,10 +292,25 @@ resource "agyn_app" "reminders" {
   permissions     = ["thread:write"]
 }
 
+resource "agyn_app" "telegram" {
+  organization_id = agyn_organization.platform.id
+  slug            = "telegram"
+  name            = "Telegram Connector"
+  description     = "Telegram connector for threads"
+  visibility      = "public"
+  permissions     = ["thread:create", "thread:write", "participant:add"]
+}
+
 resource "agyn_app_installation" "reminders" {
   app_id          = agyn_app.reminders.id
   organization_id = agyn_organization.platform.id
   slug            = "reminders"
+}
+
+resource "agyn_app_installation" "telegram" {
+  app_id          = agyn_app.telegram.id
+  organization_id = agyn_organization.platform.id
+  slug            = "telegram"
 }
 
 resource "kubernetes_secret_v1" "reminders_service_token" {
@@ -210,6 +323,19 @@ resource "kubernetes_secret_v1" "reminders_service_token" {
 
   data = {
     token = agyn_app.reminders.service_token
+  }
+}
+
+resource "kubernetes_secret_v1" "telegram_connector_service_token" {
+  metadata {
+    name      = "telegram-connector-service-token"
+    namespace = var.platform_namespace
+  }
+
+  type = "Opaque"
+
+  data = {
+    token = agyn_app.telegram.service_token
   }
 }
 
@@ -285,6 +411,98 @@ resource "argocd_application" "reminders" {
 
       helm {
         values = local.reminders_values
+      }
+    }
+
+    destination {
+      server    = var.destination_server
+      namespace = var.platform_namespace
+    }
+
+    sync_policy {
+      automated {
+        prune       = true
+        self_heal   = true
+        allow_empty = false
+      }
+
+      sync_options = local.default_sync_options
+    }
+  }
+}
+
+resource "argocd_application" "telegram_connector_db" {
+  wait = true
+
+  metadata {
+    name      = "telegram-connector-db"
+    namespace = "argocd"
+    annotations = {
+      "argocd.argoproj.io/sync-wave" = "7"
+    }
+  }
+
+  spec {
+    project = "default"
+
+    source {
+      repo_url        = local.postgres_chart_repo_host
+      chart           = local.postgres_chart_name
+      target_revision = var.postgres_chart_version
+
+      helm {
+        values = local.telegram_connector_db_values
+      }
+    }
+
+    destination {
+      server    = var.destination_server
+      namespace = var.platform_namespace
+    }
+
+    sync_policy {
+      # DB apps always use automated sync with prune disabled for stateful safety.
+      automated {
+        prune       = false
+        self_heal   = true
+        allow_empty = false
+      }
+
+      sync_options = local.postgres_sync_options
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
+resource "argocd_application" "telegram_connector" {
+  depends_on = [
+    argocd_application.telegram_connector_db,
+    kubernetes_secret_v1.telegram_connector_service_token,
+  ]
+
+  metadata {
+    name      = "telegram-connector"
+    namespace = "argocd"
+    annotations = {
+      "argocd.argoproj.io/sync-wave" = "30"
+    }
+  }
+
+  spec {
+    project = "default"
+
+    source {
+      repo_url        = local.platform_chart_repo_host
+      chart           = local.telegram_connector_chart_name
+      target_revision = var.telegram_connector_chart_version
+
+      helm {
+        values = local.telegram_connector_values
       }
     }
 

--- a/stacks/apps/main.tf
+++ b/stacks/apps/main.tf
@@ -137,9 +137,6 @@ locals {
       tag        = local.resolved_telegram_connector_image_tag
       pullPolicy = "IfNotPresent"
     }
-    securityContext = {
-      runAsNonRoot = false
-    }
     extraVolumes = [
       {
         name     = "ziti-identity"

--- a/stacks/apps/outputs.tf
+++ b/stacks/apps/outputs.tf
@@ -7,6 +7,7 @@ output "app_installation_ids" {
   description = "App installation IDs keyed by slug"
   value = {
     reminders = agyn_app_installation.reminders.id
+    telegram  = agyn_app_installation.telegram.id
   }
 }
 
@@ -14,6 +15,7 @@ output "app_ids" {
   description = "App IDs keyed by slug"
   value = {
     reminders = agyn_app.reminders.id
+    telegram  = agyn_app.telegram.id
   }
 }
 
@@ -21,6 +23,7 @@ output "app_identity_ids" {
   description = "App identity IDs keyed by slug"
   value = {
     reminders = agyn_app.reminders.identity_id
+    telegram  = agyn_app.telegram.identity_id
   }
 }
 
@@ -36,6 +39,8 @@ output "argocd_app_names" {
   value = [
     argocd_application.reminders_db.metadata[0].name,
     argocd_application.reminders.metadata[0].name,
+    argocd_application.telegram_connector_db.metadata[0].name,
+    argocd_application.telegram_connector.metadata[0].name,
     argocd_application.k8s_runner.metadata[0].name,
   ]
 }
@@ -45,6 +50,8 @@ output "argocd_app_ids" {
   value = [
     argocd_application.reminders_db.id,
     argocd_application.reminders.id,
+    argocd_application.telegram_connector_db.id,
+    argocd_application.telegram_connector.id,
     argocd_application.k8s_runner.id,
   ]
 }

--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -82,3 +82,28 @@ variable "reminders_db_pvc_size" {
   description = "Persistent volume claim size for the reminders PostgreSQL primary"
   default     = "5Gi"
 }
+
+variable "telegram_connector_chart_version" {
+  type        = string
+  description = "Version of the telegram-connector Helm chart published to GHCR"
+  default     = "0.1.1"
+}
+
+variable "telegram_connector_image_tag" {
+  type        = string
+  description = "Optional override for the telegram-connector image tag"
+  default     = ""
+}
+
+variable "telegram_connector_db_password" {
+  type        = string
+  description = "Password for the telegram-connector PostgreSQL database user"
+  default     = "telegram"
+  sensitive   = true
+}
+
+variable "telegram_connector_db_pvc_size" {
+  type        = string
+  description = "Persistent volume claim size for the telegram-connector PostgreSQL primary"
+  default     = "5Gi"
+}

--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -86,7 +86,7 @@ variable "reminders_db_pvc_size" {
 variable "telegram_connector_chart_version" {
   type        = string
   description = "Version of the telegram-connector Helm chart published to GHCR"
-  default     = "0.1.1"
+  default     = "0.1.2"
 }
 
 variable "telegram_connector_image_tag" {


### PR DESCRIPTION
## Summary
- add telegram connector app, service token, and ArgoCD apps in stacks/apps
- wire telegram connector Helm values for envs, DB settings, and image tag defaults
- extend apps outputs for telegram IDs and ArgoCD apps

## Testing
- terraform fmt -recursive
- terraform -chdir=stacks/apps validate
- ./apply.sh -y
- kubectl --kubeconfig stacks/k8s/.kube/agyn-local-kubeconfig.yaml -n argocd get application telegram-connector -o jsonpath='{.status.sync.status} {.status.health.status}'
- kubectl --kubeconfig stacks/k8s/.kube/agyn-local-kubeconfig.yaml -n argocd get application telegram-connector-db -o jsonpath='{.status.sync.status} {.status.health.status}'

Closes #375