### PR TITLE
bootstrap: set WORKLOAD_DNS_UPSTREAM default for agents-orchestrator

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -790,6 +790,10 @@ locals {
         value = "openziti/ziti-tunnel:2.0.0-pre8"
       },
       {
+        name  = "WORKLOAD_DNS_UPSTREAM"
+        value = "1.1.1.1"
+      },
+      {
         name  = "RUNNER_ADDRESS"
         value = "k8s-runner:50051"
       },


### PR DESCRIPTION
Sets  in the agents-orchestrator env list so Ziti-enabled workload pods can resolve non-Ziti DNS without relying on in-cluster CoreDNS by default. Users can override this for their environment if needed.