### PR TITLE
chore(apps): bump reminders chart to 0.2.3

### DIFF
--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -49,7 +49,7 @@ variable "postgres_chart_version" {
 variable "reminders_chart_version" {
   type        = string
   description = "Version of the reminders Helm chart published to GHCR"
-  default     = "0.2.1"
+  default     = "0.2.3"
 }
 
 variable "reminders_image_tag" {


### PR DESCRIPTION
Bumps Reminders to 0.2.3. This includes the 0.2.1 chart rendering fix and the app-proxy PascalCase route aliases for /CreateReminder, /CancelReminder, /ListReminders, and /GetReminder.