### PR TITLE
Bump threads chart version to 0.4.13

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agents_orchestrator_chart_version" {
 variable "threads_chart_version" {
   type        = string
   description = "Version of the threads Helm chart published to GHCR"
-  default     = "0.4.11"
+  default     = "0.4.13"
 }
 
 variable "metering_chart_version" {


### PR DESCRIPTION
Closes #526.

Bumps `threads_chart_version` so provisioned stacks pull a threads release that includes the CreateThread initiator dedupe + cascade delete fixes.

Threads release: https://github.com/agynio/threads/releases/tag/v0.4.13