### PR TITLE
chore(platform): bump chat-app chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -135,7 +135,7 @@ variable "apps_chart_version" {
 variable "chat_app_chart_version" {
   type        = string
   description = "Version of the chat-app Helm chart published to GHCR"
-  default     = "0.4.5"
+  default     = "0.4.6"
 }
 
 variable "chat_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump chat-app Helm chart version to 0.4.6

## Testing
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh
- shellcheck apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Closes #423