### PR TITLE
Bump tracing-app chart version to 0.2.9

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -190,7 +190,7 @@ variable "oidc_client_secret" {
 variable "tracing_app_chart_version" {
   type        = string
   description = "Version of the tracing-app Helm chart published to GHCR"
-  default     = "0.2.8"
+  default     = "0.2.9"
 }
 
 variable "tracing_app_image_tag" {


### PR DESCRIPTION
Bumps `tracing_app_chart_version` to `0.2.9` so provisioned E2E stacks pick up tracing-app message deeplink redirect fix.

Release: https://github.com/agynio/tracing-app/releases/tag/v0.2.9