### PR TITLE
chore(console): bump chart pin

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -147,7 +147,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.10.9"
+  default     = "0.10.10"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
## Summary
- Bumps `console_app_chart_version` from `0.10.9` to `0.10.10` so bootstrap deploys the Console build that includes the TooltipProvider fix.
- Verified the `0.10.10` Helm chart and image are published before changing the pin.

## Coupled e2e PR
This bootstrap PR is coupled with agynio/e2e#197 for #196. The e2e PR adds the centralized Console navigation crash regression coverage; this PR fixes the deployed bootstrap version mismatch that was still serving the pre-fix Console build.

References agynio/e2e#196.

## Test & Lint Summary
- `helm show chart oci://ghcr.io/agynio/charts/console-app --version 0.10.10`: chart availability verified.
- `docker manifest inspect ghcr.io/agynio/console-app:0.10.10`: image availability verified.
- `cd /workspace/bootstrap && terraform -chdir=stacks/platform fmt -check`: formatting passed with 0 errors.
- `cd /workspace/bootstrap && git diff --check`: lint/whitespace check passed with no errors.