### PR TITLE
fix(data): avoid OpenFGA image repulls

### DIFF
--- a/stacks/data/main.tf
+++ b/stacks/data/main.tf
@@ -71,6 +71,9 @@ locals {
   openfga_values = yamlencode({
     fullnameOverride = "openfga"
     replicaCount     = 1
+    image = {
+      pullPolicy = "IfNotPresent"
+    }
     datastore = {
       engine            = "postgres"
       uri               = format("postgresql://openfga:%s@openfga-db:5432/openfga?sslmode=disable", var.openfga_db_password)


### PR DESCRIPTION
## Summary
- Set the OpenFGA chart image pull policy to `IfNotPresent`.
- Keeps local/bootstrap clusters from repeatedly pulling `openfga/openfga:v1.12.0` after the init container has already used the imported image.
- This unblocked the latest-bootstrap local repro work for agynio/e2e#124 in an environment with intermittent registry TLS timeouts.

## Related
- agynio/e2e#124

## Validation
- `terraform -chdir=stacks/data fmt -check`
- `terraform -chdir=stacks/data validate`
- `terraform -chdir=stacks/data apply -input=false -auto-approve`