### PR TITLE
feat(platform): add tracing app OIDC client

### DIFF
--- a/apply.sh
+++ b/apply.sh
@@ -24,6 +24,7 @@ Environment variables:
   PORT    Override the ingress port (default: 2496)
   OIDC_ISSUER_URL     Override the OIDC issuer URL (default: https://mockauth.dev/r/301ebb13-15a8-48f4-baac-e3fa25be29fc/oidc)
   OIDC_CLIENT_ID      Override the OIDC client ID (default: client_MU95KU3gHQf5Ir7p)
+  TRACING_APP_OIDC_CLIENT_ID  Override the tracing-app OIDC client ID (default: reuse console-app)
   OIDC_CLIENT_SECRET  Override the OIDC client secret (default: XPKka2i9uzISrKZ95zxli8sY51BK4eTJ)
   ADMIN_OIDC_SUBJECT  Optional OIDC subject for the bootstrap admin user (default: admin@agyn.io)
   GHCR_USERNAME        Optional GHCR username for private OCI charts
@@ -135,6 +136,11 @@ else
   echo "OIDC client ID provided via OIDC_CLIENT_ID environment variable: ${oidc_client_id}"
 fi
 
+tracing_app_oidc_client_id="${TRACING_APP_OIDC_CLIENT_ID:-}"
+if [[ -n "${tracing_app_oidc_client_id}" ]]; then
+  echo "Tracing app OIDC client ID provided via TRACING_APP_OIDC_CLIENT_ID environment variable: ${tracing_app_oidc_client_id}"
+fi
+
 oidc_client_secret="${OIDC_CLIENT_SECRET:-}"
 if [[ -z "${oidc_client_secret}" ]]; then
   if [[ "${auto_approve}" == "true" ]]; then
@@ -181,6 +187,7 @@ run_stack() {
       -var "oidc_issuer_url=${oidc_issuer_url}"
       -var "oidc_client_id=${oidc_client_id}"
       -var "oidc_client_secret=${oidc_client_secret}"
+      -var "tracing_app_oidc_client_id=${tracing_app_oidc_client_id}"
       -var "ghcr_username=${ghcr_username}"
       -var "ghcr_token=${ghcr_token}"
     )

--- a/apply.sh
+++ b/apply.sh
@@ -24,7 +24,7 @@ Environment variables:
   PORT    Override the ingress port (default: 2496)
   OIDC_ISSUER_URL     Override the OIDC issuer URL (default: https://mockauth.dev/r/301ebb13-15a8-48f4-baac-e3fa25be29fc/oidc)
   OIDC_CLIENT_ID      Override the OIDC client ID (default: client_MU95KU3gHQf5Ir7p)
-  TRACING_APP_OIDC_CLIENT_ID  Override the tracing-app OIDC client ID (default: reuse console-app)
+  TRACING_APP_OIDC_CLIENT_ID  Override the tracing-app OIDC client ID (default: client_tzqVFAYTvpkfUzy5)
   OIDC_CLIENT_SECRET  Override the OIDC client secret (default: XPKka2i9uzISrKZ95zxli8sY51BK4eTJ)
   ADMIN_OIDC_SUBJECT  Optional OIDC subject for the bootstrap admin user (default: admin@agyn.io)
   GHCR_USERNAME        Optional GHCR username for private OCI charts
@@ -187,10 +187,13 @@ run_stack() {
       -var "oidc_issuer_url=${oidc_issuer_url}"
       -var "oidc_client_id=${oidc_client_id}"
       -var "oidc_client_secret=${oidc_client_secret}"
-      -var "tracing_app_oidc_client_id=${tracing_app_oidc_client_id}"
       -var "ghcr_username=${ghcr_username}"
       -var "ghcr_token=${ghcr_token}"
     )
+
+    if [[ -n "${tracing_app_oidc_client_id}" ]]; then
+      apply_cmd+=(-var "tracing_app_oidc_client_id=${tracing_app_oidc_client_id}")
+    fi
   fi
 
   if [[ "${stack}" == "apps" && -n "${admin_oidc_subject}" ]]; then

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -8,7 +8,7 @@ locals {
   resolved_chat_app_image_tag            = trimspace(var.chat_app_image_tag) != "" ? var.chat_app_image_tag : var.chat_app_chart_version
   resolved_console_app_image_tag         = trimspace(var.console_app_image_tag) != "" ? var.console_app_image_tag : var.console_app_chart_version
   resolved_tracing_app_image_tag         = trimspace(var.tracing_app_image_tag) != "" ? var.tracing_app_image_tag : var.tracing_app_chart_version
-  resolved_tracing_app_oidc_client_id    = trimspace(var.tracing_app_oidc_client_id) != "" ? var.tracing_app_oidc_client_id : var.console_app_oidc_client_id
+  resolved_tracing_app_oidc_client_id    = trimspace(var.tracing_app_oidc_client_id) != "" ? trimspace(var.tracing_app_oidc_client_id) : var.console_app_oidc_client_id
   resolved_files_image_tag               = trimspace(var.files_image_tag) != "" ? var.files_image_tag : var.files_chart_version
   resolved_media_proxy_image_tag         = trimspace(var.media_proxy_image_tag) != "" ? var.media_proxy_image_tag : var.media_proxy_chart_version
   resolved_llm_image_tag                 = trimspace(var.llm_image_tag) != "" ? var.llm_image_tag : format("v%s", var.llm_chart_version)
@@ -1361,7 +1361,7 @@ locals {
       },
       {
         name  = "OIDC_CLIENT_ID"
-        value = local.resolved_tracing_app_oidc_client_id
+        value = var.console_app_oidc_client_id
       },
       {
         name  = "OIDC_SCOPE"
@@ -1440,7 +1440,7 @@ locals {
       },
       {
         name  = "OIDC_CLIENT_ID"
-        value = var.console_app_oidc_client_id
+        value = local.resolved_tracing_app_oidc_client_id
       },
       {
         name  = "OIDC_SCOPE"

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -8,7 +8,7 @@ locals {
   resolved_chat_app_image_tag            = trimspace(var.chat_app_image_tag) != "" ? var.chat_app_image_tag : var.chat_app_chart_version
   resolved_console_app_image_tag         = trimspace(var.console_app_image_tag) != "" ? var.console_app_image_tag : var.console_app_chart_version
   resolved_tracing_app_image_tag         = trimspace(var.tracing_app_image_tag) != "" ? var.tracing_app_image_tag : var.tracing_app_chart_version
-  resolved_tracing_app_oidc_client_id    = trimspace(var.tracing_app_oidc_client_id) != "" ? trimspace(var.tracing_app_oidc_client_id) : var.console_app_oidc_client_id
+  resolved_tracing_app_oidc_client_id    = trimspace(var.tracing_app_oidc_client_id)
   resolved_files_image_tag               = trimspace(var.files_image_tag) != "" ? var.files_image_tag : var.files_chart_version
   resolved_media_proxy_image_tag         = trimspace(var.media_proxy_image_tag) != "" ? var.media_proxy_image_tag : var.media_proxy_chart_version
   resolved_llm_image_tag                 = trimspace(var.llm_image_tag) != "" ? var.llm_image_tag : format("v%s", var.llm_chart_version)

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -8,6 +8,7 @@ locals {
   resolved_chat_app_image_tag            = trimspace(var.chat_app_image_tag) != "" ? var.chat_app_image_tag : var.chat_app_chart_version
   resolved_console_app_image_tag         = trimspace(var.console_app_image_tag) != "" ? var.console_app_image_tag : var.console_app_chart_version
   resolved_tracing_app_image_tag         = trimspace(var.tracing_app_image_tag) != "" ? var.tracing_app_image_tag : var.tracing_app_chart_version
+  resolved_tracing_app_oidc_client_id    = trimspace(var.tracing_app_oidc_client_id) != "" ? var.tracing_app_oidc_client_id : var.console_app_oidc_client_id
   resolved_files_image_tag               = trimspace(var.files_image_tag) != "" ? var.files_image_tag : var.files_chart_version
   resolved_media_proxy_image_tag         = trimspace(var.media_proxy_image_tag) != "" ? var.media_proxy_image_tag : var.media_proxy_chart_version
   resolved_llm_image_tag                 = trimspace(var.llm_image_tag) != "" ? var.llm_image_tag : format("v%s", var.llm_chart_version)
@@ -1360,7 +1361,7 @@ locals {
       },
       {
         name  = "OIDC_CLIENT_ID"
-        value = var.console_app_oidc_client_id
+        value = local.resolved_tracing_app_oidc_client_id
       },
       {
         name  = "OIDC_SCOPE"

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -174,6 +174,12 @@ variable "console_app_oidc_client_id" {
   default     = "client_4XUh4_1VfUzpfYkN"
 }
 
+variable "tracing_app_oidc_client_id" {
+  type        = string
+  description = "OIDC client ID for the tracing-app (public client); leave empty to reuse console-app"
+  default     = ""
+}
+
 variable "oidc_client_secret" {
   type        = string
   description = "OIDC client secret (dev/QA only - production should use a K8s Secret)"

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -176,8 +176,8 @@ variable "console_app_oidc_client_id" {
 
 variable "tracing_app_oidc_client_id" {
   type        = string
-  description = "OIDC client ID for the tracing-app (public client); leave empty to reuse console-app"
-  default     = ""
+  description = "OIDC client ID for the tracing-app (public client)"
+  default     = "client_tzqVFAYTvpkfUzy5"
 }
 
 variable "oidc_client_secret" {


### PR DESCRIPTION
## Summary
- add tracing-app OIDC client id variable with console fallback
- wire tracing-app env to resolved tracing-app client id
- allow apply.sh override via TRACING_APP_OIDC_CLIENT_ID

## Testing
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh
- shellcheck apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh
- terraform -chdir=stacks/platform validate

Closes #420