### PR TITLE
Bump organizations chart to 0.4.4

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -111,7 +111,7 @@ variable "expose_chart_version" {
 variable "organizations_chart_version" {
   type        = string
   description = "Version of the organizations Helm chart published to GHCR"
-  default     = "0.4.3"
+  default     = "0.4.4"
 }
 
 variable "identity_chart_version" {


### PR DESCRIPTION
## Summary
- bump organizations chart version to 0.4.4

## Testing
- bash -n .github/scripts/verify_platform_health.sh
- bash -n apply.sh install-ca-cert.sh
- shellcheck .github/scripts/verify_platform_health.sh
- shellcheck apply.sh install-ca-cert.sh
- terraform fmt -check -recursive
- ./apply.sh -y
- ./.github/scripts/verify_platform_health.sh

Closes #470