### PR TITLE
chore: bump egress bootstrap versions

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -659,7 +659,7 @@ variable "llm_proxy_image_tag" {
 variable "egress_chart_version" {
   type        = string
   description = "Version of the egress Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.1.1"
 }
 
 variable "egress_image_tag" {
@@ -684,7 +684,7 @@ variable "egress_db_pvc_size" {
 variable "egress_gateway_chart_version" {
   type        = string
   description = "Version of the egress-gateway Helm chart published to GHCR"
-  default     = "0.1.0"
+  default     = "0.1.1"
 }
 
 variable "egress_gateway_image_tag" {


### PR DESCRIPTION
Fixes agynio/egress#9.

## Summary
- Bump `egress_chart_version` to `0.1.1`.
- Bump `egress_gateway_chart_version` to `0.1.1`.
- Preserve the existing public GHCR OCI chart pattern; no GHCR credentials, tokens, or imagePullSecrets added.

## Validation
- `terraform fmt -check -recursive` — passed
- `bash -n apply.sh .github/scripts/verify_platform_health.sh` — passed
- `terraform init -backend=false` in `stacks/platform` — passed
- `terraform validate` in `stacks/platform` — passed
- `git diff --check` — passed