### PR TITLE
chore(platform): bump agents-orchestrator to 0.13.16

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -39,7 +39,7 @@ variable "gateway_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.15"
+  default     = "0.13.16"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
Bumps the Bootstrap-pinned agents-orchestrator chart/image version to v0.13.16.

Includes the centralized E2E workflow fix released from agynio/agents-orchestrator#179.