### PR TITLE
chore(platform): bump gateway chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -33,7 +33,7 @@ variable "ghcr_token" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.22.8"
+  default     = "0.22.9"
 }
 
 variable "agents_orchestrator_chart_version" {


### PR DESCRIPTION
## Summary
- bump gateway_chart_version to 0.22.9

## Testing
- not run (version bump only)

## Issue
#29