### PR TITLE
chore(platform): bump chat-app chart to 0.4.15

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -135,7 +135,7 @@ variable "apps_chart_version" {
 variable "chat_app_chart_version" {
   type        = string
   description = "Version of the chat-app Helm chart published to GHCR"
-  default     = "0.4.14"
+  default     = "0.4.15"
 }
 
 variable "chat_app_image_tag" {


### PR DESCRIPTION
## Summary
- Bump chat-app Helm chart version from 0.4.14 to 0.4.15

## Release
- agynio/chat-app tag: v0.4.15
- Release workflow: https://github.com/agynio/chat-app/actions/runs/25642347857

## Test plan
- Not run (version-only bootstrap chart pin update).