### PR TITLE
Bump llm-proxy to 0.12.4

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -659,7 +659,7 @@ variable "media_proxy_image_tag" {
 variable "llm_proxy_chart_version" {
   type        = string
   description = "Version of the llm-proxy Helm chart published to GHCR"
-  default     = "0.12.3"
+  default     = "0.12.4"
 }
 
 variable "llm_proxy_image_tag" {


### PR DESCRIPTION
## Summary
- bump default `llm_proxy_chart_version` from `0.12.3` to `0.12.4`
- this pulls in the llm-proxy fix that authorizes agent model access with the agent identity rather than the runtime workload id

## Tests
- `terraform fmt -check -recursive`
