### PR TITLE
fix(platform): bump openfga module ref

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1450,11 +1450,11 @@ locals {
   })
 }
 
-# NOTE: The module ref (fcddc3a) must be updated in lockstep with
+# NOTE: The module ref (v0.5.2) must be updated in lockstep with
 # var.authorization_chart_version to ensure the provisioned FGA model
 # matches the model expected by the deployed Helm chart.
 module "openfga_authorization" {
-  source          = "github.com/agynio/authorization//terraform?ref=fcddc3a78916b038d597132580af167cb139414a"
+  source          = "github.com/agynio/authorization//terraform?ref=v0.5.2"
   openfga_api_url = local.openfga_api_url_external
 }
 

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1450,11 +1450,11 @@ locals {
   })
 }
 
-# NOTE: The module ref (v0.5.1) must be updated in lockstep with
+# NOTE: The module ref (fcddc3a) must be updated in lockstep with
 # var.authorization_chart_version to ensure the provisioned FGA model
 # matches the model expected by the deployed Helm chart.
 module "openfga_authorization" {
-  source          = "github.com/agynio/authorization//terraform?ref=v0.5.1"
+  source          = "github.com/agynio/authorization//terraform?ref=fcddc3a78916b038d597132580af167cb139414a"
   openfga_api_url = local.openfga_api_url_external
 }
 

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -629,7 +629,7 @@ variable "secrets_encryption_key" {
 variable "authorization_chart_version" {
   type        = string
   description = "Version of the authorization Helm chart published to GHCR"
-  default     = "0.5.1"
+  default     = "0.5.2"
 }
 
 variable "authorization_image_tag" {


### PR DESCRIPTION
## Summary
- bump OpenFGA authorization module ref to fcddc3a78916b038d597132580af167cb139414a for can_view_* relations
- keep module ref note in stacks/platform/main.tf in sync with authorization chart expectations

## Testing
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh
- shellcheck apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh

Fixes #456