### PR TITLE
chore: bump k8s-runner chart version

### DIFF
--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -61,7 +61,7 @@ variable "reminders_image_tag" {
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.10.9"
+  default     = "0.10.10"
 }
 
 variable "k8s_runner_image_tag" {


### PR DESCRIPTION
## Summary
- bump k8s-runner Helm chart default to 0.10.10

## Testing
- ./apply.sh -y
- .github/scripts/verify_platform_health.sh
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh
- shellcheck apply.sh install-ca-cert.sh

Fixes #399