### PR TITLE
chore(platform): bump agents-orchestrator chart to 0.13.13

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -39,7 +39,7 @@ variable "gateway_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.12"
+  default     = "0.13.13"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
Closes #356.

Bumps `agents_orchestrator_chart_version` default to `0.13.13` (post agents-orchestrator v0.13.13 release).