### PR TITLE
Bump agents chart to v0.7.5

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -87,7 +87,7 @@ variable "postgres_chart_version" {
 variable "agents_chart_version" {
   type        = string
   description = "Version of the agents Helm chart published to GHCR"
-  default     = "0.7.4"
+  default     = "0.7.5"
 }
 
 variable "ziti_management_chart_version" {


### PR DESCRIPTION
## Summary
- Bumps `agents_chart_version` from `0.7.4` to `0.7.5`.
- `0.7.5` is the minimal agents chart/image release that contains agynio/agents#56 (`1be4b3f`), which writes and cleans up the `identity:<agent_id> member organization:<org_id>` OpenFGA tuple.
- No docs changes needed; this only updates the pinned chart/image version.

Closes #510

## Test & Lint Summary
- `terraform fmt -check -recursive`: passed with no formatting changes required
- `terraform -chdir=stacks/platform init -backend=false -input=false`: passed
- `terraform -chdir=stacks/platform validate`: passed
- `./apply.sh -y`: blocked by local rootless Docker runtime before deployment; k3d cluster creation failed because privileged sysfs mounts are not permitted in this environment (`operation not permitted` mounting `sysfs`)

Tests: 0 passed / 0 failed / 0 skipped (no test suite exists for this Terraform-only change).
Linting passed with no errors.