### PR TITLE
chore(platform): bump chat v0.3.1

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -232,7 +232,7 @@ variable "tracing_image_tag" {
 variable "chat_chart_version" {
   type        = string
   description = "Version of the chat Helm chart published to GHCR"
-  default     = "0.3.0"
+  default     = "0.3.1"
 }
 
 variable "chat_image_tag" {


### PR DESCRIPTION
## Summary
- bump chat chart default to 0.3.1 (includes identity metadata forwarding)

## Testing
- terraform fmt -recursive -check
- terraform -chdir=stacks/platform validate
- terraform -chdir=stacks/platform apply -auto-approve
- devspace run-pipeline e2e (chat)

Refs #385