### PR TITLE
Wire NATS JetStream into platform bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ Default domain and port: `agyn.dev` on `2496`.
 - OpenFGA API: https://openfga.agyn.dev:2496/
 - OpenFGA Playground: https://openfga-playground.agyn.dev:2496/
 
+## Optional NATS JetStream event bus
+
+The platform stack can deploy NATS JetStream for durable service-to-service
+events used by private Networks and Groups work. It is disabled by default.
+Enable it when applying the platform stack:
+
+```sh
+terraform -chdir=stacks/platform apply -var='nats_enabled=true'
+```
+
+The local deployment creates the `nats` Argo CD application in the platform
+namespace, enables JetStream file storage with a PVC, and configures the
+`AGYN_GROUPS` and `AGYN_NETWORKS` streams. The stable in-cluster endpoint is
+available from the platform stack output `nats_endpoint`.
+
 ## DEV/E2E-only diagnostics credentials
 
 The `ziti-diagnostics` Ziti identity, Kubernetes secret, and RBAC are for local

--- a/stacks/platform/README.md
+++ b/stacks/platform/README.md
@@ -36,6 +36,36 @@ Each application chart enables a Kubernetes `Ingress` with `ingressClassName: is
 
 Platform charts are pulled from the GHCR OCI registry (`ghcr.io/agynio/charts`). Pin the release with `platform_chart_version`. The PostgreSQL Argo CD applications use the same registry and are pinned via `postgres_chart_version`.
 
+### NATS JetStream event bus
+
+NATS JetStream is optional and disabled by default so existing local stacks keep
+their previous footprint. Enable it with the platform stack variable:
+
+```bash
+terraform -chdir=stacks/platform apply -var='nats_enabled=true'
+```
+
+When enabled, Terraform creates an Argo CD application named `nats` in the
+platform namespace using the upstream NATS Helm chart. The application enables
+JetStream file storage with a PVC (`nats_jetstream_file_store_pvc_size`,
+default `10Gi`) and a matching file store max size
+(`nats_jetstream_file_store_max_size`, default `10Gi`). The stable in-cluster
+endpoint is exposed as the `nats_endpoint` output and defaults to:
+
+```text
+nats://nats.platform.svc.cluster.local:4222
+```
+
+By default, the NATS application also runs a stream configuration job for the
+platform event streams required by private Networks and Groups:
+
+- `AGYN_GROUPS` on subject `agyn.groups.>`
+- `AGYN_NETWORKS` on subject `agyn.networks.>`
+
+Set `nats_platform_streams_enabled=false` only if streams are managed outside
+bootstrap. Stream retention knobs follow the NATS API schema: age and duplicate
+window values are in nanoseconds, and size values are in bytes.
+
 ### Graph persistence
 
 `platform-server` mounts `/shared` (sourced from the repository-root `./shared` directory created by the k3d stack) into `/mnt/graph` and sets `GRAPH_REPO_PATH=/mnt/graph/graph`. The graph repository is created under the host directory at `./shared/graph`, and swap artifacts land transiently under `./shared`.

--- a/stacks/platform/README.md
+++ b/stacks/platform/README.md
@@ -63,8 +63,11 @@ platform event streams required by private Networks and Groups:
 - `AGYN_NETWORKS` on subject `agyn.networks.>`
 
 Set `nats_platform_streams_enabled=false` only if streams are managed outside
-bootstrap. Stream retention knobs follow the NATS API schema: age and duplicate
-window values are in nanoseconds, and size values are in bytes.
+bootstrap. The stream configuration Job is annotated as an Argo CD PostSync hook
+and Helm post-install/post-upgrade hook with before-hook-creation cleanup, so
+stream config changes delete and recreate the Job instead of attempting an
+immutable Job update. Stream retention knobs follow the NATS API schema: age and
+duplicate window values are in nanoseconds, and size values are in bytes.
 
 ### Graph persistence
 

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -1046,6 +1046,9 @@ locals {
         kind       = "ConfigMap"
         metadata = {
           name = "nats-platform-streams"
+          annotations = {
+            "argocd.argoproj.io/sync-wave" = "0"
+          }
           labels = {
             "app.kubernetes.io/name"       = "nats-platform-streams"
             "app.kubernetes.io/managed-by" = "terraform"
@@ -1111,6 +1114,14 @@ locals {
         kind       = "Job"
         metadata = {
           name = "nats-platform-streams"
+          annotations = {
+            "argocd.argoproj.io/hook"               = "PostSync"
+            "argocd.argoproj.io/hook-delete-policy" = "BeforeHookCreation,HookSucceeded"
+            "argocd.argoproj.io/sync-wave"          = "1"
+            "helm.sh/hook"                          = "post-install,post-upgrade"
+            "helm.sh/hook-delete-policy"            = "before-hook-creation,hook-succeeded"
+            "helm.sh/hook-weight"                   = "1"
+          }
           labels = {
             "app.kubernetes.io/name"       = "nats-platform-streams"
             "app.kubernetes.io/managed-by" = "terraform"

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -47,6 +47,7 @@ locals {
   secrets_chart_name             = "agynio/charts/secrets"
   token_counting_chart_name      = "agynio/charts/token-counting"
   notifications_chart_name       = "agynio/charts/notifications"
+  nats_chart_name                = "nats"
   redis_chart_name               = "redis"
   agents_chart_name              = "agynio/charts/agents"
   ziti_management_chart_name     = "agynio/charts/ziti-management"
@@ -68,6 +69,7 @@ locals {
   workload_namespace            = "agyn-workloads"
   openfga_api_url_external      = format("https://openfga.%s:%d", local.base_domain, local.ingress_port)
   openfga_api_url_internal      = format("http://openfga.%s.svc.cluster.local:8080", var.openfga_namespace)
+  nats_endpoint                 = format("nats://nats.%s.svc.cluster.local:4222", var.platform_namespace)
   # Deterministic v5 UUID for the cluster admin identity.
   # This is a synthetic identity used only during bootstrap;
   # it does not correspond to a user record in the Users DB.
@@ -1004,6 +1006,172 @@ locals {
         value = "info"
       }
     ]
+  })
+
+  nats_values = yamlencode({
+    fullnameOverride = "nats"
+    config = {
+      jetstream = {
+        enabled = true
+        fileStore = {
+          enabled = true
+          pvc = {
+            enabled = true
+            size    = var.nats_jetstream_file_store_pvc_size
+          }
+          maxSize = var.nats_jetstream_file_store_max_size
+        }
+        memoryStore = {
+          enabled = false
+        }
+      }
+    }
+    service = {
+      enabled = true
+      ports = {
+        nats = {
+          enabled = true
+        }
+        monitor = {
+          enabled = false
+        }
+      }
+    }
+    natsBox = {
+      enabled = false
+    }
+    extraResources = [for resource in [
+      {
+        apiVersion = "v1"
+        kind       = "ConfigMap"
+        metadata = {
+          name = "nats-platform-streams"
+          labels = {
+            "app.kubernetes.io/name"       = "nats-platform-streams"
+            "app.kubernetes.io/managed-by" = "terraform"
+          }
+        }
+        data = {
+          "AGYN_GROUPS.json" = jsonencode({
+            name                    = "AGYN_GROUPS"
+            subjects                = ["agyn.groups.>"]
+            retention               = "limits"
+            max_consumers           = -1
+            max_msgs                = -1
+            max_bytes               = var.nats_platform_stream_max_bytes
+            discard                 = "old"
+            max_age                 = var.nats_platform_stream_max_age
+            max_msgs_per_subject    = -1
+            max_msg_size            = -1
+            storage                 = "file"
+            num_replicas            = var.nats_platform_stream_replicas
+            duplicate_window        = var.nats_platform_stream_duplicate_window
+            sealed                  = false
+            deny_delete             = false
+            deny_purge              = false
+            allow_rollup_hdrs       = false
+            allow_direct            = false
+            mirror_direct           = false
+            discard_new_per_subject = false
+            allow_msg_ttl           = false
+            metadata = {
+              managed_by = "bootstrap"
+            }
+          })
+          "AGYN_NETWORKS.json" = jsonencode({
+            name                    = "AGYN_NETWORKS"
+            subjects                = ["agyn.networks.>"]
+            retention               = "limits"
+            max_consumers           = -1
+            max_msgs                = -1
+            max_bytes               = var.nats_platform_stream_max_bytes
+            discard                 = "old"
+            max_age                 = var.nats_platform_stream_max_age
+            max_msgs_per_subject    = -1
+            max_msg_size            = -1
+            storage                 = "file"
+            num_replicas            = var.nats_platform_stream_replicas
+            duplicate_window        = var.nats_platform_stream_duplicate_window
+            sealed                  = false
+            deny_delete             = false
+            deny_purge              = false
+            allow_rollup_hdrs       = false
+            allow_direct            = false
+            mirror_direct           = false
+            discard_new_per_subject = false
+            allow_msg_ttl           = false
+            metadata = {
+              managed_by = "bootstrap"
+            }
+          })
+        }
+      },
+      {
+        apiVersion = "batch/v1"
+        kind       = "Job"
+        metadata = {
+          name = "nats-platform-streams"
+          labels = {
+            "app.kubernetes.io/name"       = "nats-platform-streams"
+            "app.kubernetes.io/managed-by" = "terraform"
+          }
+        }
+        spec = {
+          backoffLimit = 6
+          template = {
+            metadata = {
+              labels = {
+                "app.kubernetes.io/name" = "nats-platform-streams"
+              }
+            }
+            spec = {
+              restartPolicy = "OnFailure"
+              containers = [
+                {
+                  name            = "configure-streams"
+                  image           = format("natsio/nats-box:%s", var.nats_box_image_tag)
+                  imagePullPolicy = "IfNotPresent"
+                  env = [
+                    {
+                      name  = "NATS_URL"
+                      value = local.nats_endpoint
+                    }
+                  ]
+                  command = ["/bin/sh", "-ec"]
+                  args = [<<-EOT
+                    for config in /etc/agyn/nats-streams/*.json; do
+                      stream="$(basename "$config" .json)"
+                      nats --server "$NATS_URL" \
+                        --timeout "${var.nats_platform_stream_wait_timeout}" \
+                        stream add --config "$config" --defaults || \
+                        nats --server "$NATS_URL" \
+                          --timeout "${var.nats_platform_stream_wait_timeout}" \
+                          stream edit "$stream" --config "$config" --force
+                    done
+                  EOT
+                  ]
+                  volumeMounts = [
+                    {
+                      name      = "stream-config"
+                      mountPath = "/etc/agyn/nats-streams"
+                      readOnly  = true
+                    }
+                  ]
+                }
+              ]
+              volumes = [
+                {
+                  name = "stream-config"
+                  configMap = {
+                    name = "nats-platform-streams"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    ] : resource if var.nats_platform_streams_enabled]
   })
 
   files_values = yamlencode({
@@ -2124,6 +2292,12 @@ resource "argocd_repository" "bitnami_repo" {
   repo = "https://charts.bitnami.com/bitnami"
   type = "helm"
 }
+
+resource "argocd_repository" "nats_repo" {
+  repo = "https://nats-io.github.io/k8s/helm/charts/"
+  type = "helm"
+}
+
 resource "argocd_repository" "ghcr" {
   repo       = "ghcr.io"
   type       = "helm"
@@ -3392,6 +3566,59 @@ resource "argocd_application" "notifications_redis" {
 
       sync_options = local.default_sync_options
     }
+  }
+}
+
+resource "argocd_application" "nats" {
+  count = var.nats_enabled ? 1 : 0
+
+  depends_on = [argocd_repository.nats_repo]
+  wait       = true
+
+  metadata {
+    name      = "nats"
+    namespace = "argocd"
+    annotations = {
+      "argocd.argoproj.io/sync-wave" = "16"
+    }
+  }
+
+  spec {
+    project = "default"
+
+    source {
+      repo_url        = "https://nats-io.github.io/k8s/helm/charts/"
+      chart           = local.nats_chart_name
+      target_revision = var.nats_chart_version
+
+      helm {
+        values = local.nats_values
+      }
+    }
+
+    destination {
+      server    = var.destination_server
+      namespace = var.platform_namespace
+    }
+
+    sync_policy {
+      dynamic "automated" {
+        for_each = var.argocd_automated_sync_enabled ? [1] : []
+        content {
+          prune       = var.argocd_prune_enabled
+          self_heal   = var.argocd_self_heal_enabled
+          allow_empty = false
+        }
+      }
+
+      sync_options = local.postgres_sync_options
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
   }
 }
 

--- a/stacks/platform/outputs.tf
+++ b/stacks/platform/outputs.tf
@@ -1,6 +1,6 @@
 output "platform_app_names" {
   description = "Names of Argo CD applications managed by this stack"
-  value = [
+  value = concat([
     argocd_application.platform_db.metadata[0].name,
     argocd_application.threads_db.metadata[0].name,
     argocd_application.metering_db.metadata[0].name,
@@ -46,12 +46,12 @@ output "platform_app_names" {
     argocd_application.tracing_app.metadata[0].name,
     argocd_application.gateway.metadata[0].name,
     argocd_application.llm_proxy.metadata[0].name,
-  ]
+  ], argocd_application.nats[*].metadata[0].name)
 }
 
 output "platform_app_ids" {
   description = "Identifiers returned by the Argo CD provider for the applications"
-  value = [
+  value = concat([
     argocd_application.platform_db.id,
     argocd_application.threads_db.id,
     argocd_application.metering_db.id,
@@ -97,12 +97,17 @@ output "platform_app_ids" {
     argocd_application.tracing_app.id,
     argocd_application.gateway.id,
     argocd_application.llm_proxy.id,
-  ]
+  ], argocd_application.nats[*].id)
 }
 
 output "platform_namespace" {
   description = "Namespace where platform workloads are deployed"
   value       = var.platform_namespace
+}
+
+output "nats_endpoint" {
+  description = "Stable in-cluster NATS endpoint for platform event bus clients"
+  value       = local.nats_endpoint
 }
 
 output "openfga_store_id" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -65,6 +65,12 @@ variable "notifications_redis_chart_version" {
   default     = "25.3.2"
 }
 
+variable "nats_chart_version" {
+  type        = string
+  description = "Version of the upstream NATS Helm chart for JetStream"
+  default     = "2.14.0"
+}
+
 variable "postgres_chart_version" {
   type        = string
   description = "Version of the postgres-helm chart published to GHCR"
@@ -304,6 +310,66 @@ variable "notifications_redis_addr" {
   type        = string
   description = "Redis address used by the notifications service"
   default     = "notifications-redis-master.platform.svc.cluster.local:6379"
+}
+
+variable "nats_enabled" {
+  type        = bool
+  description = "Enable NATS JetStream deployment for durable platform events"
+  default     = false
+}
+
+variable "nats_jetstream_file_store_pvc_size" {
+  type        = string
+  description = "Persistent volume claim size for the NATS JetStream file store"
+  default     = "10Gi"
+}
+
+variable "nats_jetstream_file_store_max_size" {
+  type        = string
+  description = "Maximum NATS JetStream file store size"
+  default     = "10Gi"
+}
+
+variable "nats_platform_streams_enabled" {
+  type        = bool
+  description = "Create platform JetStream streams for Groups and Networks events"
+  default     = true
+}
+
+variable "nats_platform_stream_replicas" {
+  type        = number
+  description = "Replica count for platform JetStream streams"
+  default     = 1
+}
+
+variable "nats_platform_stream_max_bytes" {
+  type        = number
+  description = "Maximum bytes retained per platform JetStream stream"
+  default     = 1073741824
+}
+
+variable "nats_platform_stream_max_age" {
+  type        = number
+  description = "Maximum age retained per platform JetStream stream, in nanoseconds"
+  default     = 604800000000000
+}
+
+variable "nats_platform_stream_duplicate_window" {
+  type        = number
+  description = "Duplicate detection window for platform JetStream streams, in nanoseconds"
+  default     = 120000000000
+}
+
+variable "nats_platform_stream_wait_timeout" {
+  type        = string
+  description = "NATS CLI timeout for platform stream configuration"
+  default     = "120s"
+}
+
+variable "nats_box_image_tag" {
+  type        = string
+  description = "nats-box image tag used by the platform stream configuration job"
+  default     = "0.18.0"
 }
 
 variable "argocd_automated_sync_enabled" {


### PR DESCRIPTION
## Summary

- Add optional platform-stack NATS JetStream deployment via Argo CD.
- Configure JetStream file-store/PVC defaults and stable in-cluster endpoint output.
- Add bootstrap-managed AGYN_GROUPS and AGYN_NETWORKS stream configuration resources when NATS is enabled.
- Document local enablement knobs and expected behavior.

Closes #565

## Validation

- `terraform fmt -check -recursive` - passed
- `terraform -chdir=stacks/platform validate` - passed
- `git diff --check` - passed

## Notes

- Existing behavior remains backwards-compatible: `nats_enabled` defaults to `false`.
- A local render/plan attempt with `-var='nats_enabled=true'` produced the expected `argocd_application.nats[0]` and `nats_endpoint` output before the existing platform stack Kubernetes provider failed because this workspace has no local kubeconfig/cluster.