### PR TITLE
Pin tracing-app image to 0.2.6

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -45,7 +45,7 @@ variable "agents_orchestrator_chart_version" {
 variable "threads_chart_version" {
   type        = string
   description = "Version of the threads Helm chart published to GHCR"
-  default     = "0.4.11"
+  default     = "0.4.13"
 }
 
 variable "metering_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -196,7 +196,7 @@ variable "tracing_app_chart_version" {
 variable "tracing_app_image_tag" {
   type        = string
   description = "Optional override for the tracing-app container image tag"
-  default     = ""
+  default     = "0.2.6"
 }
 
 variable "platform_namespace" {


### PR DESCRIPTION
Closes #528.

Pins `tracing_app_image_tag` to `0.2.6` so the provisioned E2E stack runs the tracing-app build that includes the message-deeplink empty-state fix (agynio/tracing-app#45).

Release: https://github.com/agynio/tracing-app/releases/tag/v0.2.6