### PR TITLE
fix(platform): remove duplicate gateway deployment names

### DIFF
--- a/stacks/apps/main.tf
+++ b/stacks/apps/main.tf
@@ -92,7 +92,7 @@ locals {
       },
       {
         name  = "GATEWAY_URL"
-        value = "http://gateway-gateway.platform.svc.cluster.local:8080"
+        value = "http://gateway.platform.svc.cluster.local:8080"
       },
       {
         name = "SERVICE_TOKEN"
@@ -174,7 +174,7 @@ locals {
       },
       {
         name  = "GATEWAY_URL"
-        value = "http://gateway-gateway.platform.svc.cluster.local:8080"
+        value = "http://gateway.platform.svc.cluster.local:8080"
       },
       {
         name  = "ZITI_SERVICE_NAME"
@@ -228,7 +228,7 @@ locals {
       },
       {
         name  = "GATEWAY_ADDRESS"
-        value = "gateway-gateway:8080"
+        value = "gateway:8080"
       },
       {
         name = "CAPABILITY_IMPLEMENTATIONS"

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1516,7 +1516,7 @@ resource "kubernetes_manifest" "virtualservice_chat_app" {
           "route" = [
             {
               "destination" = {
-                "host" = "gateway-gateway.platform.svc.cluster.local"
+                "host" = "gateway.platform.svc.cluster.local"
                 "port" = {
                   "number" = 8080
                 }
@@ -1535,7 +1535,7 @@ resource "kubernetes_manifest" "virtualservice_chat_app" {
           "route" = [
             {
               "destination" = {
-                "host" = "gateway-gateway.platform.svc.cluster.local"
+                "host" = "gateway.platform.svc.cluster.local"
                 "port" = {
                   "number" = 8080
                 }
@@ -1607,7 +1607,7 @@ resource "kubernetes_manifest" "virtualservice_console_app" {
           "route" = [
             {
               "destination" = {
-                "host" = "gateway-gateway.platform.svc.cluster.local"
+                "host" = "gateway.platform.svc.cluster.local"
                 "port" = {
                   "number" = 8080
                 }
@@ -1626,7 +1626,7 @@ resource "kubernetes_manifest" "virtualservice_console_app" {
           "route" = [
             {
               "destination" = {
-                "host" = "gateway-gateway.platform.svc.cluster.local"
+                "host" = "gateway.platform.svc.cluster.local"
                 "port" = {
                   "number" = 8080
                 }
@@ -1698,7 +1698,7 @@ resource "kubernetes_manifest" "virtualservice_tracing_app" {
           "route" = [
             {
               "destination" = {
-                "host" = "gateway-gateway.platform.svc.cluster.local"
+                "host" = "gateway.platform.svc.cluster.local"
                 "port" = {
                   "number" = 8080
                 }
@@ -1717,7 +1717,7 @@ resource "kubernetes_manifest" "virtualservice_tracing_app" {
           "route" = [
             {
               "destination" = {
-                "host" = "gateway-gateway.platform.svc.cluster.local"
+                "host" = "gateway.platform.svc.cluster.local"
                 "port" = {
                   "number" = 8080
                 }
@@ -1781,7 +1781,7 @@ resource "kubernetes_manifest" "virtualservice_gateway" {
           "route" = [
             {
               "destination" = {
-                "host" = "gateway-gateway.platform.svc.cluster.local"
+                "host" = "gateway.platform.svc.cluster.local"
                 "port" = {
                   "number" = 8080
                 }
@@ -1871,7 +1871,7 @@ resource "kubernetes_manifest" "virtualservice_llm_proxy" {
           "route" = [
             {
               "destination" = {
-                "host" = "llm-proxy-llm-proxy.platform.svc.cluster.local"
+                "host" = "llm-proxy.platform.svc.cluster.local"
                 "port" = {
                   "number" = 8080
                 }

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -3970,7 +3970,8 @@ resource "argocd_application" "gateway" {
 
       helm {
         values = yamlencode({
-          replicaCount = 1
+          replicaCount     = 1
+          fullnameOverride = "gateway"
           image = {
             tag = local.resolved_gateway_image_tag
           }
@@ -4037,7 +4038,8 @@ resource "argocd_application" "llm_proxy" {
 
       helm {
         values = yamlencode({
-          replicaCount = 1
+          replicaCount     = 1
+          fullnameOverride = "llm-proxy"
           image = {
             tag = local.resolved_llm_proxy_image_tag
           }


### PR DESCRIPTION
## Summary
- Add `fullnameOverride = "gateway"` to the gateway Argo CD Helm values.
- Add `fullnameOverride = "llm-proxy"` to the llm-proxy Argo CD Helm values.
- Keep service discovery values and all other deployment values unchanged.

Closes #555

## Test & Lint Summary
- `terraform -chdir=stacks/platform init -backend=false -input=false`: passed
- `terraform -chdir=stacks/platform fmt -check -diff -recursive`: passed with no formatting changes required
- `terraform -chdir=stacks/platform validate`: passed
- `git diff --check`: passed with no whitespace errors