### PR TITLE
chore(platform): bump runners chart to 0.5.10

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -123,7 +123,7 @@ variable "identity_chart_version" {
 variable "runners_chart_version" {
   type        = string
   description = "Version of the runners Helm chart published to GHCR"
-  default     = "0.5.9"
+  default     = "0.5.10"
 }
 
 variable "apps_chart_version" {


### PR DESCRIPTION
## Summary
- Bumps `runners_chart_version` from `0.5.9` to `0.5.10` so bootstrap E2E picks up the PR #59 auth fix.
- Published runners release tag `v0.5.10` from merged commit `76be9bd`.
- Verified chart `ghcr.io/agynio/charts/runners:0.5.10` is published.

Related runners issue: agynio/runners#60
Related runners PR: agynio/runners#59
Release workflow: https://github.com/agynio/runners/actions/runs/26504954022

## Test & Lint Summary
- `buf generate buf.build/agynio/api --include-imports --path agynio/api/agents/v1 --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/identity/v1 --path agynio/api/authorization/v1 --path agynio/api/ziti_management/v1 --path agynio/api/notifications/v1 && go test ./... && go build ./...` in `agynio/runners`: 1 package passed, 5 packages with no test files, 0 failed, 0 skipped.
- `helm dependency build charts/runners && helm lint charts/runners` in `agynio/runners`: 1 chart linted, 0 failed; no lint errors.
- `helm pull oci://ghcr.io/agynio/charts/runners --version 0.5.10 --destination /tmp && helm show chart oci://ghcr.io/agynio/charts/runners --version 0.5.10`: chart pull/show succeeded.
- `terraform -chdir=stacks/platform fmt -check`: passed with no formatting errors.
- `terraform -chdir=stacks/platform validate`: success; 1 configuration valid, 0 failed.
- `git diff --check`: passed with no whitespace errors.