### PR TITLE
chore(bootstrap): bump gateway chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -33,7 +33,7 @@ variable "ghcr_token" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.22.7"
+  default     = "0.22.8"
 }
 
 variable "agents_orchestrator_chart_version" {


### PR DESCRIPTION
## Summary
- bump gateway chart default to 0.22.8 in stacks/platform/variables.tf

## Context
- References https://github.com/agynio/e2e/issues/68
- Unblocks Reminders app-proxy E2E by pulling gateway chart 0.22.8

## Testing & Lint
- terraform fmt -recursive
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh
- shellcheck apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh