### PR TITLE
chore(platform): bump runners chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -123,7 +123,7 @@ variable "identity_chart_version" {
 variable "runners_chart_version" {
   type        = string
   description = "Version of the runners Helm chart published to GHCR"
-  default     = "0.5.5"
+  default     = "0.5.7"
 }
 
 variable "apps_chart_version" {


### PR DESCRIPTION
## Summary
- bump runners chart default to 0.5.7 for platform stack

## Testing
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh
- shellcheck apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh

Refs #459