### PR TITLE
chore(platform): bump identity/org charts

### DIFF
--- a/apply.sh
+++ b/apply.sh
@@ -487,7 +487,7 @@ run_stack "platform"
 step_end "stack:platform"
 
 echo "=== Waiting for platform ArgoCD applications to sync ==="
-for app in organizations gateway apps runners; do
+for app in identity organizations gateway apps runners; do
   echo "--- Waiting for ${app} ---"
   synced=0
   for i in $(seq 1 60); do

--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -61,7 +61,7 @@ variable "reminders_image_tag" {
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.10.12"
+  default     = "0.10.13"
 }
 
 variable "k8s_runner_image_tag" {

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1450,7 +1450,7 @@ locals {
   })
 }
 
-# NOTE: The module ref (v0.5.1) must be updated in lockstep with
+# NOTE: The module ref (v0.5.2) must be updated in lockstep with
 # var.authorization_chart_version to ensure the provisioned FGA model
 # matches the model expected by the deployed Helm chart.
 module "openfga_authorization" {

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1454,7 +1454,7 @@ locals {
 # var.authorization_chart_version to ensure the provisioned FGA model
 # matches the model expected by the deployed Helm chart.
 module "openfga_authorization" {
-  source          = "github.com/agynio/authorization//terraform?ref=v0.5.1"
+  source          = "github.com/agynio/authorization//terraform?ref=v0.5.2"
   openfga_api_url = local.openfga_api_url_external
 }
 

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -629,7 +629,7 @@ variable "secrets_encryption_key" {
 variable "authorization_chart_version" {
   type        = string
   description = "Version of the authorization Helm chart published to GHCR"
-  default     = "0.5.1"
+  default     = "0.5.2"
 }
 
 variable "authorization_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -33,7 +33,7 @@ variable "ghcr_token" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.22.5"
+  default     = "0.22.7"
 }
 
 variable "agents_orchestrator_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agents_orchestrator_chart_version" {
 variable "threads_chart_version" {
   type        = string
   description = "Version of the threads Helm chart published to GHCR"
-  default     = "0.4.9"
+  default     = "0.4.10"
 }
 
 variable "metering_chart_version" {
@@ -57,7 +57,7 @@ variable "metering_chart_version" {
 variable "tracing_chart_version" {
   type        = string
   description = "Version of the tracing Helm chart published to GHCR"
-  default     = "0.3.3"
+  default     = "0.3.4"
 }
 
 variable "token_counting_chart_version" {
@@ -69,7 +69,7 @@ variable "token_counting_chart_version" {
 variable "notifications_chart_version" {
   type        = string
   description = "Version of the notifications Helm chart published to GHCR"
-  default     = "0.2.2"
+  default     = "0.2.5"
 }
 
 variable "notifications_redis_chart_version" {
@@ -135,7 +135,7 @@ variable "apps_chart_version" {
 variable "chat_app_chart_version" {
   type        = string
   description = "Version of the chat-app Helm chart published to GHCR"
-  default     = "0.4.12"
+  default     = "0.4.13"
 }
 
 variable "chat_app_image_tag" {
@@ -190,7 +190,7 @@ variable "oidc_client_secret" {
 variable "tracing_app_chart_version" {
   type        = string
   description = "Version of the tracing-app Helm chart published to GHCR"
-  default     = "0.2.5"
+  default     = "0.2.6"
 }
 
 variable "tracing_app_image_tag" {
@@ -238,7 +238,7 @@ variable "tracing_image_tag" {
 variable "chat_chart_version" {
   type        = string
   description = "Version of the chat Helm chart published to GHCR"
-  default     = "0.3.1"
+  default     = "0.3.3"
 }
 
 variable "chat_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -123,7 +123,7 @@ variable "identity_chart_version" {
 variable "runners_chart_version" {
   type        = string
   description = "Version of the runners Helm chart published to GHCR"
-  default     = "0.5.5"
+  default     = "0.5.7"
 }
 
 variable "apps_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -111,13 +111,13 @@ variable "expose_chart_version" {
 variable "organizations_chart_version" {
   type        = string
   description = "Version of the organizations Helm chart published to GHCR"
-  default     = "0.4.2"
+  default     = "0.4.3"
 }
 
 variable "identity_chart_version" {
   type        = string
   description = "Version of the identity Helm chart published to GHCR"
-  default     = "0.2.0"
+  default     = "0.2.1"
 }
 
 variable "runners_chart_version" {


### PR DESCRIPTION
## Summary
- bump organizations chart to 0.4.3
- bump identity chart to 0.2.1

## Testing
- terraform fmt stacks/platform/variables.tf
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh
- shellcheck apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh
- ./apply.sh -y

Refs #459