### PR TITLE
Bump llm chart to 0.4.3

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -482,7 +482,7 @@ variable "files_db_pvc_size" {
 variable "llm_chart_version" {
   type        = string
   description = "Version of the llm Helm chart published to GHCR"
-  default     = "0.4.2"
+  default     = "0.4.3"
 }
 
 variable "llm_image_tag" {


### PR DESCRIPTION
Bumps the default `llm_chart_version` to **0.4.3**.

This picks up the LLM service fix ensuring model creation rolls back if the authorization tuple write fails (prevents models without `organization:<org_id> org model:<model_id>` tuple, which breaks llm-proxy `model#can_use`).

Release: https://github.com/agynio/llm/releases/tag/v0.4.3