### PR TITLE
fix(platform): add workload Ziti DNS resolver

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -60,6 +60,8 @@ locals {
   ziti_diagnostics_secret_name  = "ziti-diagnostics"
   istio_gateway_namespace       = data.terraform_remote_state.system.outputs.istio_gateway_namespace
   istio_gateway_tls_secret_name = data.terraform_remote_state.system.outputs.wildcard_tls_gateway_secret_name
+  ziti_namespace                = data.terraform_remote_state.system.outputs.installed_namespaces[1]
+  workload_namespace            = "agyn-workloads"
   openfga_api_url_external      = format("https://openfga.%s:%d", local.base_domain, local.ingress_port)
   openfga_api_url_internal      = format("http://openfga.%s.svc.cluster.local:8080", var.openfga_namespace)
   # Deterministic v5 UUID for the cluster admin identity.
@@ -791,7 +793,7 @@ locals {
       },
       {
         name  = "WORKLOAD_DNS_UPSTREAM"
-        value = "1.1.1.1"
+        value = kubernetes_service_v1.ziti_workload_dns.spec[0].cluster_ip
       },
       {
         name  = "RUNNER_ADDRESS"

--- a/stacks/platform/outputs.tf
+++ b/stacks/platform/outputs.tf
@@ -119,3 +119,8 @@ output "cluster_admin_api_token" {
   value       = random_password.cluster_admin_token.result
   sensitive   = true
 }
+
+output "ziti_workload_dns_service_ip" {
+  value       = kubernetes_service_v1.ziti_workload_dns.spec[0].cluster_ip
+  description = "ClusterIP for the dev/local workload-only Ziti DNS resolver"
+}

--- a/stacks/platform/remote_state.tf
+++ b/stacks/platform/remote_state.tf
@@ -26,3 +26,17 @@ data "terraform_remote_state" "ziti" {
     path = "../ziti/state/terraform.tfstate"
   }
 }
+
+data "kubernetes_service_v1" "ziti_controller_client" {
+  metadata {
+    name      = "ziti-controller-client"
+    namespace = local.ziti_namespace
+  }
+}
+
+data "kubernetes_service_v1" "ziti_router_edge" {
+  metadata {
+    name      = "ziti-router-edge"
+    namespace = local.ziti_namespace
+  }
+}

--- a/stacks/platform/ziti_workload_dns.tf
+++ b/stacks/platform/ziti_workload_dns.tf
@@ -10,21 +10,48 @@ resource "kubernetes_config_map_v1" "ziti_workload_dns" {
 
   data = {
     Corefile = <<-COREFILE
+      ziti.${local.base_domain}:53 {
+          errors
+          file /etc/coredns/ziti.db ziti.${local.base_domain}
+          cache 30
+          reload
+      }
+
+      ziti-router.${local.base_domain}:53 {
+          errors
+          file /etc/coredns/ziti-router.db ziti-router.${local.base_domain}
+          cache 30
+          reload
+      }
+
       .:53 {
           errors
           health
           ready
-          hosts {
-              ${data.kubernetes_service_v1.ziti_controller_client.spec[0].cluster_ip} ziti.${local.base_domain}
-              ${data.kubernetes_service_v1.ziti_router_edge.spec[0].cluster_ip} ziti-router.${local.base_domain}
-              fallthrough
-          }
           forward . 1.1.1.1
           cache 30
           loop
           reload
       }
     COREFILE
+
+    "ziti.db" = <<-ZONE
+      $ORIGIN ziti.${local.base_domain}.
+      $TTL 30
+      @ IN SOA ns.ziti.${local.base_domain}. hostmaster.${local.base_domain}. 1 7200 3600 1209600 30
+      @ IN NS ns.ziti.${local.base_domain}.
+      @ IN A ${data.kubernetes_service_v1.ziti_controller_client.spec[0].cluster_ip}
+      ns IN A ${data.kubernetes_service_v1.ziti_controller_client.spec[0].cluster_ip}
+    ZONE
+
+    "ziti-router.db" = <<-ZONE
+      $ORIGIN ziti-router.${local.base_domain}.
+      $TTL 30
+      @ IN SOA ns.ziti-router.${local.base_domain}. hostmaster.${local.base_domain}. 1 7200 3600 1209600 30
+      @ IN NS ns.ziti-router.${local.base_domain}.
+      @ IN A ${data.kubernetes_service_v1.ziti_router_edge.spec[0].cluster_ip}
+      ns IN A ${data.kubernetes_service_v1.ziti_router_edge.spec[0].cluster_ip}
+    ZONE
   }
 }
 

--- a/stacks/platform/ziti_workload_dns.tf
+++ b/stacks/platform/ziti_workload_dns.tf
@@ -1,0 +1,187 @@
+resource "kubernetes_config_map_v1" "ziti_workload_dns" {
+  metadata {
+    name      = "ziti-workload-dns"
+    namespace = local.ziti_namespace
+    labels = {
+      "app.kubernetes.io/name"      = "ziti-workload-dns"
+      "app.kubernetes.io/component" = "dns"
+    }
+  }
+
+  data = {
+    Corefile = <<-COREFILE
+      .:53 {
+          errors
+          health
+          ready
+          hosts {
+              ${data.kubernetes_service_v1.ziti_controller_client.spec[0].cluster_ip} ziti.${local.base_domain}
+              ${data.kubernetes_service_v1.ziti_router_edge.spec[0].cluster_ip} ziti-router.${local.base_domain}
+              fallthrough
+          }
+          forward . 1.1.1.1
+          cache 30
+          loop
+          reload
+      }
+    COREFILE
+  }
+}
+
+resource "kubernetes_deployment_v1" "ziti_workload_dns" {
+  metadata {
+    name      = "ziti-workload-dns"
+    namespace = local.ziti_namespace
+    labels = {
+      "app.kubernetes.io/name"      = "ziti-workload-dns"
+      "app.kubernetes.io/component" = "dns"
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        "app.kubernetes.io/name" = "ziti-workload-dns"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          "app.kubernetes.io/name"      = "ziti-workload-dns"
+          "app.kubernetes.io/component" = "dns"
+        }
+      }
+
+      spec {
+        container {
+          name  = "coredns"
+          image = "coredns/coredns:1.12.4"
+          args  = ["-conf", "/etc/coredns/Corefile"]
+
+          port {
+            name           = "dns"
+            container_port = 53
+            protocol       = "UDP"
+          }
+
+          port {
+            name           = "dns-tcp"
+            container_port = 53
+            protocol       = "TCP"
+          }
+
+          port {
+            name           = "health"
+            container_port = 8080
+            protocol       = "TCP"
+          }
+
+          port {
+            name           = "ready"
+            container_port = 8181
+            protocol       = "TCP"
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/health"
+              port = "health"
+            }
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/ready"
+              port = "ready"
+            }
+          }
+
+          volume_mount {
+            name       = "config"
+            mount_path = "/etc/coredns"
+            read_only  = true
+          }
+        }
+
+        volume {
+          name = "config"
+
+          config_map {
+            name = kubernetes_config_map_v1.ziti_workload_dns.metadata[0].name
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service_v1" "ziti_workload_dns" {
+  metadata {
+    name      = "ziti-workload-dns"
+    namespace = local.ziti_namespace
+    labels = {
+      "app.kubernetes.io/name"      = "ziti-workload-dns"
+      "app.kubernetes.io/component" = "dns"
+    }
+  }
+
+  spec {
+    selector = {
+      "app.kubernetes.io/name" = "ziti-workload-dns"
+    }
+
+    port {
+      name        = "dns"
+      port        = 53
+      target_port = "dns"
+      protocol    = "UDP"
+    }
+
+    port {
+      name        = "dns-tcp"
+      port        = 53
+      target_port = "dns-tcp"
+      protocol    = "TCP"
+    }
+  }
+}
+
+resource "kubernetes_network_policy_v1" "ziti_workload_dns" {
+  metadata {
+    name      = "ziti-workload-dns"
+    namespace = local.ziti_namespace
+  }
+
+  spec {
+    pod_selector {
+      match_labels = {
+        "app.kubernetes.io/name" = "ziti-workload-dns"
+      }
+    }
+
+    policy_types = ["Ingress"]
+
+    ingress {
+      from {
+        namespace_selector {
+          match_labels = {
+            "kubernetes.io/metadata.name" = local.workload_namespace
+          }
+        }
+      }
+
+      ports {
+        port     = "dns"
+        protocol = "UDP"
+      }
+
+      ports {
+        port     = "dns-tcp"
+        protocol = "TCP"
+      }
+    }
+  }
+}

--- a/stacks/platform/ziti_workload_dns.tf
+++ b/stacks/platform/ziti_workload_dns.tf
@@ -10,16 +10,16 @@ resource "kubernetes_config_map_v1" "ziti_workload_dns" {
 
   data = {
     Corefile = <<-COREFILE
-      ziti.${local.base_domain}:53 {
+      ziti.${local.base_domain}.:53 {
           errors
-          file /etc/coredns/ziti.db ziti.${local.base_domain}
+          file /etc/coredns/ziti.db ziti.${local.base_domain}.
           cache 30
           reload
       }
 
-      ziti-router.${local.base_domain}:53 {
+      ziti-router.${local.base_domain}.:53 {
           errors
-          file /etc/coredns/ziti-router.db ziti-router.${local.base_domain}
+          file /etc/coredns/ziti-router.db ziti-router.${local.base_domain}.
           cache 30
           reload
       }


### PR DESCRIPTION
## Summary
- Adds a dev/local workload-only `ziti-workload-dns` CoreDNS resolver in the Ziti namespace.
- Resolves only `ziti.<base_domain>` and `ziti-router.<base_domain>` to the in-cluster Ziti controller/router service IPs.
- Keeps general Kubernetes service discovery out of the workload DNS path by forwarding all other queries to public DNS (`1.1.1.1`).
- Wires agents-orchestrator `WORKLOAD_DNS_UPSTREAM` to the resolver ClusterIP.
- Adds an ingress NetworkPolicy allowing DNS queries from the workload namespace.

Fixes #559

## Validation
- `terraform fmt -recursive stacks/platform`
- `terraform -chdir=stacks/platform init -backend=false`
- `terraform -chdir=stacks/platform validate`
- `terraform -chdir=stacks/deps validate` attempted after provider init, but local provider cache checksums are stale/mismatched for the existing deps stack lock file; no deps stack files are changed in this PR.
- `git diff --check`

## Notes
- Runtime resolver checks require an applied dev/local cluster:
  - `kubectl get deploy,svc,cm -n ziti | grep ziti-workload-dns`
  - `nslookup ziti.agyn.dev <ziti-workload-dns-service-ip>`
  - `nslookup ziti-router.agyn.dev <ziti-workload-dns-service-ip>`
  - `nslookup kubernetes.default.svc.cluster.local <ziti-workload-dns-service-ip>` should not resolve via Kubernetes service discovery.