### PR TITLE
chore(platform): bump runners chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -123,7 +123,7 @@ variable "identity_chart_version" {
 variable "runners_chart_version" {
   type        = string
   description = "Version of the runners Helm chart published to GHCR"
-  default     = "0.5.4"
+  default     = "0.5.5"
 }
 
 variable "apps_chart_version" {


### PR DESCRIPTION
## Summary
- bump runners_chart_version default to 0.5.5

## Testing
- terraform fmt -check -recursive

Refs #434