### PR TITLE
chore(platform): bump metering chart to 0.1.3

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -51,7 +51,7 @@ variable "threads_chart_version" {
 variable "metering_chart_version" {
   type        = string
   description = "Version of the metering Helm chart published to GHCR"
-  default     = "0.1.2"
+  default     = "0.1.3"
 }
 
 variable "tracing_chart_version" {


### PR DESCRIPTION
Bumps  to **0.1.3** to pick up the metering fix release.\n\nRelease: https://github.com/agynio/metering/releases/tag/v0.1.3