### PR TITLE
Bump chart defaults for degraded-thread rollout

### DIFF
--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -86,7 +86,7 @@ variable "reminders_db_pvc_size" {
 variable "telegram_connector_chart_version" {
   type        = string
   description = "Version of the telegram-connector Helm chart published to GHCR"
-  default     = "0.1.2"
+  default     = "0.1.3"
 }
 
 variable "telegram_connector_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -39,13 +39,13 @@ variable "gateway_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.9"
+  default     = "0.13.10"
 }
 
 variable "threads_chart_version" {
   type        = string
   description = "Version of the threads Helm chart published to GHCR"
-  default     = "0.4.8"
+  default     = "0.4.9"
 }
 
 variable "metering_chart_version" {
@@ -135,7 +135,7 @@ variable "apps_chart_version" {
 variable "chat_app_chart_version" {
   type        = string
   description = "Version of the chat-app Helm chart published to GHCR"
-  default     = "0.4.4"
+  default     = "0.4.5"
 }
 
 variable "chat_app_image_tag" {
@@ -147,7 +147,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.9.2"
+  default     = "0.9.3"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump platform chart defaults for agents-orchestrator, threads, chat-app, and console-app
- bump apps telegram-connector chart default

## Testing
- terraform fmt -recursive
- bash -n apply.sh install-ca-cert.sh
- shellcheck apply.sh install-ca-cert.sh
- terraform -chdir=stacks/platform init
- terraform -chdir=stacks/platform validate
- terraform -chdir=stacks/apps init
- terraform -chdir=stacks/apps validate

Closes #394