### PR TITLE
fix: pin k3d load balancer image

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ Use auto-apply mode to skip prompts and run Terraform with `-input=false -auto-a
 ./apply.sh -y
 ```
 
+`apply.sh` exports `K3D_IMAGE_LOADBALANCER` before Terraform runs so k3d uses a
+pinned load balancer image instead of resolving `ghcr.io/k3d-io/k3d-proxy:latest`
+at cluster creation time. The default is pinned for the installed k3d CLI
+version (`v5.7.5`):
+
+```sh
+ghcr.io/k3d-io/k3d-proxy@sha256:6466619f9f2b34273e927f96e5d606c485c5803aaa8033193793b5d8137aba9e
+```
+
+When upgrading k3d, update this digest to the proxy image published for the new
+k3d release. To test a different image locally or in CI, provide
+`K3D_IMAGE_LOADBALANCER` in the environment before running `apply.sh`.
+
 **Manual**
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ Use auto-apply mode to skip prompts and run Terraform with `-input=false -auto-a
 ```
 
 `apply.sh` exports `K3D_IMAGE_LOADBALANCER` before Terraform runs so k3d uses a
-pinned load balancer image instead of resolving `ghcr.io/k3d-io/k3d-proxy:latest`
-at cluster creation time. The default is pinned for the installed k3d CLI
-version (`v5.7.5`):
+pinned load balancer image tag instead of resolving
+`ghcr.io/k3d-io/k3d-proxy:latest` at cluster creation time. The default is
+pinned for the installed k3d CLI version (`v5.7.5`):
 
 ```sh
-ghcr.io/k3d-io/k3d-proxy@sha256:6466619f9f2b34273e927f96e5d606c485c5803aaa8033193793b5d8137aba9e
+ghcr.io/k3d-io/k3d-proxy:5.7.5
 ```
 
-When upgrading k3d, update this digest to the proxy image published for the new
-k3d release. To test a different image locally or in CI, provide
+When upgrading k3d, update this tag to the proxy image published for the new k3d
+release. To test a different image locally or in CI, provide
 `K3D_IMAGE_LOADBALANCER` in the environment before running `apply.sh`.
 
 **Manual**

--- a/apply.sh
+++ b/apply.sh
@@ -7,7 +7,7 @@ DEFAULT_PORT="2496"
 DEFAULT_OIDC_ISSUER_URL="https://mockauth.dev/r/301ebb13-15a8-48f4-baac-e3fa25be29fc/oidc"
 DEFAULT_OIDC_CLIENT_ID="client_MU95KU3gHQf5Ir7p"
 DEFAULT_OIDC_CLIENT_SECRET="XPKka2i9uzISrKZ95zxli8sY51BK4eTJ"
-DEFAULT_K3D_IMAGE_LOADBALANCER="ghcr.io/k3d-io/k3d-proxy@sha256:6466619f9f2b34273e927f96e5d606c485c5803aaa8033193793b5d8137aba9e"
+DEFAULT_K3D_PROXY_IMAGE="ghcr.io/k3d-io/k3d-proxy:5.7.5"
 KUBECONFIG_PATH="stacks/k8s/.kube/agyn-local-kubeconfig.yaml"
 
 auto_approve="false"
@@ -31,7 +31,7 @@ Environment variables:
   GHCR_USERNAME        Optional GHCR username for private OCI charts
   GHCR_TOKEN           Optional GHCR token for private OCI charts
   K3D_IMAGE_LOADBALANCER  Override the k3d load balancer image
-                          (default: ghcr.io/k3d-io/k3d-proxy@sha256:6466619f9f2b34273e927f96e5d606c485c5803aaa8033193793b5d8137aba9e)
+                          (default: ghcr.io/k3d-io/k3d-proxy:5.7.5)
 EOF
 }
 
@@ -164,7 +164,7 @@ fi
 ghcr_username="${GHCR_USERNAME:-}"
 ghcr_token="${GHCR_TOKEN:-}"
 
