### PR TITLE
chore(platform): bump llm chart defaults

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -135,7 +135,7 @@ variable "apps_chart_version" {
 variable "chat_app_chart_version" {
   type        = string
   description = "Version of the chat-app Helm chart published to GHCR"
-  default     = "0.4.16"
+  default     = "0.4.17"
 }
 
 variable "chat_app_image_tag" {
@@ -482,7 +482,7 @@ variable "files_db_pvc_size" {
 variable "llm_chart_version" {
   type        = string
   description = "Version of the llm Helm chart published to GHCR"
-  default     = "0.4.3"
+  default     = "0.4.4"
 }
 
 variable "llm_image_tag" {


### PR DESCRIPTION
## Summary
- Created current-HEAD releases for `agynio/llm` (`v0.4.4`) and `agynio/chat-app` (`v0.4.17`).
- Confirmed `agynio/llm-proxy` latest release is `v0.12.5`.
- Updated `stacks/platform/variables.tf` defaults for `llm` and `chat-app`; `llm-proxy` was already at `0.12.5`.

Closes #521

## Test & Lint Summary
- `terraform fmt -recursive -check -diff` — passed with no formatting changes required.
- `terraform -chdir=stacks/platform validate` — passed; 1 configuration valid / 0 failed / 0 skipped.
- `terraform -chdir=<each stacks/* directory> init -backend=false -input=false && terraform -chdir=<each stacks/* directory> validate` — passed for 8 stacks / 0 failed / 0 skipped.

Linting passed with no errors.