### PR TITLE
fix(apps): use published reminders image tag

### DIFF
--- a/.github/scripts/verify_platform_health.sh
+++ b/.github/scripts/verify_platform_health.sh
@@ -17,7 +17,7 @@ REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
 readonly KUBECONFIG_PATH="$REPO_ROOT/stacks/k8s/.kube/agyn-local-kubeconfig.yaml"
 ZITI_MGMT_ENDPOINT=${ZITI_MGMT_ENDPOINT:-}
 ZITI_OVERLAY_SERVICES=(gateway)
-ZITI_OVERLAY_ROLE_CHECKS=("runner-services")
+ZITI_OVERLAY_ROLE_CHECKS=("runner-services" "app-services")
 
 if [[ ! -f "$KUBECONFIG_PATH" ]]; then
   printf 'Unable to locate kubeconfig at %s\n' "$KUBECONFIG_PATH" >&2

--- a/stacks/apps/main.tf
+++ b/stacks/apps/main.tf
@@ -1,5 +1,5 @@
 locals {
-  resolved_reminders_image_tag          = trimspace(var.reminders_image_tag) != "" ? var.reminders_image_tag : format("v%s", var.reminders_chart_version)
+  resolved_reminders_image_tag          = trimspace(var.reminders_image_tag) != "" ? var.reminders_image_tag : var.reminders_chart_version
   resolved_k8s_runner_image_tag         = trimspace(var.k8s_runner_image_tag) != "" ? var.k8s_runner_image_tag : var.k8s_runner_chart_version
   resolved_telegram_connector_image_tag = trimspace(var.telegram_connector_image_tag) != "" ? var.telegram_connector_image_tag : var.telegram_connector_chart_version
   admin_oidc_subject                    = trimspace(var.admin_oidc_subject)


### PR DESCRIPTION
Fixes the Reminders deployment image tag. The reminders release workflow publishes semver image tags without a leading v (for example ghcr.io/agynio/reminders:0.2.0), but bootstrap rendered v0.2.0. That leaves the Reminders pod unable to start/bind app-reminders, which surfaces through Gateway as Ziti 'service has no terminators'. Also extends platform health verification to require an app-services terminator so this is caught in CI.