### PR TITLE
Bump agents chart to 0.7.1

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -87,7 +87,7 @@ variable "postgres_chart_version" {
 variable "agents_chart_version" {
   type        = string
   description = "Version of the agents Helm chart published to GHCR"
-  default     = "0.7.0"
+  default     = "0.7.1"
 }
 
 variable "ziti_management_chart_version" {


### PR DESCRIPTION
## Summary
- bump agents chart default to 0.7.1

## Testing
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh
- ./apply.sh -y
- .github/scripts/verify_platform_health.sh

## Issue
- https://github.com/agynio/architecture/issues/133
- Refs #133