### PR TITLE
chore(platform): bump ziti-management chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -93,7 +93,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.10.9"
+  default     = "0.10.10"
 }
 
 variable "users_chart_version" {


### PR DESCRIPTION
## Summary
- bump ziti-management Helm chart default to 0.10.10 for bootstrap deployments

## Testing
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh
- shellcheck apply.sh install-ca-cert.sh
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh

## Issue
Refs #414