### PR TITLE
fix(platform): bump secrets chart

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Provision bootstrap cluster
         id: provision
         uses: ./.github/actions/provision
+        env:
+          TF_VAR_egress_image_tag: pr-14-471fd0cff8d7aa2e49c1a6ecbe296cc7afe3ecdd
         with:
           ref: ${{ github.sha }}
 

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -25,6 +25,7 @@ jobs:
         uses: ./.github/actions/provision
         env:
           TF_VAR_egress_image_tag: pr-14-471fd0cff8d7aa2e49c1a6ecbe296cc7afe3ecdd
+          TF_VAR_ziti_management_image_tag: pr-61-4f5cd681b9887dc397d24dd7cd796ab062cbe6c2
         with:
           ref: ${{ github.sha }}
 

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Provision bootstrap cluster
         id: provision
         uses: ./.github/actions/provision
-        env:
-          TF_VAR_egress_image_tag: pr-14-471fd0cff8d7aa2e49c1a6ecbe296cc7afe3ecdd
-          TF_VAR_ziti_management_image_tag: pr-61-4f5cd681b9887dc397d24dd7cd796ab062cbe6c2
         with:
           ref: ${{ github.sha }}
 

--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -61,7 +61,7 @@ variable "reminders_image_tag" {
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.10.13"
+  default     = "0.10.14"
 }
 
 variable "k8s_runner_image_tag" {

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -640,17 +640,18 @@ locals {
       { name = "TRACING_ADDRESS", value = "tracing:50051" },
       { name = "AGENTS_SERVICE_ADDRESS", value = "agents:50051" },
       { name = "ZITI_MANAGEMENT_ADDRESS", value = "ziti-management:50051" },
+      { name = "ZITI_IDENTITY_FILE", value = "/var/lib/ziti/identity.json" },
+      { name = "ZITI_LEASE_INTERVAL", value = "30s" },
+      { name = "ZITI_SERVICE_NAME", value = "" },
       { name = "EGRESS_CA_CERT_PATH", value = "/var/run/agyn/egress-ca/tls.crt" },
       { name = "EGRESS_CA_KEY_PATH", value = "/var/run/agyn/egress-ca/tls.key" },
-      { name = "ZITI_ENROLLMENT_JWT_FILE", value = "/etc/ziti-enrollment/enrollmentJwt" },
-      { name = "ZITI_IDENTITY_NAME_RESOLVE", value = "true" },
     ]
     extraVolumeMounts = [
-      { name = "ziti-enrollment", mountPath = "/etc/ziti-enrollment", readOnly = true },
+      { name = "ziti-identity", mountPath = "/var/lib/ziti", readOnly = false },
       { name = "egress-ca", mountPath = "/var/run/agyn/egress-ca", readOnly = true },
     ]
     extraVolumes = [
-      { name = "ziti-enrollment", secret = { secretName = "egress-gateway-enrollment" } },
+      { name = "ziti-identity", emptyDir = {} },
       { name = "egress-ca", secret = { secretName = "egress-ca" } },
     ]
     resources = {
@@ -1642,19 +1643,6 @@ resource "kubernetes_secret_v1" "ziti_management_enrollment" {
 
   data = {
     enrollmentJwt = data.terraform_remote_state.ziti.outputs.ziti_management_enrollment_token
-  }
-}
-
-resource "kubernetes_secret_v1" "egress_gateway_enrollment" {
-  metadata {
-    name      = "egress-gateway-enrollment"
-    namespace = kubernetes_namespace.platform.metadata[0].name
-  }
-
-  type = "Opaque"
-
-  data = {
-    enrollmentJwt = data.terraform_remote_state.ziti.outputs.egress_gateway_enrollment_token
   }
 }
 
@@ -3793,7 +3781,6 @@ resource "argocd_application" "egress_gateway" {
     argocd_application.metering,
     argocd_application.tracing,
     argocd_application.notifications,
-    kubernetes_secret_v1.egress_gateway_enrollment,
     kubernetes_manifest.egress_ca_certificate,
   ]
   metadata {

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -703,6 +703,7 @@ locals {
       accessMode = "ReadWriteOnce"
       size       = "10Mi"
     }
+    zitiControllerUrl = format("https://ziti-mgmt.%s:%d/edge/management/v1", local.base_domain, local.ingress_port)
     configMounts = [
       {
         name       = "ziti-enrollment"

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -582,6 +582,9 @@ locals {
     }
     database = {
       url = format("postgresql://secrets:%s@secrets-db:5432/secrets?sslmode=disable", var.secrets_db_password)
+      existingSecret = {
+        name = ""
+      }
     }
     image = {
       repository = "ghcr.io/agynio/secrets"

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -86,7 +86,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.10.10"
+  default     = "0.10.12"
 }
 
 variable "users_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -731,7 +731,7 @@ variable "egress_chart_version" {
 variable "egress_image_tag" {
   type        = string
   description = "Optional override for the egress image tag"
-  default     = "pr-14-471fd0cff8d7aa2e49c1a6ecbe296cc7afe3ecdd"
+  default     = ""
 }
 
 variable "egress_db_password" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -146,7 +146,7 @@ variable "console_app_chart_version" {
 variable "console_app_image_tag" {
   type        = string
   description = "Optional override for the console-app container image tag"
-  default     = ""
+  default     = "0.10.10-egress-rules"
 }
 
 variable "oidc_issuer_url" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -725,7 +725,7 @@ variable "llm_proxy_image_tag" {
 variable "egress_chart_version" {
   type        = string
   description = "Version of the egress Helm chart published to GHCR"
-  default     = "0.1.2"
+  default     = "0.1.3"
 }
 
 variable "egress_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -731,7 +731,7 @@ variable "egress_chart_version" {
 variable "egress_image_tag" {
   type        = string
   description = "Optional override for the egress image tag"
-  default     = ""
+  default     = "pr-14-471fd0cff8d7aa2e49c1a6ecbe296cc7afe3ecdd"
 }
 
 variable "egress_db_password" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -86,7 +86,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.10.13"
+  default     = "0.10.14"
 }
 
 variable "users_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -140,13 +140,13 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.10.10"
+  default     = "0.10.11"
 }
 
 variable "console_app_image_tag" {
   type        = string
   description = "Optional override for the console-app container image tag"
-  default     = "0.10.10-egress-rules"
+  default     = ""
 }
 
 variable "oidc_issuer_url" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -651,7 +651,7 @@ variable "minio_bucket_name" {
 variable "secrets_chart_version" {
   type        = string
   description = "Version of the secrets Helm chart published to GHCR"
-  default     = "0.2.0"
+  default     = "0.2.2"
 }
 
 variable "secrets_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -86,7 +86,7 @@ variable "agents_chart_version" {
 variable "ziti_management_chart_version" {
   type        = string
   description = "Version of the ziti-management Helm chart published to GHCR"
-  default     = "0.10.12"
+  default     = "0.10.13"
 }
 
 variable "users_chart_version" {
@@ -725,7 +725,7 @@ variable "llm_proxy_image_tag" {
 variable "egress_chart_version" {
   type        = string
   description = "Version of the egress Helm chart published to GHCR"
-  default     = "0.1.1"
+  default     = "0.1.2"
 }
 
 variable "egress_image_tag" {
@@ -750,7 +750,7 @@ variable "egress_db_pvc_size" {
 variable "egress_gateway_chart_version" {
   type        = string
   description = "Version of the egress-gateway Helm chart published to GHCR"
-  default     = "0.1.1"
+  default     = "0.1.3"
 }
 
 variable "egress_gateway_image_tag" {


### PR DESCRIPTION
## Summary
- Bump the platform Secrets chart default from `0.2.0` to `0.2.2`.
- Keeps the default Secrets image tag aligned with the chart-derived `v0.2.2` tag via existing `local.resolved_secrets_image_tag` logic.
- Addresses Console E2E/backend version skew where egress rule creation expected `SecretsService.ResolveSecretExists`.

Closes #571

## Verification
- `terraform fmt -check -diff -recursive` passed with no formatting changes required.
- `terraform -chdir=stacks/platform init -backend=false -input=false` succeeded.
- `terraform -chdir=stacks/platform validate -no-color` passed: Success! The configuration is valid.
- `./apply.sh -y` was attempted for full bootstrap/platform verification, but the local environment could not complete the `system` stack because cluster pods repeatedly failed to pull required Docker Hub images due TLS handshake timeouts. See details below.

## Local full-apply blocker
`./apply.sh -y` created the k3d cluster, then failed during `helm_release.istiod` after the 5 minute Helm timeout:

```text
Warning: Helm release "" was created but has a failed status. Use the `helm` command to investigate the error, correct it, then run Terraform again.

Error: context deadline exceeded

  with helm_release.istiod,
  on main.tf line 31, in resource "helm_release" "istiod":
  31: resource "helm_release" "istiod" {
```

Kubernetes events showed image pulls timing out, for example:

```text
failed to pull and unpack image "docker.io/rancher/mirrored-pause:3.6": failed to resolve reference "docker.io/rancher/mirrored-pause:3.6": failed to do request: Head "https://registry-1.docker.io/v2/rancher/mirrored-pause/manifests/3.6": net/http: TLS handshake timeout
```

Also observed for:

```text
rancher/mirrored-coredns-coredns:1.13.1
rancher/mirrored-metrics-server:v0.8.0
docker.io/istio/pilot:1.21.0
```

Proposed resolution: rerun full bootstrap verification in an environment with reliable Docker Hub/registry access or with required images pre-pulled/cached.