### PR TITLE
Bump agents orchestrator chart to 0.13.12

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -39,7 +39,7 @@ variable "gateway_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.11"
+  default     = "0.13.12"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
## Summary
- bump agents-orchestrator chart default to 0.13.12

## Testing
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh
- shellcheck apply.sh install-ca-cert.sh
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh

Refs #441