### PR TITLE
feat: speed up bootstrap provisioning caches

### DIFF
--- a/.github/actions/provision/action.yml
+++ b/.github/actions/provision/action.yml
@@ -48,6 +48,22 @@ runs:
       with:
         terraform_version: 1.6.6
 
+    - name: Restore Terraform plugin cache
+      uses: actions/cache@v4
+      with:
+        path: .terraform.d/plugin-cache
+        key: terraform-plugin-cache-${{ runner.os }}-${{ runner.arch }}-1.6.6-${{ hashFiles('bootstrap/stacks/*/.terraform.lock.hcl') }}
+        restore-keys: |
+          terraform-plugin-cache-${{ runner.os }}-${{ runner.arch }}-1.6.6-
+
+    - name: Configure Terraform plugin cache
+      shell: bash
+      working-directory: bootstrap
+      run: |
+        set -euo pipefail
+        mkdir -p "$GITHUB_WORKSPACE/.terraform.d/plugin-cache"
+        echo "TF_PLUGIN_CACHE_DIR=$GITHUB_WORKSPACE/.terraform.d/plugin-cache" >> "$GITHUB_ENV"
+
     - name: Apply bootstrap stacks
       shell: bash
       working-directory: bootstrap

--- a/README.md
+++ b/README.md
@@ -80,3 +80,24 @@ Both the `stacks/ziti` and `stacks/platform` Terraform stacks guard the
 diagnostics resources behind `enable_ziti_diagnostics`, which
 defaults to `false`. Only enable it in DEV/E2E environments, and keep the value
 disabled for production plans and applies.
+
+## Image preload
+
+`apply.sh` can pre-pull bootstrap images into Docker and import manifest images
+into the k3d cluster to reduce warm-cache provisioning time and external image
+pull flakiness.
+
+Configure preloading with:
+
+```sh
+BOOTSTRAP_PRELOAD_IMAGES=auto|always|never ./apply.sh -y
+```
+
+Modes:
+
+- `auto` (default): warn and continue if preloading is unavailable or fails.
+- `always`: fail immediately if an image cannot be pulled or imported.
+- `never`: skip all image preload work.
+
+The manifest defaults to `image-cache/bootstrap-images.txt` and supports blank
+lines and `#` comments. Override it with `BOOTSTRAP_IMAGE_MANIFEST`.

--- a/apply.sh
+++ b/apply.sh
@@ -8,6 +8,10 @@ DEFAULT_OIDC_ISSUER_URL="https://mockauth.dev/r/301ebb13-15a8-48f4-baac-e3fa25be
 DEFAULT_OIDC_CLIENT_ID="client_MU95KU3gHQf5Ir7p"
 DEFAULT_OIDC_CLIENT_SECRET="XPKka2i9uzISrKZ95zxli8sY51BK4eTJ"
 DEFAULT_K3D_PROXY_IMAGE="ghcr.io/k3d-io/k3d-proxy:5.7.5"
+DEFAULT_K3D_TOOLS_IMAGE="ghcr.io/k3d-io/k3d-tools:5.7.5"
+DEFAULT_K3S_IMAGE="rancher/k3s:v1.34.3-k3s1"
+DEFAULT_CLUSTER_NAME="agyn-local"
+DEFAULT_BOOTSTRAP_IMAGE_MANIFEST="image-cache/bootstrap-images.txt"
 KUBECONFIG_PATH="stacks/k8s/.kube/agyn-local-kubeconfig.yaml"
 
 auto_approve="false"
@@ -32,6 +36,8 @@ Environment variables:
   GHCR_TOKEN           Optional GHCR token for private OCI charts
   K3D_IMAGE_LOADBALANCER  Override the k3d load balancer image
                           (default: ghcr.io/k3d-io/k3d-proxy:5.7.5)
+  BOOTSTRAP_PRELOAD_IMAGES  Image preload mode: auto, always, or never (default: auto)
+  BOOTSTRAP_IMAGE_MANIFEST  Image manifest path (default: image-cache/bootstrap-images.txt)
 EOF
 }
 
