### PR TITLE
chore: bump telegram connector chart version

### DIFF
--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -86,7 +86,7 @@ variable "reminders_db_pvc_size" {
 variable "telegram_connector_chart_version" {
   type        = string
   description = "Version of the telegram-connector Helm chart published to GHCR"
-  default     = "0.1.3"
+  default     = "0.1.4"
 }
 
 variable "telegram_connector_image_tag" {


### PR DESCRIPTION
## Summary
- bump telegram-connector chart default to 0.1.4

## Testing
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh
- shellcheck apply.sh install-ca-cert.sh
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Refs #413