### PR TITLE
chore(bootstrap): bump tracing and agents

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -57,7 +57,7 @@ variable "metering_chart_version" {
 variable "tracing_chart_version" {
   type        = string
   description = "Version of the tracing Helm chart published to GHCR"
-  default     = "0.3.1"
+  default     = "0.3.3"
 }
 
 variable "token_counting_chart_version" {
@@ -87,7 +87,7 @@ variable "postgres_chart_version" {
 variable "agents_chart_version" {
   type        = string
   description = "Version of the agents Helm chart published to GHCR"
-  default     = "0.7.1"
+  default     = "0.7.2"
 }
 
 variable "ziti_management_chart_version" {


### PR DESCRIPTION
## Summary
- bump tracing chart version to 0.3.3
- bump agents chart version to 0.7.2

## Testing
- terraform fmt stacks/platform/variables.tf
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh

Refs agynio/architecture#136