### PR TITLE
chore(platform): bump notifications and gateway charts

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -33,7 +33,7 @@ variable "ghcr_token" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.22.8"
+  default     = "0.22.9"
 }
 
 variable "agents_orchestrator_chart_version" {
@@ -69,7 +69,7 @@ variable "token_counting_chart_version" {
 variable "notifications_chart_version" {
   type        = string
   description = "Version of the notifications Helm chart published to GHCR"
-  default     = "0.2.6"
+  default     = "0.2.7"
 }
 
 variable "notifications_redis_chart_version" {


### PR DESCRIPTION
## Summary
- bump gateway chart/image default to 0.22.9
- bump notifications chart/image default to 0.2.7

These releases contain the notification self-subscribe support needed for agent CLI `--wait` flows.

## Validation
- `git diff --check`
- `terraform fmt -check` not completed locally: terraform was not installed, and nix install is still building Terraform from source in this environment.

## Release workflow status at PR creation
- agynio/notifications v0.2.7: release succeeded
- agynio/gateway v0.22.9: release running
- agynio/agynd-cli v0.14.13: release succeeded
- agynio/agyn-cli v0.2.9: release running