### PR TITLE
feat: add egress gateway bootstrap resources

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1389,10 +1389,11 @@ resource "kubernetes_manifest" "egress_ca_certificate" {
       "commonName"  = "Agyn Egress CA"
       "secretName"  = "egress-ca"
       "duration"    = "87600h"
-      "renewBefore" = "720h"
+      "renewBefore" = "8760h"
       "privateKey" = {
-        "algorithm" = "ECDSA"
-        "size"      = 256
+        "algorithm"      = "ECDSA"
+        "rotationPolicy" = "Always"
+        "size"           = 256
       }
       "issuerRef" = {
         "name"  = kubernetes_manifest.agyn_selfsigned_cluster_issuer.manifest.metadata.name

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1363,6 +1363,53 @@ resource "kubernetes_secret_v1" "ziti_management_enrollment" {
   }
 }
 
+resource "kubernetes_manifest" "agyn_selfsigned_cluster_issuer" {
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "ClusterIssuer"
+    "metadata" = {
+      "name" = "agyn-selfsigned"
+    }
+    "spec" = {
+      "selfSigned" = {}
+    }
+  }
+}
+
+resource "kubernetes_manifest" "egress_ca_certificate" {
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "Certificate"
+    "metadata" = {
+      "name"      = "egress-ca"
+      "namespace" = kubernetes_namespace.platform.metadata[0].name
+    }
+    "spec" = {
+      "isCA"        = true
+      "commonName"  = "Agyn Egress CA"
+      "secretName"  = "egress-ca"
+      "duration"    = "87600h"
+      "renewBefore" = "720h"
+      "privateKey" = {
+        "algorithm" = "ECDSA"
+        "size"      = 256
+      }
+      "issuerRef" = {
+        "name"  = kubernetes_manifest.agyn_selfsigned_cluster_issuer.manifest.metadata.name
+        "kind"  = "ClusterIssuer"
+        "group" = "cert-manager.io"
+      }
+    }
+  }
+
+  computed_fields = [
+    "metadata.annotations",
+    "metadata.labels",
+  ]
+
+  depends_on = [kubernetes_manifest.agyn_selfsigned_cluster_issuer]
+}
+
 # DEV/E2E ONLY: ziti-diagnostics contains admin UPDB credentials
 # for diagnostics tests. Keep enable_ziti_diagnostics=false in prod.
 resource "kubernetes_secret_v1" "ziti_diagnostics" {

--- a/stacks/ziti/main.tf
+++ b/stacks/ziti/main.tf
@@ -282,6 +282,13 @@ resource "ziti_service_policy" "llm_proxy_bind" {
   serviceroles  = [format("@%s", ziti_service.llm_proxy.id)]
 }
 
+resource "ziti_service_policy" "egress_gateway_bind" {
+  name          = "egress-gateway-bind"
+  type          = "Bind"
+  identityroles = ["#egress-gateway-hosts"]
+  serviceroles  = ["#egress-services"]
+}
+
 resource "ziti_service_policy" "agents_dial_llm_proxy" {
   name          = "agents-dial-llm-proxy"
   type          = "Dial"


### PR DESCRIPTION
## Summary
- Adds cert-manager resources for `agyn-selfsigned` `ClusterIssuer` and `egress-ca` CA `Certificate` in the platform namespace.
- Adds the static OpenZiti `egress-gateway-bind` Bind policy from `#egress-gateway-hosts` to `#egress-services`.

## Issue
Part of agynio/architecture#151.

## Test & Lint Summary
- `terraform fmt -check -recursive`: passed with no errors.
- `terraform -chdir=stacks/ziti init -backend=false`: passed.
- `terraform -chdir=stacks/ziti validate`: passed.
- `terraform -chdir=stacks/platform init -backend=false`: passed.
- `terraform -chdir=stacks/platform validate`: passed.
- Tests: not applicable for Terraform-only bootstrap changes.
