### PR TITLE
Bump tracing-app chart version to 0.2.6

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -190,7 +190,7 @@ variable "oidc_client_secret" {
 variable "tracing_app_chart_version" {
   type        = string
   description = "Version of the tracing-app Helm chart published to GHCR"
-  default     = "0.2.6"
+  default     = "0.2.8"
 }
 
 variable "tracing_app_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -190,7 +190,7 @@ variable "oidc_client_secret" {
 variable "tracing_app_chart_version" {
   type        = string
   description = "Version of the tracing-app Helm chart published to GHCR"
-  default     = "0.2.7"
+  default     = "0.2.6"
 }
 
 variable "tracing_app_image_tag" {


### PR DESCRIPTION
Closes #528.

Bumps `tracing_app_chart_version` to `0.2.8` (no separate image tag pin) so the provisioned E2E stack runs the tracing-app release containing agynio/tracing-app#45.

Release: https://github.com/agynio/tracing-app/releases/tag/v0.2.8