### PR TITLE
Bump platform workload chart versions

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -39,7 +39,7 @@ variable "gateway_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.16"
+  default     = "0.13.17"
 }
 
 variable "threads_chart_version" {
@@ -147,7 +147,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.10.6"
+  default     = "0.10.7"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
## Summary
- Bump `agents_orchestrator_chart_version` default to `0.13.17`.
- Bump `console_app_chart_version` default to `0.10.7`.

Closes #497

## Test & Lint Summary
- `terraform fmt -check -recursive`: passed with no formatting changes required.
- `terraform -chdir=stacks/platform init -backend=false -input=false`: passed.
- `terraform -chdir=stacks/platform validate`: 1 passed / 0 failed / 0 skipped.
- Linting/status: Terraform formatting passed with no errors.