### PR TITLE
Bump chat app chart to 0.4.10

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -135,7 +135,7 @@ variable "apps_chart_version" {
 variable "chat_app_chart_version" {
   type        = string
   description = "Version of the chat-app Helm chart published to GHCR"
-  default     = "0.4.9"
+  default     = "0.4.10"
 }
 
 variable "chat_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump chat-app Helm chart default to 0.4.10

## Testing
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh
- shellcheck apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh

Refs #450