### PR TITLE
fix(platform): bump llm-proxy chart version

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -659,7 +659,7 @@ variable "media_proxy_image_tag" {
 variable "llm_proxy_chart_version" {
   type        = string
   description = "Version of the llm-proxy Helm chart published to GHCR"
-  default     = "0.12.0"
+  default     = "0.12.2"
 }
 
 variable "llm_proxy_image_tag" {


### PR DESCRIPTION
## Summary
- Bumps the default `llm_proxy_chart_version` in `stacks/platform/variables.tf` from `0.12.0` to `0.12.2`.
- Keeps the existing image-tag resolution behavior unchanged.

Closes #508

## Test & Lint Summary
- `terraform fmt -check -recursive`: passed with no formatting errors.
- `terraform -chdir=<stack> init -backend=false -input=false && terraform -chdir=<stack> validate` for `stacks/apps`, `stacks/data`, `stacks/deps`, `stacks/k8s`, `stacks/platform`, `stacks/routing`, `stacks/system`, and `stacks/ziti`: 8 passed / 0 failed / 0 skipped.
- `shellcheck apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh`: passed with no lint errors.