### PR TITLE
chore: bump tracing-app chart to 0.2.7

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -190,7 +190,7 @@ variable "oidc_client_secret" {
 variable "tracing_app_chart_version" {
   type        = string
   description = "Version of the tracing-app Helm chart published to GHCR"
-  default     = "0.2.6"
+  default     = "0.2.7"
 }
 
 variable "tracing_app_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -659,7 +659,7 @@ variable "media_proxy_image_tag" {
 variable "llm_proxy_chart_version" {
   type        = string
   description = "Version of the llm-proxy Helm chart published to GHCR"
-  default     = "0.12.4"
+  default     = "0.12.5"
 }
 
 variable "llm_proxy_image_tag" {


### PR DESCRIPTION
Bumps tracing_app_chart_version to 0.2.7 so chat-app E2E uses the tracing-app message redirect polling fix.

Validation:
- terraform fmt -check -recursive