### PR TITLE
Bump console-app chart version to 0.10.0

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -147,7 +147,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.9.3"
+  default     = "0.10.0"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump console-app chart default to 0.10.0

## Testing
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh
- shellcheck apply.sh install-ca-cert.sh

Closes #406