### PR TITLE
chore(platform): bump gateway chart to 0.22.10

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -33,7 +33,7 @@ variable "ghcr_token" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.22.9"
+  default     = "0.22.10"
 }
 
 variable "agents_orchestrator_chart_version" {


### PR DESCRIPTION
Bumps the platform Gateway chart/image to 0.22.10, which includes the app proxy fix that derives the organization for agent identities instead of requiring agents to send x-organization-id. This unblocks agyn app reminders create-reminder from agent pods.