### PR TITLE
chore(platform): bump console identity

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -117,7 +117,7 @@ variable "organizations_chart_version" {
 variable "identity_chart_version" {
   type        = string
   description = "Version of the identity Helm chart published to GHCR"
-  default     = "0.2.1"
+  default     = "0.2.2"
 }
 
 variable "runners_chart_version" {
@@ -147,7 +147,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.10.5"
+  default     = "0.10.6"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump console-app chart default to 0.10.6
- bump identity chart default to 0.2.2

## Testing
- terraform fmt -check -recursive
- bash -n apply.sh install-ca-cert.sh
- shellcheck apply.sh install-ca-cert.sh
- terraform fmt -recursive
- terraform -chdir=stacks/platform init -backend=false
- terraform -chdir=stacks/platform validate

Ref #479