### PR TITLE
chore(apps): bump k8s-runner chart

### DIFF
--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -61,7 +61,7 @@ variable "reminders_image_tag" {
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.10.4"
+  default     = "0.10.5"
 }
 
 variable "k8s_runner_image_tag" {


### PR DESCRIPTION
## Summary
- bump k8s-runner chart default to 0.10.5

## Testing
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh
- shellcheck apply.sh install-ca-cert.sh
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

## Related
- Fixes #392