### PR TITLE
chore(platform): bump chat-app chart to 0.4.14

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -135,7 +135,7 @@ variable "apps_chart_version" {
 variable "chat_app_chart_version" {
   type        = string
   description = "Version of the chat-app Helm chart published to GHCR"
-  default     = "0.4.13"
+  default     = "0.4.14"
 }
 
 variable "chat_app_image_tag" {


### PR DESCRIPTION
## Summary
- Bump chat-app Helm chart version from 0.4.13 to 0.4.14

## Release
- agynio/chat-app tag: v0.4.14
- Release workflow: https://github.com/agynio/chat-app/actions/runs/25637981766

## Test plan
- Not run (version-only bootstrap chart pin update).