### PR TITLE
chore(platform): bump threads chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agents_orchestrator_chart_version" {
 variable "threads_chart_version" {
   type        = string
   description = "Version of the threads Helm chart published to GHCR"
-  default     = "0.4.6"
+  default     = "0.4.8"
 }
 
 variable "metering_chart_version" {


### PR DESCRIPTION
## Summary
- bump threads chart default to v0.4.8 for the latest Threads release

## Testing
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh

#67