### PR TITLE
Bump llm-proxy to 0.12.3

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -659,7 +659,7 @@ variable "media_proxy_image_tag" {
 variable "llm_proxy_chart_version" {
   type        = string
   description = "Version of the llm-proxy Helm chart published to GHCR"
-  default     = "0.12.2"
+  default     = "0.12.3"
 }
 
 variable "llm_proxy_image_tag" {


### PR DESCRIPTION
## Summary
- Bumps the default platform llm-proxy chart/image version from `0.12.2` to `0.12.3`.
- Ensures bootstrap/provisioned environments pick up agynio/llm-proxy#60 for chat-app e2e reruns.

Related to agynio/chat-app#96 and agynio/llm-proxy#60.

## Test & Lint Summary
- `terraform fmt -check -recursive stacks/platform`: passed with no formatting errors.