### PR TITLE
refactor(platform): rename tenants to organizations

### DIFF
--- a/apply.sh
+++ b/apply.sh
@@ -477,7 +477,7 @@ run_stack "platform"
 step_end "stack:platform"
 
 echo "=== Waiting for platform ArgoCD applications to sync ==="
-for app in gateway apps runners; do
+for app in organizations gateway apps runners; do
   echo "--- Waiting for ${app} ---"
   synced=0
   for i in $(seq 1 60); do

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -352,25 +352,25 @@ locals {
     }
   })
 
-  tenants_db_values = yamlencode({
-    fullnameOverride = "tenants-db"
+  organizations_db_values = yamlencode({
+    fullnameOverride = "organizations-db"
     postgres = {
-      database = "tenants"
-      username = "tenants"
-      password = var.tenants_db_password
+      database = "organizations"
+      username = "organizations"
+      password = var.organizations_db_password
       pgdata   = "/var/lib/postgresql/data/pgdata"
     }
     persistence = {
-      size                    = var.tenants_db_pvc_size
+      size                    = var.organizations_db_pvc_size
       mountPath               = "/var/lib/postgresql/data"
       volumeClaimTemplateName = "data"
     }
     probes = {
       readiness = {
-        execCommand = ["pg_isready", "-U", "tenants", "-d", "tenants"]
+        execCommand = ["pg_isready", "-U", "organizations", "-d", "organizations"]
       }
       liveness = {
-        execCommand = ["pg_isready", "-U", "tenants", "-d", "tenants"]
+        execCommand = ["pg_isready", "-U", "organizations", "-d", "organizations"]
       }
     }
   })
@@ -714,7 +714,7 @@ locals {
   })
 
   organizations_values = yamlencode({
-    fullnameOverride = "tenants"
+    fullnameOverride = "organizations"
     image = {
       repository = "ghcr.io/agynio/organizations"
       tag        = local.resolved_organizations_image_tag
@@ -723,7 +723,7 @@ locals {
     env = [
       {
         name  = "DATABASE_URL"
-        value = format("postgresql://tenants:%s@tenants-db:5432/tenants?sslmode=disable", var.tenants_db_password)
+        value = format("postgresql://organizations:%s@organizations-db:5432/organizations?sslmode=disable", var.organizations_db_password)
       },
     ]
   })
@@ -1908,30 +1908,6 @@ resource "kubernetes_service_v1" "files_db" {
   }
 }
 
-resource "kubernetes_service_v1" "organizations_alias" {
-  metadata {
-    name      = "organizations"
-    namespace = kubernetes_namespace.platform.metadata[0].name
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform"
-    }
-  }
-
-  spec {
-    selector = {
-      "app.kubernetes.io/name"     = "organizations"
-      "app.kubernetes.io/instance" = "tenants"
-    }
-
-    port {
-      name        = "grpc"
-      port        = 50051
-      target_port = "grpc"
-      protocol    = "TCP"
-    }
-  }
-}
-
 resource "kubernetes_stateful_set_v1" "files_db" {
   metadata {
     name      = "files-db"
@@ -2595,12 +2571,12 @@ resource "argocd_application" "expose_db" {
   }
 }
 
-resource "argocd_application" "tenants_db" {
+resource "argocd_application" "organizations_db" {
   depends_on = [argocd_repository.ghcr]
   wait       = true
 
   metadata {
-    name      = "tenants-db"
+    name      = "organizations-db"
     namespace = "argocd"
     annotations = {
       "argocd.argoproj.io/sync-wave" = "8"
@@ -2616,7 +2592,7 @@ resource "argocd_application" "tenants_db" {
       target_revision = var.postgres_chart_version
 
       helm {
-        values = local.tenants_db_values
+        values = local.organizations_db_values
       }
     }
 
@@ -3629,14 +3605,14 @@ resource "argocd_application" "expose" {
   }
 }
 
-resource "argocd_application" "tenants" {
+resource "argocd_application" "organizations" {
   depends_on = [
     argocd_repository.ghcr,
-    argocd_application.tenants_db,
+    argocd_application.organizations_db,
     argocd_application.authorization,
   ]
   metadata {
-    name      = "tenants"
+    name      = "organizations"
     namespace = "argocd"
     annotations = {
       "argocd.argoproj.io/sync-wave" = "17"

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -512,10 +512,10 @@ variable "ziti_management_db_password" {
   sensitive   = true
 }
 
-variable "tenants_db_password" {
+variable "organizations_db_password" {
   type        = string
-  description = "Password for the tenants PostgreSQL database user"
-  default     = "tenants"
+  description = "Password for the organizations PostgreSQL database user"
+  default     = "organizations"
   sensitive   = true
 }
 
@@ -557,9 +557,9 @@ variable "expose_db_pvc_size" {
   default     = "5Gi"
 }
 
-variable "tenants_db_pvc_size" {
+variable "organizations_db_pvc_size" {
   type        = string
-  description = "Persistent volume claim size for the tenants PostgreSQL primary"
+  description = "Persistent volume claim size for the organizations PostgreSQL primary"
   default     = "5Gi"
 }
 


### PR DESCRIPTION
## Summary
- rename tenants DB/app resources to organizations
- remove the tenants alias service and wait for organizations during bootstrap apply

## Issue
- https://github.com/agynio/bootstrap/issues/377
- Ref: #377