### PR TITLE
chore(platform): bump agents chart to 0.7.3

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -87,7 +87,7 @@ variable "postgres_chart_version" {
 variable "agents_chart_version" {
   type        = string
   description = "Version of the agents Helm chart published to GHCR"
-  default     = "0.7.2"
+  default     = "0.7.3"
 }
 
 variable "ziti_management_chart_version" {


### PR DESCRIPTION
## Summary
- bump the platform agents chart default to 0.7.3

## Testing
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh
- shellcheck apply.sh install-ca-cert.sh

Closes #473