### PR TITLE
fix(ziti): add diagnostics credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,13 @@ Default domain and port: `agyn.dev` on `2496`.
 
 ## DEV/E2E-only diagnostics credentials
 
-The `ziti-management-diagnostics` Ziti identity, Kubernetes secret, and RBAC are
-for local development and E2E diagnostics only. They intentionally expose a
-dedicated admin UPDB credential so tests can query Ziti management diagnostics.
-Production deployments must not create or publish these resources.
+The `ziti-diagnostics` Ziti identity, Kubernetes secret, and RBAC are for local
+development and reusable E2E diagnostics only. They intentionally expose a
+dedicated admin UPDB credential so the E2E diagnostics framework can query Ziti
+management state after failures. Production deployments must not create or
+publish these resources.
 
 Both the `stacks/ziti` and `stacks/platform` Terraform stacks guard the
-diagnostics resources behind `enable_ziti_management_diagnostics`, which
+diagnostics resources behind `enable_ziti_diagnostics`, which
 defaults to `false`. Only enable it in DEV/E2E environments, and keep the value
 disabled for production plans and applies.

--- a/README.md
+++ b/README.md
@@ -67,3 +67,15 @@ Default domain and port: `agyn.dev` on `2496`.
 - Argo CD: https://argocd.agyn.dev:2496/
 - OpenFGA API: https://openfga.agyn.dev:2496/
 - OpenFGA Playground: https://openfga-playground.agyn.dev:2496/
+
+## DEV/E2E-only diagnostics credentials
+
+The `ziti-management-diagnostics` Ziti identity, Kubernetes secret, and RBAC are
+for local development and E2E diagnostics only. They intentionally expose a
+dedicated admin UPDB credential so tests can query Ziti management diagnostics.
+Production deployments must not create or publish these resources.
+
+Both the `stacks/ziti` and `stacks/platform` Terraform stacks guard the
+diagnostics resources behind `enable_ziti_management_diagnostics`, which
+defaults to `false`. Only enable it in DEV/E2E environments, and keep the value
+disabled for production plans and applies.

--- a/stacks/platform/README.md
+++ b/stacks/platform/README.md
@@ -58,3 +58,13 @@ Verify persistence by:
 | 25        | `platform-ui`      | Platform web UI                     | Connects to `platform-server` |
 
 All chart versions, image tags, and critical secrets are pinned via Terraform variables for reproducibility.
+
+## DEV/E2E-only Ziti diagnostics secret
+
+`ziti-management-diagnostics` is reserved for development and E2E diagnostics.
+When explicitly enabled, the platform stack publishes a Kubernetes secret with
+dedicated Ziti management diagnostics credentials and grants the
+`agents-orchestrator-e2e` service account get-only access to that secret.
+
+Production deployments must leave `enable_ziti_management_diagnostics` at its
+default value of `false` so the secret and RBAC do not exist.

--- a/stacks/platform/README.md
+++ b/stacks/platform/README.md
@@ -61,10 +61,10 @@ All chart versions, image tags, and critical secrets are pinned via Terraform va
 
 ## DEV/E2E-only Ziti diagnostics secret
 
-`ziti-management-diagnostics` is reserved for development and E2E diagnostics.
+`ziti-diagnostics` is reserved for development and reusable E2E diagnostics.
 When explicitly enabled, the platform stack publishes a Kubernetes secret with
-dedicated Ziti management diagnostics credentials and grants the
-`agents-orchestrator-e2e` service account get-only access to that secret.
+dedicated Ziti diagnostics credentials and grants the `agents-orchestrator-e2e`
+service account get-only access to that secret for failure diagnostics.
 
