### PR TITLE
fix(platform): set orchestrator admin id

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -816,6 +816,10 @@ locals {
       {
         name  = "RUNNERS_ADDRESS"
         value = "runners:50051"
+      },
+      {
+        name  = "CLUSTER_ADMIN_IDENTITY_ID"
+        value = local.cluster_admin_identity_id
       }
     ]
   })


### PR DESCRIPTION
## Summary
- wire CLUSTER_ADMIN_IDENTITY_ID into agents-orchestrator Helm values
- align orchestrator config with the OpenFGA cluster-admin tuple seed

## Testing
- terraform fmt -recursive
- terraform -chdir=stacks/platform validate

## Issue
- agynio/architecture#144