-export K3D_IMAGE_LOADBALANCER="${K3D_IMAGE_LOADBALANCER:-${DEFAULT_K3D_IMAGE_LOADBALANCER}}"
+export K3D_IMAGE_LOADBALANCER="${K3D_IMAGE_LOADBALANCER:-${DEFAULT_K3D_PROXY_IMAGE}}"
 echo "Using k3d load balancer image: ${K3D_IMAGE_LOADBALANCER}"
 
 printf '\nUsing domain: %s\nUsing port:   %s\n\n' "${domain}" "${port}"

--- a/apply.sh
+++ b/apply.sh
@@ -7,6 +7,7 @@ DEFAULT_PORT="2496"
 DEFAULT_OIDC_ISSUER_URL="https://mockauth.dev/r/301ebb13-15a8-48f4-baac-e3fa25be29fc/oidc"
 DEFAULT_OIDC_CLIENT_ID="client_MU95KU3gHQf5Ir7p"
 DEFAULT_OIDC_CLIENT_SECRET="XPKka2i9uzISrKZ95zxli8sY51BK4eTJ"
+DEFAULT_K3D_IMAGE_LOADBALANCER="ghcr.io/k3d-io/k3d-proxy@sha256:6466619f9f2b34273e927f96e5d606c485c5803aaa8033193793b5d8137aba9e"
 KUBECONFIG_PATH="stacks/k8s/.kube/agyn-local-kubeconfig.yaml"
 
 auto_approve="false"
@@ -29,6 +30,8 @@ Environment variables:
   ADMIN_OIDC_SUBJECT  Optional OIDC subject for the bootstrap admin user (default: admin@agyn.io)
   GHCR_USERNAME        Optional GHCR username for private OCI charts
   GHCR_TOKEN           Optional GHCR token for private OCI charts
+  K3D_IMAGE_LOADBALANCER  Override the k3d load balancer image
+                          (default: ghcr.io/k3d-io/k3d-proxy@sha256:6466619f9f2b34273e927f96e5d606c485c5803aaa8033193793b5d8137aba9e)
 EOF
 }
 
@@ -160,6 +163,9 @@ fi
 
 ghcr_username="${GHCR_USERNAME:-}"
 ghcr_token="${GHCR_TOKEN:-}"
+
+export K3D_IMAGE_LOADBALANCER="${K3D_IMAGE_LOADBALANCER:-${DEFAULT_K3D_IMAGE_LOADBALANCER}}"
+echo "Using k3d load balancer image: ${K3D_IMAGE_LOADBALANCER}"
 
 printf '\nUsing domain: %s\nUsing port:   %s\n\n' "${domain}" "${port}"
 


### PR DESCRIPTION
## Summary
- Export `K3D_IMAGE_LOADBALANCER` from `apply.sh` with a default pinned k3d proxy version tag for k3d CLI `v5.7.5`.
- Document the tag pin and override/update guidance in usage docs.
- Echo the selected load balancer image before Terraform runs.

Fixes #541

## Test & Lint Summary
- `shellcheck apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh`: passed, 0 errors.
- `terraform fmt -check -recursive`: passed, 0 formatting changes needed.
- `./apply.sh -h >/tmp/apply-help.txt && grep -F "K3D_IMAGE_LOADBALANCER" /tmp/apply-help.txt && grep -F "ghcr.io/k3d-io/k3d-proxy:5.7.5" /tmp/apply-help.txt`: passed, 2/2 checks passed.
- `git diff --check`: passed, 0 whitespace errors.
- `for dir in stacks/*; do if [ -d "$dir" ]; then terraform -chdir="$dir" init -backend=false -input=false >/tmp/tf-init-$(basename "$dir").log && terraform -chdir="$dir" validate; fi; done`: passed, 8/8 stacks valid.
- `bash -n apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh`: passed, 3/3 scripts valid.