### PR TITLE
chore(platform): bump runners workload auth

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1314,7 +1314,7 @@ locals {
 # var.authorization_chart_version to ensure the provisioned FGA model
 # matches the model expected by the deployed Helm chart.
 module "openfga_authorization" {
-  source          = "github.com/agynio/authorization//terraform?ref=v0.5.3"
+  source          = "github.com/agynio/authorization//terraform?ref=v0.5.4"
   openfga_api_url = local.openfga_api_url_external
 }
 

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -123,7 +123,7 @@ variable "identity_chart_version" {
 variable "runners_chart_version" {
   type        = string
   description = "Version of the runners Helm chart published to GHCR"
-  default     = "0.5.10"
+  default     = "0.5.11"
 }
 
 variable "apps_chart_version" {
@@ -624,7 +624,7 @@ variable "secrets_encryption_key" {
 variable "authorization_chart_version" {
   type        = string
   description = "Version of the authorization Helm chart published to GHCR"
-  default     = "0.5.3"
+  default     = "0.5.4"
 }
 
 variable "authorization_image_tag" {


### PR DESCRIPTION
## Summary
- Bump `runners_chart_version` to `0.5.11` for agynio/runners#66.
- Bump `authorization_chart_version` to `0.5.4` so the deployed authorization service includes the workload OpenFGA model.
- Bump the `openfga_authorization` module source ref to `v0.5.4` in lockstep with the authorization chart.

## Release
- Runners release: https://github.com/agynio/runners/releases/tag/v0.5.11
- Release workflow: https://github.com/agynio/runners/actions/runs/26538397043

## Test & Lint Summary
- `for d in stacks/k8s stacks/system stacks/deps stacks/ziti stacks/platform stacks/data stacks/routing stacks/apps; do terraform -chdir="$d" fmt -check; done` — passed with no formatting errors.
- `for d in stacks/k8s stacks/system stacks/deps stacks/ziti stacks/platform stacks/data stacks/routing stacks/apps; do terraform -chdir="$d" init -backend=false -input=false && terraform -chdir="$d" validate; done` — 8 passed, 0 failed, 0 skipped.
- `bash -n apply.sh && bash -n install-ca-cert.sh && bash -n .github/scripts/verify_platform_health.sh` — passed with no shell syntax errors.
- `git diff --check` — passed with no whitespace errors.

Closes agynio/runners#66