### PR TITLE
Bump expose chart version to 0.1.5

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -105,7 +105,7 @@ variable "users_chart_version" {
 variable "expose_chart_version" {
   type        = string
   description = "Version of the expose Helm chart published to GHCR"
-  default     = "0.1.4"
+  default     = "0.1.5"
 }
 
 variable "organizations_chart_version" {


### PR DESCRIPTION
Bumps `expose_chart_version` to `0.1.5` to pick up the expose→runners identity propagation fix (unblocks go-core `expose add` in E2E).

Release: https://github.com/agynio/expose/releases/tag/v0.1.5