### PR TITLE
chore(platform): bump chart versions

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -33,7 +33,7 @@ variable "ghcr_token" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.22.2"
+  default     = "0.22.4"
 }
 
 variable "agents_orchestrator_chart_version" {
@@ -147,7 +147,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.10.1"
+  default     = "0.10.2"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump gateway chart default to 0.22.4
- bump console-app chart default to 0.10.2

## Testing
- tofu fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh
- shellcheck apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh

Fixes #428