### PR TITLE
Bump tracing app chart to v0.2.3

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1428,6 +1428,24 @@ locals {
         mountPath = "/etc/nginx/conf.d"
       }
     ]
+    env = [
+      {
+        name  = "API_BASE_URL"
+        value = "/api"
+      },
+      {
+        name  = "OIDC_AUTHORITY"
+        value = var.oidc_issuer_url
+      },
+      {
+        name  = "OIDC_CLIENT_ID"
+        value = var.console_app_oidc_client_id
+      },
+      {
+        name  = "OIDC_SCOPE"
+        value = "openid profile email offline_access"
+      }
+    ]
   })
 }
 

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -184,7 +184,7 @@ variable "oidc_client_secret" {
 variable "tracing_app_chart_version" {
   type        = string
   description = "Version of the tracing-app Helm chart published to GHCR"
-  default     = "0.2.2"
+  default     = "0.2.3"
 }
 
 variable "tracing_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump tracing-app chart default to v0.2.3
- add tracing-app env configuration for API base URL and OIDC

## Testing
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh
- shellcheck apply.sh install-ca-cert.sh

Refs #397