### PR TITLE
fix: wire egress gateway self-enrollment

### DIFF
--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -899,10 +899,6 @@ locals {
         name  = "RUNNERS_ADDRESS"
         value = "runners:50051"
       },
-      {
-        name  = "EGRESS_CA_NAMESPACE"
-        value = "agyn-workloads"
-      }
     ]
   })
 

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -26,7 +26,7 @@ variable "gateway_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.17"
+  default     = "0.13.18"
 }
 
 variable "threads_chart_version" {
@@ -116,7 +116,7 @@ variable "identity_chart_version" {
 variable "runners_chart_version" {
   type        = string
   description = "Version of the runners Helm chart published to GHCR"
-  default     = "0.5.11"
+  default     = "0.5.12"
 }
 
 variable "apps_chart_version" {
@@ -713,7 +713,7 @@ variable "media_proxy_image_tag" {
 variable "llm_proxy_chart_version" {
   type        = string
   description = "Version of the llm-proxy Helm chart published to GHCR"
-  default     = "0.12.5"
+  default     = "0.12.6"
 }
 
 variable "llm_proxy_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -86,7 +86,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.10.14"
+  default     = "0.10.15"
 }
 
 variable "users_chart_version" {
@@ -750,7 +750,7 @@ variable "egress_db_pvc_size" {
 variable "egress_gateway_chart_version" {
   type        = string
   description = "Version of the egress-gateway Helm chart published to GHCR"
-  default     = "0.1.3"
+  default     = "0.1.4"
 }
 
 variable "egress_gateway_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -86,7 +86,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.10.15"
+  default     = "0.10.16"
 }
 
 variable "users_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -86,7 +86,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.10.16"
+  default     = "0.10.17"
 }
 
 variable "users_chart_version" {


### PR DESCRIPTION
## Summary
- Replaces the closed PR #569 bootstrap shim direction with the existing provider-created enrollment Secret contract.
- Keeps `ziti_identity.egress_gateway` / `egress_gateway_enrollment_token` / `kubernetes_secret_v1.egress_gateway_enrollment` as the bootstrap path.
- Mounts the enrollment Secret and a writable `/var/lib/ziti` volume for the egress-gateway runtime to self-enroll.
- Pins egress-compatible runtime chart defaults.
- Builds terraform-provider-agyn PR #81 from `noa/issue-153-continue` during full-apply and passes the built provider binary into e2e, so bootstrap CI recognizes `agyn_egress_rule` and `agyn_egress_rule_attachment` until provider #81 lands.

Linked to agynio/architecture#153 and follows up on agynio/bootstrap#569 review feedback.

Runtime/chart support PRs:
- agynio/egress-gateway#10
- agynio/platform-charts#24
- agynio/terraform-provider-agyn#81
- agynio/egress#14
- agynio/e2e#207

## Test & Lint Summary
- `terraform -chdir=stacks/platform fmt -check -diff` — passed.
- `terraform -chdir=stacks/platform init -backend=false` — passed.
- `terraform -chdir=stacks/platform validate` — passed.
- `actionlint .github/workflows/bootstrap.yml` — passed with no errors.
- `git diff --check` — passed with no whitespace errors.
- `go build -o /tmp/terraform-provider-agyn .` from terraform-provider-agyn PR #81 branch — passed.
- `go test -run '^$' -tags 'e2e svc_gateway tf_provider_agyn' ./tests` from e2e/suites/go-terraform — passed: 1 package, failed: 0, skipped: 0; no tests run in compile-only mode.
- `go vet -tags 'e2e svc_gateway tf_provider_agyn' ./tests` from e2e/suites/go-terraform — passed with no errors.

## Notes
- The provider binary is staged at `provider-bin/terraform-provider-agyn` rather than the repository root, because `go build -o ../terraform-provider-agyn .` would create a binary inside the existing checkout directory and would not satisfy the e2e action's file check.
- The egress backend default-port fix is in agynio/egress#14 and the e2e workflow pins that fixed runtime image until it is released.