### PR TITLE
chore(platform): bump llm-proxy to 0.12.5

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -659,7 +659,7 @@ variable "media_proxy_image_tag" {
 variable "llm_proxy_chart_version" {
   type        = string
   description = "Version of the llm-proxy Helm chart published to GHCR"
-  default     = "0.12.4"
+  default     = "0.12.5"
 }
 
 variable "llm_proxy_image_tag" {


### PR DESCRIPTION
## Summary\n- Bump llm_proxy_chart_version to 0.12.5.\n\n## Includes\n- agynio/llm-proxy#63: fall back to Ziti identity when bearer auth fails on a Ziti-authenticated request.\n\n## Validation\n- terraform fmt -check -recursive\n