### PR TITLE
chore(platform): bump tracing/expose chart versions

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -57,7 +57,7 @@ variable "metering_chart_version" {
 variable "tracing_chart_version" {
   type        = string
   description = "Version of the tracing Helm chart published to GHCR"
-  default     = "0.3.4"
+  default     = "0.3.5"
 }
 
 variable "token_counting_chart_version" {
@@ -105,7 +105,7 @@ variable "users_chart_version" {
 variable "expose_chart_version" {
   type        = string
   description = "Version of the expose Helm chart published to GHCR"
-  default     = "0.1.6"
+  default     = "0.1.7"
 }
 
 variable "organizations_chart_version" {


### PR DESCRIPTION
### Why

`agynio/agents-orchestrator` main E2E is still deploying older `expose`/`tracing` charts/images, so it does not pick up recently merged fixes:
- Expose fix: https://github.com/agynio/expose/pull/30
- Tracing fix: https://github.com/agynio/tracing/pull/20

This PR bumps the default chart versions used by the bootstrap `platform` stack so new ephemeral/E2E clusters deploy the updated charts.

### Changes

- `tracing_chart_version`: `0.3.4` -> `0.3.5`
- `expose_chart_version`: `0.1.6` -> `0.1.7`

### Acceptance

- E2E environment deploys updated `ghcr.io/agynio/tracing:v0.3.5` and `ghcr.io/agynio/expose:0.1.7` (or whatever those charts reference).
- Rerun `agents-orchestrator` main E2E and confirm previous expose/tracing failures are resolved.