### PR TITLE
Deploy console-app v0.10.12

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -140,7 +140,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.10.11"
+  default     = "0.10.12"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
## Summary
- Updates `console_app_chart_version` from `0.10.11` to `0.10.12` in `stacks/platform/variables.tf`.
- Leaves `console_app_image_tag` empty, so no temporary console image override is introduced.
- Does not modify unrelated platform versions.

Closes #573

## Validations
- `terraform fmt -check -recursive` passed.
- `terraform -chdir=stacks/platform init -backend=false -input=false` passed.
- `terraform -chdir=stacks/platform validate -no-color` passed.
- `helm show chart oci://ghcr.io/agynio/charts/console-app --version 0.10.12` passed.
  - Chart digest: `sha256:1822c6b6f94bcf8f9187b9b0f5cf004f56ad4b64cd4535c782ce342501865ad0`
- `oras manifest fetch ghcr.io/agynio/console-app:0.10.12 --descriptor` passed.
  - Image index digest: `sha256:4996e60c0914c7e72b4c06eca5c5a613b31680c363620265f6cf09703acfbf4d`
