### PR TITLE
chore(apps): bump reminders chart to 0.2.5

### DIFF
--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -49,7 +49,7 @@ variable "postgres_chart_version" {
 variable "reminders_chart_version" {
   type        = string
   description = "Version of the reminders Helm chart published to GHCR"
-  default     = "0.2.4"
+  default     = "0.2.5"
 }
 
 variable "reminders_image_tag" {


### PR DESCRIPTION
## Summary\n- Bump apps stack reminders Helm chart version from 0.2.4 to 0.2.5\n\n## Context\n- reminders v0.2.5 fixes SQLSTATE 42P08 reminder completion failures by casting reminder_status parameters\n\n## Verification\n- terraform fmt -check -recursive stacks/apps