### PR TITLE
fix(platform): bump console app chart

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -2891,15 +2891,19 @@ resource "argocd_application" "gateway" {
     source {
       repo_url        = "ghcr.io"
       chart           = "agynio/charts/gateway"
-      target_revision = "0.3.0"
+      target_revision = "0.5.0"
 
       helm {
         values = yamlencode({
           gateway = {
-            platformBaseUrl  = "http://platform-server.${var.platform_namespace}.svc.cluster.local:3010"
-            teamsServiceAddr = "teams.${var.platform_namespace}.svc.cluster.local:50051"
+            platformBaseUrl   = "http://platform-server.${var.platform_namespace}.svc.cluster.local:3010"
+            secretsGrpcTarget = "secrets.${var.platform_namespace}.svc.cluster.local:50051"
+            teamsGrpcTarget   = "teams.${var.platform_namespace}.svc.cluster.local:50051"
+            filesGrpcTarget   = "files.${var.platform_namespace}.svc.cluster.local:50051"
+            llmGrpcTarget     = "llm.${var.platform_namespace}.svc.cluster.local:50051"
+            llmHttpBaseUrl    = "http://llm.${var.platform_namespace}.svc.cluster.local:8080"
             image = {
-              tag = "0.3.0"
+              tag = "0.5.0"
             }
           }
         })

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -147,7 +147,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.10.3"
+  default     = "0.10.4"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump console-app chart version to 0.10.4 for the invite UX fix

## Testing
- terraform fmt -recursive
- terraform -chdir=stacks/platform init
- terraform -chdir=stacks/platform validate
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh
- shellcheck apply.sh install-ca-cert.sh
- bash -n .github/scripts/verify_platform_health.sh
- shellcheck .github/scripts/verify_platform_health.sh

Refs agynio/console-app#87
Refs agynio/console-app#85