@@ -167,7 +173,44 @@ ghcr_token="${GHCR_TOKEN:-}"
 export K3D_IMAGE_LOADBALANCER="${K3D_IMAGE_LOADBALANCER:-${DEFAULT_K3D_PROXY_IMAGE}}"
 echo "Using k3d load balancer image: ${K3D_IMAGE_LOADBALANCER}"
 
+bootstrap_preload_images="${BOOTSTRAP_PRELOAD_IMAGES:-auto}"
+bootstrap_image_manifest="${BOOTSTRAP_IMAGE_MANIFEST:-${DEFAULT_BOOTSTRAP_IMAGE_MANIFEST}}"
+case "${bootstrap_preload_images}" in
+  auto|always|never)
+    ;;
+  *)
+    echo "Error: BOOTSTRAP_PRELOAD_IMAGES must be one of: auto, always, never." >&2
+    exit 1
+    ;;
+esac
+echo "Image preload mode: ${bootstrap_preload_images}"
+echo "Image manifest: ${bootstrap_image_manifest}"
+
 printf '\nUsing domain: %s\nUsing port:   %s\n\n' "${domain}" "${port}"
+
+preload_images() {
+  ./scripts/preload-images.sh \
+    --mode "${bootstrap_preload_images}" \
+    --cluster "${DEFAULT_CLUSTER_NAME}" \
+    --manifest "${bootstrap_image_manifest}" \
+    "$@"
+}
+
+print_image_pull_diagnostics() {
+  if [[ ! -f "${KUBECONFIG_PATH}" ]]; then
+    return 0
+  fi
+
+  echo "--- Image pull related events ---"
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" get events --all-namespaces --sort-by='.lastTimestamp' 2>/dev/null \
+    | grep -E 'Pulling|Pulled|Failed|ErrImagePull|ImagePullBackOff' \
+    | tail -100 || true
+
+  echo "--- Pending pod images ---"
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" get pods --all-namespaces \
+    -o jsonpath='{range .items[?(@.status.phase=="Pending")]}{.metadata.namespace}{"/"}{.metadata.name}{"\t"}{range .spec.initContainers[*]}{.image}{" "}{end}{range .spec.containers[*]}{.image}{" "}{end}{"\n"}{end}' 2>/dev/null || true
+}
+
 
 run_stack() {
   local stack="$1"
@@ -383,9 +426,17 @@ print_timing_summary() {
 
 global_start="${SECONDS}"
 
+step_start "preload:k3d"
+preload_images --pull-only --images "${DEFAULT_K3S_IMAGE}" "${K3D_IMAGE_LOADBALANCER}" "${DEFAULT_K3D_TOOLS_IMAGE}"
+step_end "preload:k3d"
+
 step_start "stack:k8s"
 run_stack "k8s"
 step_end "stack:k8s"
+
+step_start "preload:cluster"
+preload_images
+step_end "preload:cluster"
 
 step_start "stack:system"
 run_stack "system"
@@ -437,6 +488,7 @@ for app in cert-manager trust-manager ziti-controller; do
     echo "--- ${app} namespace events ---"
     kubectl --kubeconfig "${KUBECONFIG_PATH}" \
       -n "${ns}" get events --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+    print_image_pull_diagnostics
     exit 1
   fi
 done
@@ -457,6 +509,7 @@ done
 
 if [[ "${management_ready}" -ne 1 ]]; then
   echo "ERROR: OpenZiti Management API did not become ready." >&2
+  print_image_pull_diagnostics
   exit 1
 fi
 
@@ -480,6 +533,7 @@ if [ "${ZITI_EXIT}" -ne 0 ]; then
   echo "--- Router events ---"
   kubectl --kubeconfig "${KUBECONFIG_PATH}" \
     -n ziti get events --sort-by='.lastTimestamp' --field-selector reason!=Pulled 2>&1 | tail -20 || true
+  print_image_pull_diagnostics
   exit "${ZITI_EXIT}"
 fi
 step_end "stack:ziti"
@@ -527,6 +581,7 @@ for app in identity organizations gateway apps runners; do
     echo "--- ${app} namespace events ---"
     kubectl --kubeconfig "${KUBECONFIG_PATH}" \
       -n "${ns}" get events --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+    print_image_pull_diagnostics
     exit 1
   fi
 done
@@ -554,6 +609,7 @@ done
 
 if [[ "${gateway_ready}" -ne 1 ]]; then
   echo "ERROR: Gateway did not become ready at ${gateway_base_url}" >&2
+  print_image_pull_diagnostics
   exit 1
 fi
 

--- a/image-cache/bootstrap-images.txt
+++ b/image-cache/bootstrap-images.txt
@@ -1,0 +1,47 @@
+# k3d cluster images are pre-pulled before cluster creation by apply.sh.
+
+rancher/mirrored-pause:3.6
+rancher/mirrored-coredns-coredns:1.13.1
+rancher/local-path-provisioner:v0.0.32
+rancher/mirrored-metrics-server:v0.8.0
+rancher/klipper-lb:v0.4.13
+docker.io/istio/pilot:1.21.0
+docker.io/istio/proxyv2:1.21.0
+quay.io/argoproj/argocd:v3.3.1
+ecr-public.aws.com/docker/library/redis:8.2.3-alpine
+
+# Core platform dependencies
+quay.io/minio/minio:RELEASE.2024-11-07T00-52-20Z
+postgres:16.6-alpine
+
+# Agyn platform services
+ghcr.io/agynio/agents-orchestrator:0.13.17
+ghcr.io/agynio/threads:0.4.13
+ghcr.io/agynio/metering:0.1.3
+ghcr.io/agynio/tracing:v0.3.4
+ghcr.io/agynio/chat:0.3.4
+ghcr.io/agynio/chat-app:0.4.17
+ghcr.io/agynio/console-app:0.10.9
+ghcr.io/agynio/tracing-app:0.3.0
+ghcr.io/agynio/files:0.1.4
+ghcr.io/agynio/media-proxy:0.1.5
+ghcr.io/agynio/llm:v0.4.4
+ghcr.io/agynio/llm-proxy:0.12.5
+ghcr.io/agynio/secrets:v0.2.0
+ghcr.io/agynio/token-counting:v0.3.2
+ghcr.io/agynio/notifications:0.2.7
+ghcr.io/agynio/agents:0.7.5
+ghcr.io/agynio/ziti-management:0.10.10
+ghcr.io/agynio/users:0.5.2
+ghcr.io/agynio/expose:0.1.6
+ghcr.io/agynio/organizations:0.4.4
+ghcr.io/agynio/authorization:0.5.4
+ghcr.io/agynio/identity:0.2.2
+ghcr.io/agynio/runners:0.5.11
+ghcr.io/agynio/apps:0.4.2
+ghcr.io/agynio/gateway:0.22.10
+
+# Demo apps
+ghcr.io/agynio/reminders:0.2.5
+ghcr.io/agynio/telegram-connector:0.1.5
+ghcr.io/agynio/k8s-runner:0.10.13

--- a/scripts/preload-images.sh
+++ b/scripts/preload-images.sh
@@ -206,13 +206,19 @@ run_preload() {
       cache_hits=$(( cache_hits + 1 ))
       echo "Image preload: cache hit ${image}"
     else
-      pull_image "${image}"
+      if ! pull_image "${image}"; then
+        echo "Error: failed to pull ${image}." >&2
+        return 1
+      fi
       pulls=$(( pulls + 1 ))
     fi
 
     if [[ "${pull_only}" == "false" ]]; then
       echo "Image preload: importing ${image}"
-      k3d image import "${image}" --cluster "${cluster_name}"
+      if ! k3d image import "${image}" --cluster "${cluster_name}"; then
+        echo "Error: failed to import ${image} into k3d cluster ${cluster_name}." >&2
+        return 1
+      fi
       imports=$(( imports + 1 ))
     fi
   done

--- a/scripts/preload-images.sh
+++ b/scripts/preload-images.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/preload-images.sh --mode auto|always|never [--cluster CLUSTER] --manifest FILE [--images IMAGE...] [--pull-only] [--retry-pulls N]
+
+Options:
+  --mode        Preload behavior: auto warns and continues, always fails, never no-ops.
+  --cluster     k3d cluster name used for imports. Required unless --pull-only is set.
+  --manifest    Image manifest file. Lines may contain comments beginning with #.
+  --images      Optional explicit images to preload instead of manifest images.
+  --pull-only   Pull missing images into the Docker cache without importing into k3d.
+  --retry-pulls Number of docker pull attempts per image (default: 3).
+USAGE
+}
+
+mode="auto"
+cluster_name=""
+manifest_path="image-cache/bootstrap-images.txt"
+pull_only="false"
+pull_attempts="3"
+declare -a cli_images=()
+declare -a images=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --mode requires a value." >&2
+        exit 1
+      fi
+      mode="$2"
+      shift 2
+      ;;
+    --cluster)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --cluster requires a value." >&2
+        exit 1
+      fi
+      cluster_name="$2"
+      shift 2
+      ;;
+    --manifest)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --manifest requires a value." >&2
+        exit 1
+      fi
+      manifest_path="$2"
+      shift 2
+      ;;
+    --images)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo "Error: --images requires at least one image." >&2
+        exit 1
+      fi
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --*)
+            break
+            ;;
+          *)
+            cli_images+=("$1")
+            shift
+            ;;
+        esac
+      done
+      ;;
+    --pull-only)
+      pull_only="true"
+      shift
+      ;;
+    --retry-pulls)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --retry-pulls requires a value." >&2
+        exit 1
+      fi
+      pull_attempts="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Error: unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+case "${mode}" in
+  auto|always|never)
+    ;;
+  *)
+    echo "Error: --mode must be one of: auto, always, never." >&2
+    exit 1
+    ;;
+esac
+
+if ! [[ "${pull_attempts}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Error: --retry-pulls must be a positive integer." >&2
+  exit 1
+fi
+
+format_duration() {
+  local total_seconds="$1"
+  local minutes
+  local seconds
+
+  if (( total_seconds < 60 )); then
+    printf '%ss' "${total_seconds}"
+    return
+  fi
+
+  minutes=$(( total_seconds / 60 ))
+  seconds=$(( total_seconds % 60 ))
+  printf '%sm %ss' "${minutes}" "${seconds}"
+}
+
+normalize_manifest_line() {
+  local line="$1"
+
+  line="${line%%#*}"
+  line="${line#"${line%%[![:space:]]*}"}"
+  line="${line%"${line##*[![:space:]]}"}"
+  printf '%s' "${line}"
+}
+
+load_manifest_images() {
+  local image
+  local line
+  local -A seen=()
+
+  if [[ ! -f "${manifest_path}" ]]; then
+    echo "Error: image manifest not found: ${manifest_path}" >&2
+    return 1
+  fi
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    image="$(normalize_manifest_line "${line}")"
+    if [[ -z "${image}" || -n "${seen[${image}]:-}" ]]; then
+      continue
+    fi
+    seen["${image}"]=1
+    images+=("${image}")
+  done <"${manifest_path}"
+}
+
+pull_image() {
+  local image="$1"
+  local attempt
+
+  for attempt in $(seq 1 "${pull_attempts}"); do
+    echo "Image preload: pulling ${image} (attempt ${attempt}/${pull_attempts})"
+    if docker pull "${image}"; then
+      return 0
+    fi
+
+    if (( attempt == pull_attempts )); then
+      return 1
+    fi
+
+    sleep $(( attempt * 5 ))
+  done
+}
+
+run_preload() {
+  local image
+  local start_time="${SECONDS}"
+  local cache_hits=0
+  local pulls=0
+  local imports=0
+  local elapsed
+  local formatted_duration
+
+  if (( ${#images[@]} == 0 )); then
+    echo "Image preload: no images to preload (mode=${mode})."
+    return 0
+  fi
+
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Error: required command not found: docker" >&2
+    return 1
+  fi
+
+  if [[ "${pull_only}" == "false" ]]; then
+    if ! command -v k3d >/dev/null 2>&1; then
+      echo "Error: required command not found: k3d" >&2
+      return 1
+    fi
+
+    if [[ -z "${cluster_name}" ]]; then
+      echo "Error: --cluster is required unless --pull-only is set." >&2
+      return 1
+    fi
+  fi
+
+  echo "Image preload: mode=${mode} cluster=${cluster_name:-none} pull_only=${pull_only} images=${#images[@]}"
+
+  for image in "${images[@]}"; do
+    if docker image inspect "${image}" >/dev/null 2>&1; then
+      cache_hits=$(( cache_hits + 1 ))
+      echo "Image preload: cache hit ${image}"
+    else
+      pull_image "${image}"
+      pulls=$(( pulls + 1 ))
+    fi
+
+    if [[ "${pull_only}" == "false" ]]; then
+      echo "Image preload: importing ${image}"
+      k3d image import "${image}" --cluster "${cluster_name}"
+      imports=$(( imports + 1 ))
+    fi
+  done
+
+  elapsed=$(( SECONDS - start_time ))
+  formatted_duration="$(format_duration "${elapsed}")"
+  echo "Image preload summary: images=${#images[@]} cache_hits=${cache_hits} pulls=${pulls} imports=${imports} duration=${formatted_duration}"
+}
+
+main() {
+  local preload_status=0
+
+  echo "Image preload requested: mode=${mode} manifest=${manifest_path} pull_only=${pull_only}"
+
+  if [[ "${mode}" == "never" ]]; then
+    echo "Image preload skipped because mode=never."
+    return 0
+  fi
+
+  if (( ${#cli_images[@]} > 0 )); then
+    images=("${cli_images[@]}")
+  else
+    load_manifest_images || preload_status=$?
+  fi
+
+  if [[ "${preload_status}" -eq 0 ]]; then
+    run_preload || preload_status=$?
+  fi
+
+  if [[ "${preload_status}" -eq 0 ]]; then
+    return 0
+  fi
+
+  if [[ "${mode}" == "auto" ]]; then
+    echo "Warning: image preload failed with exit code ${preload_status}; continuing because mode=auto." >&2
+    return 0
+  fi
+
+  echo "Error: image preload failed with exit code ${preload_status}." >&2
+  return "${preload_status}"
+}
+
+main


### PR DESCRIPTION
## Summary
- Adds Terraform plugin cache restore/save to the bootstrap provision composite action.
- Adds manifest-driven k3d image preload support with `auto`, `always`, and `never` modes.
- Wires pre-pull before `stack:k8s`, cluster import after `stack:k8s`, timing output, and image-pull diagnostics on failures.

Closes #545

## Test & Lint Summary
- `terraform fmt -recursive -check`: passed with no formatting changes required.
- `for stack in stacks/k8s stacks/system stacks/routing stacks/deps stacks/ziti stacks/data stacks/platform stacks/apps; do terraform -chdir="$stack" init -input=false -backend=false; terraform -chdir="$stack" validate; done`: 8 passed / 0 failed / 0 skipped.
- `bash -n apply.sh .github/scripts/verify_platform_health.sh scripts/preload-images.sh`: 3 passed / 0 failed / 0 skipped.
- `./scripts/preload-images.sh --mode never --cluster agyn-local --manifest image-cache/bootstrap-images.txt`: 1 passed / 0 failed / 0 skipped.
- `./scripts/preload-images.sh --mode auto --pull-only --retry-pulls 1 --manifest /no/such/file`: 1 passed / 0 failed / 0 skipped (warned and continued as expected).
- `./scripts/preload-images.sh --mode always --pull-only --retry-pulls 1 --manifest /no/such/file`: 1 passed / 0 failed / 0 skipped (failed as expected).

## Bootstrap Verification Notes
- `BOOTSTRAP_PRELOAD_IMAGES=never ./apply.sh -y` was attempted locally but did not complete due external registry pull instability/timeouts in the environment. The failure reproduced the issue's target failure mode, e.g. k3d/k3s pods and Argo CD waited on external pulls such as `quay.io/argoproj/argocd:v3.3.1` and `ecr-public.aws.com/docker/library/redis:8.2.3-alpine`.
- `BOOTSTRAP_PRELOAD_IMAGES=auto ./apply.sh -y` was not completed after the disabled-preload run remained blocked by the local cluster's tainted/partial Helm state from those external pull failures.
- No `registry-mirror` or `ncps` apps were introduced.