### PR TITLE
chore(platform): bump agents-orchestrator chart to 0.13.15

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -39,7 +39,7 @@ variable "gateway_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.14"
+  default     = "0.13.15"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
Closes #481.

Bumps `agents_orchestrator_chart_version` in `stacks/platform/variables.tf`:
- `0.13.14` -> `0.13.15`

This ships the agents-orchestrator fix for STARTING workloads getting stuck when `InspectWorkload` returns no containers but `state_running=true`.