### PR TITLE
chore(apps): bump reminders chart to 0.2.1

### DIFF
--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -49,7 +49,7 @@ variable "postgres_chart_version" {
 variable "reminders_chart_version" {
   type        = string
   description = "Version of the reminders Helm chart published to GHCR"
-  default     = "0.2.0"
+  default     = "0.2.1"
 }
 
 variable "reminders_image_tag" {


### PR DESCRIPTION
Bumps Reminders to 0.2.1, which fixes the Helm chart rendering empty manifests by adding the missing service-base template wrappers. This should make Argo CD create the Reminders Deployment/Service/ServiceAccount resources instead of a synced empty app.