### PR TITLE
chore(platform): bump auth/runners charts

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1454,7 +1454,7 @@ locals {
 # var.authorization_chart_version to ensure the provisioned FGA model
 # matches the model expected by the deployed Helm chart.
 module "openfga_authorization" {
-  source          = "github.com/agynio/authorization//terraform?ref=v0.5.1"
+  source          = "github.com/agynio/authorization//terraform?ref=v0.5.2"
   openfga_api_url = local.openfga_api_url_external
 }
 

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -629,7 +629,7 @@ variable "secrets_encryption_key" {
 variable "authorization_chart_version" {
   type        = string
   description = "Version of the authorization Helm chart published to GHCR"
-  default     = "0.5.1"
+  default     = "0.5.2"
 }
 
 variable "authorization_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -123,7 +123,7 @@ variable "identity_chart_version" {
 variable "runners_chart_version" {
   type        = string
   description = "Version of the runners Helm chart published to GHCR"
-  default     = "0.5.5"
+  default     = "0.5.7"
 }
 
 variable "apps_chart_version" {


### PR DESCRIPTION
## Summary
- bump runners chart default to 0.5.7
- bump authorization chart defaults/module ref to 0.5.2

## Testing
- `terraform fmt -check -recursive`
- `bash -n apply.sh install-ca-cert.sh`
- `shellcheck apply.sh install-ca-cert.sh`
- `bash -n .github/scripts/verify_platform_health.sh`
- `shellcheck .github/scripts/verify_platform_health.sh`

#459