-Production deployments must leave `enable_ziti_management_diagnostics` at its
+Production deployments must leave `enable_ziti_diagnostics` at its
 default value of `false` so the secret and RBAC do not exist.

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -55,6 +55,7 @@ locals {
   identity_chart_name            = "agynio/charts/identity"
   runners_chart_name             = "agynio/charts/runners"
   apps_chart_name                = "agynio/charts/apps"
+  ziti_diagnostics_secret_name   = "ziti-management-diagnostics"
   istio_gateway_namespace        = data.terraform_remote_state.system.outputs.istio_gateway_namespace
   istio_gateway_tls_secret_name  = data.terraform_remote_state.system.outputs.wildcard_tls_gateway_secret_name
   openfga_api_url_external       = format("https://openfga.%s:%d", local.base_domain, local.ingress_port)
@@ -1357,6 +1358,53 @@ resource "kubernetes_secret_v1" "ziti_management_enrollment" {
 
   data = {
     enrollmentJwt = data.terraform_remote_state.ziti.outputs.ziti_management_enrollment_token
+  }
+}
+
+resource "kubernetes_secret_v1" "ziti_management_diagnostics" {
+  metadata {
+    name      = local.ziti_diagnostics_secret_name
+    namespace = kubernetes_namespace.platform.metadata[0].name
+  }
+
+  type = "Opaque"
+
+  data = {
+    username = data.terraform_remote_state.ziti.outputs.ziti_diagnostics_credentials.username
+    password = data.terraform_remote_state.ziti.outputs.ziti_diagnostics_credentials.password
+  }
+}
+
+resource "kubernetes_role_v1" "ziti_management_diagnostics_reader" {
+  metadata {
+    name      = "ziti-management-diagnostics-reader"
+    namespace = kubernetes_namespace.platform.metadata[0].name
+  }
+
+  rule {
+    api_groups     = [""]
+    resources      = ["secrets"]
+    resource_names = [kubernetes_secret_v1.ziti_management_diagnostics.metadata[0].name]
+    verbs          = ["get"]
+  }
+}
+
+resource "kubernetes_role_binding_v1" "ziti_management_diagnostics_reader" {
+  metadata {
+    name      = "ziti-management-diagnostics-reader"
+    namespace = kubernetes_namespace.platform.metadata[0].name
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role_v1.ziti_management_diagnostics_reader.metadata[0].name
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = "agents-orchestrator-e2e"
+    namespace = kubernetes_namespace.platform.metadata[0].name
   }
 }
 

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -57,7 +57,7 @@ locals {
   apps_chart_name                = "agynio/charts/apps"
   # DEV/E2E ONLY: this secret name is used by diagnostics tests and must not
   # be published in production deployments.
-  ziti_diagnostics_secret_name  = "ziti-management-diagnostics"
+  ziti_diagnostics_secret_name  = "ziti-diagnostics"
   istio_gateway_namespace       = data.terraform_remote_state.system.outputs.istio_gateway_namespace
   istio_gateway_tls_secret_name = data.terraform_remote_state.system.outputs.wildcard_tls_gateway_secret_name
   openfga_api_url_external      = format("https://openfga.%s:%d", local.base_domain, local.ingress_port)
@@ -1363,10 +1363,10 @@ resource "kubernetes_secret_v1" "ziti_management_enrollment" {
   }
 }
 
-# DEV/E2E ONLY: ziti-management-diagnostics contains admin UPDB credentials
-# for diagnostics tests. Keep enable_ziti_management_diagnostics=false in prod.
-resource "kubernetes_secret_v1" "ziti_management_diagnostics" {
-  count = var.enable_ziti_management_diagnostics ? 1 : 0
+# DEV/E2E ONLY: ziti-diagnostics contains admin UPDB credentials
+# for diagnostics tests. Keep enable_ziti_diagnostics=false in prod.
+resource "kubernetes_secret_v1" "ziti_diagnostics" {
+  count = var.enable_ziti_diagnostics ? 1 : 0
 
   metadata {
     name      = local.ziti_diagnostics_secret_name
@@ -1381,36 +1381,36 @@ resource "kubernetes_secret_v1" "ziti_management_diagnostics" {
   }
 }
 
-resource "kubernetes_role_v1" "ziti_management_diagnostics_reader" {
-  count = var.enable_ziti_management_diagnostics ? 1 : 0
+resource "kubernetes_role_v1" "ziti_diagnostics_reader" {
+  count = var.enable_ziti_diagnostics ? 1 : 0
 
   metadata {
-    name      = "ziti-management-diagnostics-reader"
+    name      = "ziti-diagnostics-reader"
     namespace = kubernetes_namespace.platform.metadata[0].name
   }
 
   rule {
     api_groups     = [""]
     resources      = ["secrets"]
-    resource_names = [kubernetes_secret_v1.ziti_management_diagnostics[0].metadata[0].name]
+    resource_names = [kubernetes_secret_v1.ziti_diagnostics[0].metadata[0].name]
     verbs          = ["get"]
   }
 }
 
 # DEV/E2E ONLY: grants agents-orchestrator-e2e access to the diagnostics
 # secret. Production deployments must not create this binding.
-resource "kubernetes_role_binding_v1" "ziti_management_diagnostics_reader" {
-  count = var.enable_ziti_management_diagnostics ? 1 : 0
+resource "kubernetes_role_binding_v1" "ziti_diagnostics_reader" {
+  count = var.enable_ziti_diagnostics ? 1 : 0
 
   metadata {
-    name      = "ziti-management-diagnostics-reader"
+    name      = "ziti-diagnostics-reader"
     namespace = kubernetes_namespace.platform.metadata[0].name
   }
 
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Role"
-    name      = kubernetes_role_v1.ziti_management_diagnostics_reader[0].metadata[0].name
+    name      = kubernetes_role_v1.ziti_diagnostics_reader[0].metadata[0].name
   }
 
   subject {

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -55,11 +55,13 @@ locals {
   identity_chart_name            = "agynio/charts/identity"
   runners_chart_name             = "agynio/charts/runners"
   apps_chart_name                = "agynio/charts/apps"
-  ziti_diagnostics_secret_name   = "ziti-management-diagnostics"
-  istio_gateway_namespace        = data.terraform_remote_state.system.outputs.istio_gateway_namespace
-  istio_gateway_tls_secret_name  = data.terraform_remote_state.system.outputs.wildcard_tls_gateway_secret_name
-  openfga_api_url_external       = format("https://openfga.%s:%d", local.base_domain, local.ingress_port)
-  openfga_api_url_internal       = format("http://openfga.%s.svc.cluster.local:8080", var.openfga_namespace)
+  # DEV/E2E ONLY: this secret name is used by diagnostics tests and must not
+  # be published in production deployments.
+  ziti_diagnostics_secret_name  = "ziti-management-diagnostics"
+  istio_gateway_namespace       = data.terraform_remote_state.system.outputs.istio_gateway_namespace
+  istio_gateway_tls_secret_name = data.terraform_remote_state.system.outputs.wildcard_tls_gateway_secret_name
+  openfga_api_url_external      = format("https://openfga.%s:%d", local.base_domain, local.ingress_port)
+  openfga_api_url_internal      = format("http://openfga.%s.svc.cluster.local:8080", var.openfga_namespace)
   # Deterministic v5 UUID for the cluster admin identity.
   # This is a synthetic identity used only during bootstrap;
   # it does not correspond to a user record in the Users DB.
@@ -1361,7 +1363,11 @@ resource "kubernetes_secret_v1" "ziti_management_enrollment" {
   }
 }
 
+# DEV/E2E ONLY: ziti-management-diagnostics contains admin UPDB credentials
+# for diagnostics tests. Keep enable_ziti_management_diagnostics=false in prod.
 resource "kubernetes_secret_v1" "ziti_management_diagnostics" {
+  count = var.enable_ziti_management_diagnostics ? 1 : 0
+
   metadata {
     name      = local.ziti_diagnostics_secret_name
     namespace = kubernetes_namespace.platform.metadata[0].name
@@ -1376,6 +1382,8 @@ resource "kubernetes_secret_v1" "ziti_management_diagnostics" {
 }
 
 resource "kubernetes_role_v1" "ziti_management_diagnostics_reader" {
+  count = var.enable_ziti_management_diagnostics ? 1 : 0
+
   metadata {
     name      = "ziti-management-diagnostics-reader"
     namespace = kubernetes_namespace.platform.metadata[0].name
@@ -1384,12 +1392,16 @@ resource "kubernetes_role_v1" "ziti_management_diagnostics_reader" {
   rule {
     api_groups     = [""]
     resources      = ["secrets"]
-    resource_names = [kubernetes_secret_v1.ziti_management_diagnostics.metadata[0].name]
+    resource_names = [kubernetes_secret_v1.ziti_management_diagnostics[0].metadata[0].name]
     verbs          = ["get"]
   }
 }
 
+# DEV/E2E ONLY: grants agents-orchestrator-e2e access to the diagnostics
+# secret. Production deployments must not create this binding.
 resource "kubernetes_role_binding_v1" "ziti_management_diagnostics_reader" {
+  count = var.enable_ziti_management_diagnostics ? 1 : 0
+
   metadata {
     name      = "ziti-management-diagnostics-reader"
     namespace = kubernetes_namespace.platform.metadata[0].name
@@ -1398,7 +1410,7 @@ resource "kubernetes_role_binding_v1" "ziti_management_diagnostics_reader" {
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Role"
-    name      = kubernetes_role_v1.ziti_management_diagnostics_reader.metadata[0].name
+    name      = kubernetes_role_v1.ziti_management_diagnostics_reader[0].metadata[0].name
   }
 
   subject {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -518,6 +518,12 @@ variable "ziti_management_db_password" {
   sensitive   = true
 }
 
+variable "enable_ziti_management_diagnostics" {
+  type        = bool
+  description = "DEV/E2E-only: publish the ziti-management-diagnostics secret and RBAC. Production deployments must leave this false."
+  default     = false
+}
+
 variable "organizations_db_password" {
   type        = string
   description = "Password for the organizations PostgreSQL database user"

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -518,9 +518,9 @@ variable "ziti_management_db_password" {
   sensitive   = true
 }
 
-variable "enable_ziti_management_diagnostics" {
+variable "enable_ziti_diagnostics" {
   type        = bool
-  description = "DEV/E2E-only: publish the ziti-management-diagnostics secret and RBAC. Production deployments must leave this false."
+  description = "DEV/E2E-only: publish the ziti-diagnostics secret and RBAC. Production deployments must leave this false."
   default     = false
 }
 

--- a/stacks/ziti/.terraform.lock.hcl
+++ b/stacks/ziti/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.17.0"
   constraints = "~> 2.13"
   hashes = [
+    "h1:If79Gw54AMearm13Sk9RmWuDesCQQMUtmlJXXqISxfU=",
     "h1:K5FEjxvDnxb1JF1kG1xr8J3pNGxoaR3Z0IBG9Csm/Is=",
     "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
     "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
@@ -27,6 +28,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   constraints = "~> 2.27"
   hashes = [
     "h1:5CkveFo5ynsLdzKk+Kv+r7+U9rMrNjfZPT3a0N/fhgE=",
+    "h1:XCkL/mxjWTawg6gg+jlpCQhF/+SNRoCEZxbbkDTj42s=",
     "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
     "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
     "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
@@ -43,10 +45,32 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:lVDv+0AjDjrLfpmaJbWqUmIw/k3/AHXLc3N4m55SNdo=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}
+
 provider "registry.terraform.io/netfoundry/ziti" {
   version     = "1.0.4"
   constraints = "~> 1.0"
   hashes = [
+    "h1:25udaHtNFkH1hoEmyEZYGrXG1oJEaqSkveaouHK+kbU=",
     "h1:5wURt290SaHrl/7OwkKf8PMSgIbhvPfzN2SnFgbIIOY=",
     "h1:j4gXV1/ojqp+NSVdxDpgO0IiRIxUOnSTfFKV8xBpaOA=",
     "zh:014d13a23e160a4706f45f4bc11edafa612d711269598eb15f59f259e14418b9",

--- a/stacks/ziti/main.tf
+++ b/stacks/ziti/main.tf
@@ -109,11 +109,17 @@ resource "ziti_identity" "ziti_management" {
 }
 
 resource "random_password" "ziti_management_diagnostics" {
+  count = var.enable_ziti_management_diagnostics ? 1 : 0
+
   length  = 32
   special = false
 }
 
+# DEV/E2E ONLY: ziti-management-diagnostics is an admin UPDB identity used
+# solely by diagnostics tests. Production deployments must not enable this.
 resource "ziti_auth_policy" "ziti_management_diagnostics" {
+  count = var.enable_ziti_management_diagnostics ? 1 : 0
+
   name = "ziti-management-diagnostics"
 
   primary = {
@@ -141,11 +147,14 @@ resource "ziti_auth_policy" "ziti_management_diagnostics" {
   }
 }
 
+# DEV/E2E ONLY: this admin identity is for diagnostics tests and must not
+# exist in production. Keep enable_ziti_management_diagnostics=false for prod.
 resource "ziti_identity_updb" "ziti_management_diagnostics" {
   name           = "ziti-management-diagnostics"
+  count          = var.enable_ziti_management_diagnostics ? 1 : 0
   type           = "User"
   updb_username  = "ziti-management-diagnostics"
-  auth_policy_id = ziti_auth_policy.ziti_management_diagnostics.id
+  auth_policy_id = ziti_auth_policy.ziti_management_diagnostics[0].id
   # The current Terraform provider does not expose OpenZiti's permissions
   # field, so this identity must be an admin to access management endpoints.
   # E2E only stores its one-time login credential in the platform namespace.
@@ -154,22 +163,26 @@ resource "ziti_identity_updb" "ziti_management_diagnostics" {
 }
 
 locals {
-  ziti_management_diagnostics_enrollment_jwt_payload = split(".", ziti_identity_updb.ziti_management_diagnostics.enrollment_token)[1]
+  ziti_management_diagnostics_enrollment_jwt_payload = var.enable_ziti_management_diagnostics ? split(".", ziti_identity_updb.ziti_management_diagnostics[0].enrollment_token)[1] : ""
   ziti_management_diagnostics_enrollment_jwt_padding = substr("===", 0, (4 - length(local.ziti_management_diagnostics_enrollment_jwt_payload) % 4) % 4)
-  ziti_management_diagnostics_enrollment_token       = jsondecode(base64decode(format("%s%s", replace(replace(local.ziti_management_diagnostics_enrollment_jwt_payload, "-", "+"), "_", "/"), local.ziti_management_diagnostics_enrollment_jwt_padding))).jti
+  ziti_management_diagnostics_enrollment_token       = var.enable_ziti_management_diagnostics ? jsondecode(base64decode(format("%s%s", replace(replace(local.ziti_management_diagnostics_enrollment_jwt_payload, "-", "+"), "_", "/"), local.ziti_management_diagnostics_enrollment_jwt_padding))).jti : ""
 }
 
+# DEV/E2E ONLY: enroll the ziti-management-diagnostics identity so tests can
+# read the generated password from the platform namespace. Do not enable in prod.
 resource "terraform_data" "ziti_management_diagnostics_enrollment" {
+  count = var.enable_ziti_management_diagnostics ? 1 : 0
+
   input = {
     endpoint = format("https://ziti-mgmt.%s:%d/edge/client/v1", local.base_domain, local.ingress_port)
-    password = random_password.ziti_management_diagnostics.result
+    password = random_password.ziti_management_diagnostics[0].result
     token    = local.ziti_management_diagnostics_enrollment_token
-    username = ziti_identity_updb.ziti_management_diagnostics.updb_username
+    username = ziti_identity_updb.ziti_management_diagnostics[0].updb_username
   }
 
   triggers_replace = [
-    random_password.ziti_management_diagnostics.result,
-    ziti_identity_updb.ziti_management_diagnostics.id,
+    random_password.ziti_management_diagnostics[0].result,
+    ziti_identity_updb.ziti_management_diagnostics[0].id,
   ]
 
   provisioner "local-exec" {

--- a/stacks/ziti/main.tf
+++ b/stacks/ziti/main.tf
@@ -108,6 +108,87 @@ resource "ziti_identity" "ziti_management" {
   role_attributes = []
 }
 
+resource "random_password" "ziti_management_diagnostics" {
+  length  = 32
+  special = false
+}
+
+resource "ziti_auth_policy" "ziti_management_diagnostics" {
+  name = "ziti-management-diagnostics"
+
+  primary = {
+    cert = {
+      allowed             = false
+      allow_expired_certs = false
+    }
+    ext_jwt = {
+      allowed         = false
+      allowed_signers = []
+    }
+    updb = {
+      allowed                  = true
+      lockout_duration_minutes = 5
+      max_attempts             = 5
+      min_password_length      = 8
+      require_mixed_case       = false
+      require_number_char      = false
+      require_special_char     = false
+    }
+  }
+
+  secondary = {
+    require_totp = false
+  }
+}
+
+resource "ziti_identity_updb" "ziti_management_diagnostics" {
+  name           = "ziti-management-diagnostics"
+  type           = "User"
+  updb_username  = "ziti-management-diagnostics"
+  auth_policy_id = ziti_auth_policy.ziti_management_diagnostics.id
+  # The current Terraform provider does not expose OpenZiti's permissions
+  # field, so this identity must be an admin to access management endpoints.
+  # E2E only stores its one-time login credential in the platform namespace.
+  is_admin        = true
+  role_attributes = []
+}
+
+locals {
+  ziti_management_diagnostics_enrollment_jwt_payload = split(".", ziti_identity_updb.ziti_management_diagnostics.enrollment_token)[1]
+  ziti_management_diagnostics_enrollment_jwt_padding = substr("===", 0, (4 - length(local.ziti_management_diagnostics_enrollment_jwt_payload) % 4) % 4)
+  ziti_management_diagnostics_enrollment_token       = jsondecode(base64decode(format("%s%s", replace(replace(local.ziti_management_diagnostics_enrollment_jwt_payload, "-", "+"), "_", "/"), local.ziti_management_diagnostics_enrollment_jwt_padding))).jti
+}
+
+resource "terraform_data" "ziti_management_diagnostics_enrollment" {
+  input = {
+    endpoint = format("https://ziti-mgmt.%s:%d/edge/client/v1", local.base_domain, local.ingress_port)
+    password = random_password.ziti_management_diagnostics.result
+    token    = local.ziti_management_diagnostics_enrollment_token
+    username = ziti_identity_updb.ziti_management_diagnostics.updb_username
+  }
+
+  triggers_replace = [
+    random_password.ziti_management_diagnostics.result,
+    ziti_identity_updb.ziti_management_diagnostics.id,
+  ]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      curl -fsS -k -X POST \
+        -H 'Content-Type: application/json' \
+        -d "{\"username\":\"$ZITI_USERNAME\",\"password\":\"$ZITI_PASSWORD\"}" \
+        "$ZITI_ENDPOINT/enroll?method=updb&token=$ZITI_TOKEN"
+    EOT
+
+    environment = {
+      ZITI_ENDPOINT = self.input.endpoint
+      ZITI_PASSWORD = self.input.password
+      ZITI_TOKEN    = self.input.token
+      ZITI_USERNAME = self.input.username
+    }
+  }
+}
+
 resource "ziti_identity" "orchestrator" {
   name            = "orchestrator"
   type            = "Device"

--- a/stacks/ziti/main.tf
+++ b/stacks/ziti/main.tf
@@ -108,19 +108,19 @@ resource "ziti_identity" "ziti_management" {
   role_attributes = []
 }
 
-resource "random_password" "ziti_management_diagnostics" {
-  count = var.enable_ziti_management_diagnostics ? 1 : 0
+resource "random_password" "ziti_diagnostics" {
+  count = var.enable_ziti_diagnostics ? 1 : 0
 
   length  = 32
   special = false
 }
 
-# DEV/E2E ONLY: ziti-management-diagnostics is an admin UPDB identity used
+# DEV/E2E ONLY: ziti-diagnostics is an admin UPDB identity used
 # solely by diagnostics tests. Production deployments must not enable this.
-resource "ziti_auth_policy" "ziti_management_diagnostics" {
-  count = var.enable_ziti_management_diagnostics ? 1 : 0
+resource "ziti_auth_policy" "ziti_diagnostics" {
+  count = var.enable_ziti_diagnostics ? 1 : 0
 
-  name = "ziti-management-diagnostics"
+  name = "ziti-diagnostics"
 
   primary = {
     cert = {
@@ -148,13 +148,13 @@ resource "ziti_auth_policy" "ziti_management_diagnostics" {
 }
 
 # DEV/E2E ONLY: this admin identity is for diagnostics tests and must not
-# exist in production. Keep enable_ziti_management_diagnostics=false for prod.
-resource "ziti_identity_updb" "ziti_management_diagnostics" {
-  name           = "ziti-management-diagnostics"
-  count          = var.enable_ziti_management_diagnostics ? 1 : 0
+# exist in production. Keep enable_ziti_diagnostics=false for prod.
+resource "ziti_identity_updb" "ziti_diagnostics" {
+  name           = "ziti-diagnostics"
+  count          = var.enable_ziti_diagnostics ? 1 : 0
   type           = "User"
-  updb_username  = "ziti-management-diagnostics"
-  auth_policy_id = ziti_auth_policy.ziti_management_diagnostics[0].id
+  updb_username  = "ziti-diagnostics"
+  auth_policy_id = ziti_auth_policy.ziti_diagnostics[0].id
   # The current Terraform provider does not expose OpenZiti's permissions
   # field, so this identity must be an admin to access management endpoints.
   # E2E only stores its one-time login credential in the platform namespace.
@@ -163,26 +163,26 @@ resource "ziti_identity_updb" "ziti_management_diagnostics" {
 }
 
 locals {
-  ziti_management_diagnostics_enrollment_jwt_payload = var.enable_ziti_management_diagnostics ? split(".", ziti_identity_updb.ziti_management_diagnostics[0].enrollment_token)[1] : ""
-  ziti_management_diagnostics_enrollment_jwt_padding = substr("===", 0, (4 - length(local.ziti_management_diagnostics_enrollment_jwt_payload) % 4) % 4)
-  ziti_management_diagnostics_enrollment_token       = var.enable_ziti_management_diagnostics ? jsondecode(base64decode(format("%s%s", replace(replace(local.ziti_management_diagnostics_enrollment_jwt_payload, "-", "+"), "_", "/"), local.ziti_management_diagnostics_enrollment_jwt_padding))).jti : ""
+  ziti_diagnostics_enrollment_jwt_payload = var.enable_ziti_diagnostics ? split(".", ziti_identity_updb.ziti_diagnostics[0].enrollment_token)[1] : ""
+  ziti_diagnostics_enrollment_jwt_padding = substr("===", 0, (4 - length(local.ziti_diagnostics_enrollment_jwt_payload) % 4) % 4)
+  ziti_diagnostics_enrollment_token       = var.enable_ziti_diagnostics ? jsondecode(base64decode(format("%s%s", replace(replace(local.ziti_diagnostics_enrollment_jwt_payload, "-", "+"), "_", "/"), local.ziti_diagnostics_enrollment_jwt_padding))).jti : ""
 }
 
-# DEV/E2E ONLY: enroll the ziti-management-diagnostics identity so tests can
+# DEV/E2E ONLY: enroll the ziti-diagnostics identity so tests can
 # read the generated password from the platform namespace. Do not enable in prod.
-resource "terraform_data" "ziti_management_diagnostics_enrollment" {
-  count = var.enable_ziti_management_diagnostics ? 1 : 0
+resource "terraform_data" "ziti_diagnostics_enrollment" {
+  count = var.enable_ziti_diagnostics ? 1 : 0
 
   input = {
     endpoint = format("https://ziti-mgmt.%s:%d/edge/client/v1", local.base_domain, local.ingress_port)
-    password = random_password.ziti_management_diagnostics[0].result
-    token    = local.ziti_management_diagnostics_enrollment_token
-    username = ziti_identity_updb.ziti_management_diagnostics[0].updb_username
+    password = random_password.ziti_diagnostics[0].result
+    token    = local.ziti_diagnostics_enrollment_token
+    username = ziti_identity_updb.ziti_diagnostics[0].updb_username
   }
 
   triggers_replace = [
-    random_password.ziti_management_diagnostics[0].result,
-    ziti_identity_updb.ziti_management_diagnostics[0].id,
+    random_password.ziti_diagnostics[0].result,
+    ziti_identity_updb.ziti_diagnostics[0].id,
   ]
 
   provisioner "local-exec" {

--- a/stacks/ziti/outputs.tf
+++ b/stacks/ziti/outputs.tf
@@ -26,11 +26,11 @@ output "ziti_management_enrollment_token" {
 }
 
 output "ziti_diagnostics_credentials" {
-  value = {
-    username = ziti_identity_updb.ziti_management_diagnostics.updb_username
-    password = random_password.ziti_management_diagnostics.result
-  }
-  description = "Username and password for the Ziti management diagnostics identity"
+  value = var.enable_ziti_management_diagnostics ? {
+    username = ziti_identity_updb.ziti_management_diagnostics[0].updb_username
+    password = random_password.ziti_management_diagnostics[0].result
+  } : null
+  description = "DEV/E2E-only username and password for ziti-management-diagnostics. Null when disabled; production must keep it disabled."
   sensitive   = true
 
   depends_on = [terraform_data.ziti_management_diagnostics_enrollment]

--- a/stacks/ziti/outputs.tf
+++ b/stacks/ziti/outputs.tf
@@ -24,3 +24,14 @@ output "ziti_management_enrollment_token" {
   description = "Enrollment JWT for the ziti-management identity"
   sensitive   = true
 }
+
+output "ziti_diagnostics_credentials" {
+  value = {
+    username = ziti_identity_updb.ziti_management_diagnostics.updb_username
+    password = random_password.ziti_management_diagnostics.result
+  }
+  description = "Username and password for the Ziti management diagnostics identity"
+  sensitive   = true
+
+  depends_on = [terraform_data.ziti_management_diagnostics_enrollment]
+}

--- a/stacks/ziti/outputs.tf
+++ b/stacks/ziti/outputs.tf
@@ -26,12 +26,12 @@ output "ziti_management_enrollment_token" {
 }
 
 output "ziti_diagnostics_credentials" {
-  value = var.enable_ziti_management_diagnostics ? {
-    username = ziti_identity_updb.ziti_management_diagnostics[0].updb_username
-    password = random_password.ziti_management_diagnostics[0].result
+  value = var.enable_ziti_diagnostics ? {
+    username = ziti_identity_updb.ziti_diagnostics[0].updb_username
+    password = random_password.ziti_diagnostics[0].result
   } : null
-  description = "DEV/E2E-only username and password for ziti-management-diagnostics. Null when disabled; production must keep it disabled."
+  description = "DEV/E2E-only username and password for ziti-diagnostics. Null when disabled; production must keep it disabled."
   sensitive   = true
 
-  depends_on = [terraform_data.ziti_management_diagnostics_enrollment]
+  depends_on = [terraform_data.ziti_diagnostics_enrollment]
 }

--- a/stacks/ziti/variables.tf
+++ b/stacks/ziti/variables.tf
@@ -16,8 +16,8 @@ variable "ziti_router_chart_version" {
   default     = "3.0.0-pre5"
 }
 
-variable "enable_ziti_management_diagnostics" {
+variable "enable_ziti_diagnostics" {
   type        = bool
-  description = "DEV/E2E-only: create the ziti-management-diagnostics admin identity and credentials. Production deployments must leave this false."
+  description = "DEV/E2E-only: create the ziti-diagnostics admin identity and credentials. Production deployments must leave this false."
   default     = false
 }

--- a/stacks/ziti/variables.tf
+++ b/stacks/ziti/variables.tf
@@ -15,3 +15,9 @@ variable "ziti_router_chart_version" {
   description = "OpenZiti router chart version"
   default     = "3.0.0-pre5"
 }
+
+variable "enable_ziti_management_diagnostics" {
+  type        = bool
+  description = "DEV/E2E-only: create the ziti-management-diagnostics admin identity and credentials. Production deployments must leave this false."
+  default     = false
+}

--- a/stacks/ziti/versions.tf
+++ b/stacks/ziti/versions.tf
@@ -14,6 +14,10 @@ terraform {
       source  = "hashicorp/helm"
       version = "~> 2.13"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
   }
 
   backend "local" {


### PR DESCRIPTION
## Summary

- Creates a generic `ziti-diagnostics` UPDB Ziti management identity for reusable E2E diagnostics only.
- Guards all `ziti-diagnostics` Ziti identity, platform secret, and RBAC resources behind `enable_ziti_diagnostics`, which defaults to `false`.
- Publishes its credentials into the platform namespace as `ziti-diagnostics` only when the DEV/E2E-only flag is explicitly enabled.
- Grants `platform:agents-orchestrator-e2e` get-only RBAC for that dedicated secret only when the DEV/E2E-only flag is explicitly enabled.
- Documents that production deployments must not enable this flag and must not create these resources.

## Production Safety Warning

`ziti-diagnostics` is **DEV/E2E-only**. It creates and publishes a dedicated admin UPDB credential because the current `netfoundry/ziti` Terraform provider does not expose OpenZiti's granular `permissions` field on identities. Production deployments must leave `enable_ziti_diagnostics=false` in both the `stacks/ziti` and `stacks/platform` stacks so the identity, secret, and RBAC do not exist.

Fixes agynio/e2e#170
Closes #543

## Test & Lint Summary

- `terraform -chdir=/workspace/bootstrap/stacks/ziti fmt -check -recursive`: passed with no formatting changes needed.
- `terraform -chdir=/workspace/bootstrap/stacks/platform fmt -check -recursive`: passed with no formatting changes needed.
- `terraform -chdir=/workspace/bootstrap/stacks/ziti validate`: passed.
- `terraform -chdir=/workspace/bootstrap/stacks/platform validate`: passed.
