### PR TITLE
Bump console-app chart to 0.10.1

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -147,7 +147,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.9.3"
+  default     = "0.10.1"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump console-app Helm chart default to 0.10.1
- keep platform stack defaults aligned with latest console-app release

## Testing
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh
- shellcheck apply.sh install-ca-cert.sh
- terraform -chdir=stacks/platform validate

## Issue
- #407