### PR TITLE
Bump llm-proxy chart to 0.12.1

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -659,7 +659,7 @@ variable "media_proxy_image_tag" {
 variable "llm_proxy_chart_version" {
   type        = string
   description = "Version of the llm-proxy Helm chart published to GHCR"
-  default     = "0.12.0"
+  default     = "0.12.1"
 }
 
 variable "llm_proxy_image_tag" {


### PR DESCRIPTION
Bumps the default `llm_proxy_chart_version` to **0.12.1**.

This picks up the LLM Proxy fix to forward caller headers (including `anthropic-beta`) while stripping hop-by-hop/caller-auth/x-agyn headers.

Release: https://github.com/agynio/llm-proxy/releases/tag/v0.12.1