### PR TITLE
chore(apps): bump reminders chart to 0.2.4

### DIFF
--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -49,7 +49,7 @@ variable "postgres_chart_version" {
 variable "reminders_chart_version" {
   type        = string
   description = "Version of the reminders Helm chart published to GHCR"
-  default     = "0.2.3"
+  default     = "0.2.4"
 }
 
 variable "reminders_image_tag" {


### PR DESCRIPTION
Bumps Reminders to 0.2.4. This includes the app-side compatibility fix for agyn CLI app-proxy payload aliases: thread/delay/id in addition to canonical thread_id/delay_seconds/reminder_id.\n\nRelease: https://github.com/agynio/reminders/actions/runs/25696971096