### PR TITLE
Bump chat-app chart to 0.4.16

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -135,7 +135,7 @@ variable "apps_chart_version" {
 variable "chat_app_chart_version" {
   type        = string
   description = "Version of the chat-app Helm chart published to GHCR"
-  default     = "0.4.15"
+  default     = "0.4.16"
 }
 
 variable "chat_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump platform stack chat_app_chart_version from 0.4.15 to 0.4.16

## Validation
- chat-app v0.4.16 release workflow succeeded: https://github.com/agynio/chat-app/actions/runs/25715416264