### PR TITLE
chore(platform): bump token-counting chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -63,7 +63,7 @@ variable "tracing_chart_version" {
 variable "token_counting_chart_version" {
   type        = string
   description = "Version of the token-counting Helm chart published to GHCR"
-  default     = "0.3.1"
+  default     = "0.3.2"
 }
 
 variable "notifications_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -63,7 +63,7 @@ variable "tracing_chart_version" {
 variable "token_counting_chart_version" {
   type        = string
   description = "Version of the token-counting Helm chart published to GHCR"
-  default     = "0.3.0"
+  default     = "0.3.1"
 }
 
 variable "notifications_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -63,7 +63,7 @@ variable "tracing_chart_version" {
 variable "token_counting_chart_version" {
   type        = string
   description = "Version of the token-counting Helm chart published to GHCR"
-  default     = "0.2.0"
+  default     = "0.3.0"
 }
 
 variable "notifications_chart_version" {


### PR DESCRIPTION
## Summary
- bump token-counting Helm chart default version to 0.3.0

## Testing
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh
- shellcheck apply.sh install-ca-cert.sh

Refs: agynio/token-counting#11