### PR TITLE
fix(platform): pin tracing v0.3.6

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -57,7 +57,7 @@ variable "metering_chart_version" {
 variable "tracing_chart_version" {
   type        = string
   description = "Version of the tracing Helm chart published to GHCR"
-  default     = "0.3.5"
+  default     = "0.3.6"
 }
 
 variable "token_counting_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -105,7 +105,7 @@ variable "users_chart_version" {
 variable "expose_chart_version" {
   type        = string
   description = "Version of the expose Helm chart published to GHCR"
-  default     = "0.1.7"
+  default     = "0.1.8"
 }
 
 variable "organizations_chart_version" {


### PR DESCRIPTION
## Summary
- Pin the platform tracing chart/image default to `0.3.6`.
- Pin the platform expose chart/image default to `0.1.8`.
- Picks up agynio/tracing#22 so `ListSpans(filter.message_id)` can resolve message IDs stored on span attributes.
- Picks up agynio/expose#32 so active exposure responses fail loudly if OpenZiti IDs/URL are incomplete.

## Context
- Keeps agynio/agents-orchestrator#207 as the cross-repo E2E tracker.
- Fixes #549.
- Related expose tracker: agynio/expose#31.

## Tests
- `git diff --check`
- `terraform -chdir=stacks/platform init -backend=false`
- `terraform -chdir=stacks/platform validate`