### PR TITLE
Bump tracing-app to 0.2.7

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -190,7 +190,7 @@ variable "oidc_client_secret" {
 variable "tracing_app_chart_version" {
   type        = string
   description = "Version of the tracing-app Helm chart published to GHCR"
-  default     = "0.2.6"
+  default     = "0.2.7"
 }
 
 variable "tracing_app_image_tag" {


### PR DESCRIPTION
## Summary
- bump the platform tracing-app Helm chart/image pin from `0.2.6` to `0.2.7`
- `0.2.7` contains agynio/tracing-app#43, which polls `/message/<id>` redirects until the tracing run is available

Closes #518

## Validation
- `terraform -chdir=stacks/platform fmt -check`
- `terraform -chdir=stacks/platform init -backend=false`
- `terraform -chdir=stacks/platform validate`

## Follow-up validation
- full-apply will run on this PR
- after full-apply passes, rerun agynio/chat-app PR #95 CI to validate `trace-link`