### PR TITLE
Bump expose chart version to 0.1.6

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -105,7 +105,7 @@ variable "users_chart_version" {
 variable "expose_chart_version" {
   type        = string
   description = "Version of the expose Helm chart published to GHCR"
-  default     = "0.1.5"
+  default     = "0.1.6"
 }
 
 variable "organizations_chart_version" {


### PR DESCRIPTION
Bumps `expose_chart_version` to `0.1.6` to fix exposure connectivity in E2E.

Expose change: use host.v1 address `127.0.0.1` instead of `localhost`.

Release: https://github.com/agynio/expose/releases/tag/v0.1.6
PR: https://github.com/agynio/expose/pull/24