### PR TITLE
chore(platform): bump tracing chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -190,7 +190,7 @@ variable "oidc_client_secret" {
 variable "tracing_app_chart_version" {
   type        = string
   description = "Version of the tracing-app Helm chart published to GHCR"
-  default     = "0.2.3"
+  default     = "0.2.4"
 }
 
 variable "tracing_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump tracing-app chart default to 0.2.4

## Testing
- terraform -chdir=/workspace/bootstrap fmt -check -recursive
- bash -n /workspace/bootstrap/apply.sh /workspace/bootstrap/install-ca-cert.sh /workspace/bootstrap/.github/scripts/verify_platform_health.sh
- shellcheck /workspace/bootstrap/apply.sh /workspace/bootstrap/install-ca-cert.sh /workspace/bootstrap/.github/scripts/verify_platform_health.sh
- setsid -f bash -c 'cd /workspace/bootstrap && TF_PLUGIN_TIMEOUT=300 ./apply.sh -y; echo $? > /tmp/bootstrap_apply_status' > /tmp/bootstrap_apply.log 2>&1

Refs #448