### PR TITLE
chore(platform): bump threads chart to 0.4.11

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agents_orchestrator_chart_version" {
 variable "threads_chart_version" {
   type        = string
   description = "Version of the threads Helm chart published to GHCR"
-  default     = "0.4.9"
+  default     = "0.4.11"
 }
 
 variable "metering_chart_version" {


### PR DESCRIPTION
Bumps  to **0.4.11** (re-release containing platform usage metering emission fix).

Release: https://github.com/agynio/threads/releases/tag/v0.4.11

Context: supersedes the accidental numeric downgrade in #503.