### PR TITLE
Bump authorization to 0.5.4 and runners to 0.5.11

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1314,7 +1314,7 @@ locals {
 # var.authorization_chart_version to ensure the provisioned FGA model
 # matches the model expected by the deployed Helm chart.
 module "openfga_authorization" {
-  source          = "github.com/agynio/authorization//terraform?ref=v0.5.3"
+  source          = "github.com/agynio/authorization//terraform?ref=v0.5.4"
   openfga_api_url = local.openfga_api_url_external
 }
 

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -123,7 +123,7 @@ variable "identity_chart_version" {
 variable "runners_chart_version" {
   type        = string
   description = "Version of the runners Helm chart published to GHCR"
-  default     = "0.5.10"
+  default     = "0.5.11"
 }
 
 variable "apps_chart_version" {
@@ -624,7 +624,7 @@ variable "secrets_encryption_key" {
 variable "authorization_chart_version" {
   type        = string
   description = "Version of the authorization Helm chart published to GHCR"
-  default     = "0.5.3"
+  default     = "0.5.4"
 }
 
 variable "authorization_image_tag" {


### PR DESCRIPTION
Bumps:
- `authorization_chart_version` to `0.5.4`
- OpenFGA authorization terraform module ref to `v0.5.4` (lockstep)
- `runners_chart_version` to `0.5.11`

This deploys the new workload authorization model (`workload#can_view` derived from `owner_agent` or org `can_view_workloads`) and runners changes to write workload tuples + authorize `GetWorkload` via the model.

Releases:
- https://github.com/agynio/authorization/releases/tag/v0.5.4
- https://github.com/agynio/runners/releases/tag/v0.5.11