### PR TITLE
Bump llm to 0.4.3

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -482,7 +482,7 @@ variable "files_db_pvc_size" {
 variable "llm_chart_version" {
   type        = string
   description = "Version of the llm Helm chart published to GHCR"
-  default     = "0.4.2"
+  default     = "0.4.3"
 }
 
 variable "llm_image_tag" {


### PR DESCRIPTION
## Summary
- bump default `llm_chart_version` from `0.4.2` to `0.4.3`
- `0.4.3` includes the LLM service authz tuple write on `CreateModel`, which is required for llm-proxy `can_use` checks against models created during E2E

## Why
Chat-app E2E logs show llm-proxy 403s for API-token-authenticated agent processes:

```text
principal_identity_type=user ... tuple_user=identity:<api-token-user> tuple_relation=can_use tuple_object=model:<model_id>
authorization denied
```

Those models resolve successfully in the LLM service, but OpenFGA has no `organization:<org_id>, org, model:<model_id>` tuple, so `can_use: member from org` cannot resolve. Bootstrap was still deploying `llm` chart `0.4.2`; the tuple-write fix is in `llm` `0.4.3`.

## Tests
- `terraform fmt -check -recursive`
