### PR TITLE
Fix Console agent role 404s

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -20,7 +20,7 @@ variable "argocd_admin_password" {
 variable "gateway_chart_version" {
   type        = string
   description = "Version of the gateway Helm chart published to GHCR"
-  default     = "0.22.10"
+  default     = "0.22.11"
 }
 
 variable "agents_orchestrator_chart_version" {


### PR DESCRIPTION
## Summary
- Bumps the bootstrap platform `gateway_chart_version` default from `0.22.10` to `0.22.11`.
- Verified the `ghcr.io/agynio/charts/gateway:0.22.11` Helm chart exists and has `appVersion: 0.22.11`.
- Verified `ghcr.io/agynio/gateway:0.22.11` exists and the `agynio/gateway` `v0.22.11` tag includes the `SetAgentRole`, `RemoveAgentRole`, `ListAgentRoles`, and `ListMyAgentRoles` gateway handlers.

Fixes #523

## Validation
- `terraform fmt -check -recursive`: passed
- `terraform -chdir=<stack> init -backend=false -input=false && terraform -chdir=<stack> validate` for `stacks/k8s`, `stacks/system`, `stacks/routing`, `stacks/data`, `stacks/platform`, `stacks/apps`, `stacks/deps`, and `stacks/ziti`: 8 passed / 0 failed / 0 skipped
- `helm show chart oci://ghcr.io/agynio/charts/gateway --version 0.22.11`: passed
- `docker manifest inspect ghcr.io/agynio/gateway:0.22.11`: passed
- `git diff --check`: passed