### PR TITLE
chore(platform): bump ziti management chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -93,7 +93,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.10.8"
+  default     = "0.10.9"
 }
 
 variable "users_chart_version" {


### PR DESCRIPTION
## Summary
- bump ziti-management chart default to 0.10.9

## Testing
- bash -n apply.sh install-ca-cert.sh
- shellcheck apply.sh install-ca-cert.sh
- terraform fmt -check -recursive

Relates to #414