### PR TITLE
Spike: add opt-in local appliance artifact path

### DIFF
--- a/.github/workflows/local-appliance.yml
+++ b/.github/workflows/local-appliance.yml
@@ -1,0 +1,91 @@
+name: local appliance spike
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: GHCR image tag to publish
+        required: true
+        default: manual
+      restore_validation:
+        description: Attempt restore validation before optional publish
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+      publish:
+        description: Push images to GHCR after capture
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Reclaim disk space
+        shell: bash
+        run: |
+          set -euo pipefail
+          df -h
+          sudo rm -rf /usr/local/lib/android /usr/local/share/boost /opt/ghc /usr/share/dotnet /usr/share/swift
+          sudo apt-get clean
+          docker system prune -af
+          df -h
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.34.3
+
+      - name: Install k3d
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -s https://raw.githubusercontent.com/k3d-io/k3d/v5.7.5/install.sh | TAG=v5.7.5 bash
+          k3d version
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.6
+
+      - name: Install jq
+        shell: bash
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Login to GHCR
+        if: inputs.publish == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build appliance artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(
+            build
+            --image-repository ghcr.io/agynio/bootstrap-local-appliance
+            --image-tag "${{ inputs.image_tag }}"
+          )
+          if [[ "${{ inputs.restore_validation }}" != "true" ]]; then
+            args+=(--skip-restore-validation)
+          fi
+          if [[ "${{ inputs.publish }}" == "true" ]]; then
+            args+=(--publish)
+          fi
+          scripts/local-appliance.sh "${args[@]}"

--- a/.github/workflows/local-appliance.yml
+++ b/.github/workflows/local-appliance.yml
@@ -15,7 +15,7 @@ on:
           - 'false'
           - 'true'
       publish:
-        description: Push images to GHCR after capture
+        description: Push images to GHCR after restore validation
         required: true
         default: 'false'
         type: choice
@@ -82,10 +82,9 @@ jobs:
             --image-repository ghcr.io/agynio/bootstrap-local-appliance
             --image-tag "${{ inputs.image_tag }}"
           )
-          if [[ "${{ inputs.restore_validation }}" != "true" ]]; then
-            args+=(--skip-restore-validation)
-          fi
           if [[ "${{ inputs.publish }}" == "true" ]]; then
             args+=(--publish)
+          elif [[ "${{ inputs.restore_validation }}" != "true" ]]; then
+            args+=(--skip-restore-validation)
           fi
           scripts/local-appliance.sh "${args[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ local-certs/*
 
 # Local appliance spike artifacts
 /dist/
+
+# Local appliance k8s-only Terraform overrides
+/stacks/k8s/local-appliance.auto.tfvars

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ local-certs/*
 
 # Shared host volume persisted locally
 /shared/
+
+# Local appliance spike artifacts
+/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,3 @@ local-certs/*
 
 # Local appliance spike artifacts
 /dist/
-
-# Local appliance k8s-only Terraform overrides
-/stacks/k8s/local-appliance.auto.tfvars

--- a/docs/local-appliance.md
+++ b/docs/local-appliance.md
@@ -84,9 +84,12 @@ variables through the existing `apply.sh` execution:
 - `--port`
 
 The capture and restore steps use the same values so node volume archives and
-manifest metadata stay consistent. Custom cluster names are intentionally not
-supported in this spike because existing bootstrap health checks and dependent
-stacks use `stacks/k8s/.kube/agyn-local-kubeconfig.yaml`.
+manifest metadata stay consistent. `APPLIANCE_CLUSTER_NAME` and
+`APPLIANCE_RESTORE_CLUSTER_NAME` are intentionally ignored. Custom cluster names
+are not supported in this spike because existing bootstrap health checks and
+dependent stacks use `stacks/k8s/.kube/agyn-local-kubeconfig.yaml`. The
+temporary k8s tfvars file is removed automatically when `apply.sh` returns so
+normal future `./apply.sh` runs are not affected.
 
 ## Restore an existing artifact
 

--- a/docs/local-appliance.md
+++ b/docs/local-appliance.md
@@ -2,7 +2,7 @@
 
 This is an opt-in spike path for building a pre-provisioned local Agyn
 appliance from the normal bootstrap source of truth. It does not change
-`apply.sh`, CI, Terraform stacks, or downstream users by default.
+`apply.sh`, default CI, Terraform stacks, or downstream users by default.
 
 The spike currently produces the closest feasible artifact instead of relying on
 one Docker image alone:
@@ -10,10 +10,11 @@ one Docker image alone:
 - a committed k3d server container image,
 - compressed snapshots of the Docker volumes that k3d mounts at
   `/var/lib/rancher/k3s`, `/var/lib/kubelet`, and `/var/lib/cni` for the server
-  node,
+  and each configured agent node,
 - a compressed `/shared` bind-mount snapshot,
 - Docker inspect output for the captured k3d containers,
-- a manifest and metadata image that can be pushed to GHCR.
+- a manifest and metadata image that can be pushed to GHCR and extracted by the
+  restore command on a clean machine.
 
 A plain `docker commit` is not enough for k3d state portability. k3d stores the
 k3s datastore, kubelet state, CNI state, and image-related state in Docker
@@ -42,12 +43,14 @@ scripts/local-appliance.sh build \
 
 The build command:
 
-1. runs `./apply.sh -y` with the selected domain and port,
+1. runs `./apply.sh -y` with selected domain, port, and topology/version
+   overrides,
 2. runs `.github/scripts/verify_platform_health.sh`,
 3. stops the source k3d cluster cleanly,
 4. commits the server container image,
-5. captures the mounted state volumes and inspect metadata,
-6. attempts to recreate a single-node k3d cluster from the artifact,
+5. captures the mounted state volumes and inspect metadata for the server and
+   each configured agent,
+6. attempts to recreate a matching k3d cluster from the artifact,
 7. validates that the Kubernetes API starts, nodes are Ready, PVC/PV objects are
    visible, and Argo CD Application objects are present.
 
@@ -68,6 +71,22 @@ To capture without immediately running restore validation:
 scripts/local-appliance.sh build --skip-restore-validation
 ```
 
+## Topology and version options
+
+`build` applies the following options during provisioning by passing Terraform
+variables through the existing `apply.sh` execution:
+
+- `--cluster-name`
+- `--servers` (currently limited to `1`)
+- `--agents`
+- `--k3s-version`
+- `--api-port`
+- `--domain`
+- `--port`
+
+The capture and restore steps use the same values so node names, volume archives,
+and manifest metadata stay consistent.
+
 ## Restore an existing artifact
 
 ```sh
@@ -76,6 +95,13 @@ scripts/local-appliance.sh restore \
   --image-repository ghcr.io/agynio/bootstrap-local-appliance \
   --image-tag dev
 ```
+
+If `--artifact-dir` already contains `manifest.json`, restore uses the local
+artifact directory. If it does not, restore pulls
+`ghcr.io/agynio/bootstrap-local-appliance-metadata:<tag>` and extracts the
+manifest, volume snapshots, and inspect metadata into `--artifact-dir` before
+creating the k3d shell. The server image is pulled by `k3d cluster create` when
+it is not already present locally.
 
 The default restore cluster name is `agyn-local` so persisted node names match
 objects stored in the k3s datastore. Use a different name only for experiments;
@@ -91,14 +117,15 @@ scripts/local-appliance.sh publish \
   --image-tag $(git rev-parse --short HEAD)
 ```
 
-`publish` pushes two tags:
+`publish` pushes two restorable tags:
 
 - `ghcr.io/agynio/bootstrap-local-appliance:<tag>`: committed k3d server image,
-- `ghcr.io/agynio/bootstrap-local-appliance-metadata:<tag>`: metadata and volume
-  snapshots.
+- `ghcr.io/agynio/bootstrap-local-appliance-metadata:<tag>`: manifest, Docker
+  inspect metadata, and compressed volume snapshots.
 
 The build command can publish after local capture and restore validation with
-`--publish`.
+`--publish`. The CLI rejects `--publish` when `--skip-restore-validation` is set
+so GHCR tags are only pushed after a successful restore smoke test.
 
 ## Security notes
 

--- a/docs/local-appliance.md
+++ b/docs/local-appliance.md
@@ -1,0 +1,219 @@
+# Local appliance spike
+
+This is an opt-in spike path for building a pre-provisioned local Agyn
+appliance from the normal bootstrap source of truth. It does not change
+`apply.sh`, CI, Terraform stacks, or downstream users by default.
+
+The spike currently produces the closest feasible artifact instead of relying on
+one Docker image alone:
+
+- a committed k3d server container image,
+- compressed snapshots of the Docker volumes that k3d mounts at
+  `/var/lib/rancher/k3s`, `/var/lib/kubelet`, and `/var/lib/cni` for the server
+  node,
+- a compressed `/shared` bind-mount snapshot,
+- Docker inspect output for the captured k3d containers,
+- a manifest and metadata image that can be pushed to GHCR.
+
+A plain `docker commit` is not enough for k3d state portability. k3d stores the
+k3s datastore, kubelet state, CNI state, and image-related state in Docker
+volumes mounted into each node container. Those mounts are outside the writable
+container layer and are not included in a committed image. The restore path
+therefore creates a matching k3d shell, stops it, restores the captured volumes,
+and starts it again.
+
+## Requirements
+
+- Docker Engine
+- k3d
+- kubectl
+- jq
+- tar
+- terraform and curl for `build` without `--skip-provision`
+- GHCR login with package write permission before `publish`
+
+## Build and validate locally
+
+```sh
+scripts/local-appliance.sh build \
+  --image-repository ghcr.io/agynio/bootstrap-local-appliance \
+  --image-tag dev
+```
+
+The build command:
+
+1. runs `./apply.sh -y` with the selected domain and port,
+2. runs `.github/scripts/verify_platform_health.sh`,
+3. stops the source k3d cluster cleanly,
+4. commits the server container image,
+5. captures the mounted state volumes and inspect metadata,
+6. attempts to recreate a single-node k3d cluster from the artifact,
+7. validates that the Kubernetes API starts, nodes are Ready, PVC/PV objects are
+   visible, and Argo CD Application objects are present.
+
+Local smoke testing showed that capture succeeds, but restoring the k3s data
+volume can hang before k3d observes `k3s is up and running`. That failure is the
+expected spike limitation to investigate next; use `--skip-restore-validation`
+when you only need to produce the artifact.
+
+For an already-provisioned source cluster, skip the provisioning phase:
+
+```sh
+scripts/local-appliance.sh build --skip-provision
+```
+
+To capture without immediately running restore validation:
+
+```sh
+scripts/local-appliance.sh build --skip-restore-validation
+```
+
+## Restore an existing artifact
+
+```sh
+scripts/local-appliance.sh restore \
+  --artifact-dir dist/local-appliance \
+  --image-repository ghcr.io/agynio/bootstrap-local-appliance \
+  --image-tag dev
+```
+
+The default restore cluster name is `agyn-local` so persisted node names match
+objects stored in the k3s datastore. Use a different name only for experiments;
+renaming a captured k3d cluster is not expected to be portable without rewriting
+cluster state.
+
+## Publish to GHCR
+
+```sh
+docker login ghcr.io
+scripts/local-appliance.sh publish \
+  --image-repository ghcr.io/agynio/bootstrap-local-appliance \
+  --image-tag $(git rev-parse --short HEAD)
+```
+
+`publish` pushes two tags:
+
+- `ghcr.io/agynio/bootstrap-local-appliance:<tag>`: committed k3d server image,
+- `ghcr.io/agynio/bootstrap-local-appliance-metadata:<tag>`: metadata and volume
+  snapshots.
+
+The build command can publish after local capture and restore validation with
+`--publish`.
+
+## Security notes
+
+The artifact is intended for local development only. Do not build or publish it
+from an environment containing GitHub tokens, cloud credentials,
+production/staging credentials, real external Ziti enrollment tokens, or any
+secret granting access to non-local Agyn infrastructure.
+
+## Known limitations and next shape
+
+- The artifact is not a single standalone Docker image. Docker volumes are
+  required because k3d mounts core node state outside the committed container
+  layer.
+- The restore path is cluster-name sensitive. The default restore name remains
+  `agyn-local` to match the captured k3s node records.
+- The metadata image is a pragmatic OCI carrier for the volume snapshots. A
+  follow-up can replace it with an OCI artifact layout once registry and client
+  tooling is standardized.
+- k3d load balancer and node labels are recreated by k3d rather than restored
+  from Docker inspect verbatim.
+
+## Useful investigation commands
+
+```sh
+docker inspect k3d-agyn-local-server-0 \
+  --format '{{json .Mounts}}' | jq .
+
+docker inspect k3d-agyn-local-agent-0 \
+  --format '{{json .Mounts}}' | jq .
+
+kubectl --kubeconfig stacks/k8s/.kube/agyn-local-kubeconfig.yaml get nodes -o wide
+kubectl --kubeconfig stacks/k8s/.kube/agyn-local-kubeconfig.yaml get pv,pvc -A
+kubectl --kubeconfig stacks/k8s/.kube/agyn-local-kubeconfig.yaml -n argocd get applications.argoproj.io
+```
+
+## Local validation results from this spike
+
+Environment used on 2026-06-21:
+
+```text
+Docker client 29.4.3 / server 27.5.1 on linux/arm64
+k3d 5.8.3 installed with Nix for local smoke testing
+kubectl 1.36.1 installed with Nix for local smoke testing
+Terraform 1.15.2 already available in the workspace
+jq 1.8.1 and ShellCheck 0.11.0 installed with Nix
+```
+
+Baseline and static validation:
+
+```sh
+terraform fmt -check -recursive
+shellcheck scripts/local-appliance.sh apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh
+bash -n scripts/local-appliance.sh
+```
+
+Result: all commands exited 0.
+
+k3d mount investigation command:
+
+```sh
+k3d cluster create appliance-probe --servers 1 --agents 1 \
+  --image rancher/k3s:v1.34.3-k3s1 --wait --timeout 120s
+
+docker inspect k3d-appliance-probe-server-0 \
+  --format '{{json .Mounts}}' | jq .
+```
+
+Observed server mounts included Docker volumes for `/var/lib/rancher/k3s`,
+`/var/lib/kubelet`, `/var/lib/cni`, `/var/log`, and the shared k3d image volume
+at `/k3d/images`. The agent had separate Docker volumes for the same k3s,
+kubelet, CNI, and log paths plus the shared image volume. This confirms that a
+committed node container image alone cannot contain the required persisted k3d
+state.
+
+Artifact capture smoke command:
+
+```sh
+scripts/local-appliance.sh build --skip-provision --skip-restore-validation \
+  --image-repository local/agyn-bootstrap-appliance \
+  --image-tag smoke-skip
+```
+
+Result: capture succeeded. The script created a committed server image,
+`dist/local-appliance`, `dist/local-appliance.tar.gz`, and a metadata image. The
+capture logs showed volume snapshots for `/var/lib/rancher/k3s`,
+`/var/lib/kubelet`, `/var/lib/cni`, and `/shared`.
+
+Restore validation smoke command:
+
+```sh
+scripts/local-appliance.sh build --skip-provision \
+  --image-repository local/agyn-bootstrap-appliance \
+  --image-tag smoke
+```
+
+Result: capture succeeded, then restore failed while starting the restored k3d
+server. The final k3d error was:
+
+```text
+Failed to start server k3d-agyn-local-server-0: Node k3d-agyn-local-server-0 failed to get ready: error waiting for log line `k3s is up and running` from node 'k3d-agyn-local-server-0': stopped returning log lines: context deadline exceeded
+```
+
+Docker inspect on the restored server still showed the expected restored mounts:
+
+```text
+/var/lib/rancher/k3s -> Docker volume
+/var/lib/kubelet -> Docker volume
+/var/lib/cni -> Docker volume
+/shared -> /workspace/bootstrap/shared bind mount
+/k3d/images -> k3d-agyn-local-images Docker volume
+```
+
+This means the current closest feasible artifact is an image plus explicit state
+snapshots. The next spike should investigate k3s datastore/node identity and k3d
+startup assumptions after restoring `/var/lib/rancher/k3s`, or move to a more
+explicit artifact shape such as a tarred k3d Docker volume set with a restore
+controller script instead of treating the committed server image as the primary
+artifact.

--- a/docs/local-appliance.md
+++ b/docs/local-appliance.md
@@ -76,7 +76,6 @@ scripts/local-appliance.sh build --skip-restore-validation
 `build` applies the following options during provisioning by passing Terraform
 variables through the existing `apply.sh` execution:
 
-- `--cluster-name`
 - `--servers` (currently limited to `1`)
 - `--agents`
 - `--k3s-version`
@@ -84,8 +83,10 @@ variables through the existing `apply.sh` execution:
 - `--domain`
 - `--port`
 
-The capture and restore steps use the same values so node names, volume archives,
-and manifest metadata stay consistent.
+The capture and restore steps use the same values so node volume archives and
+manifest metadata stay consistent. Custom cluster names are intentionally not
+supported in this spike because existing bootstrap health checks and dependent
+stacks use `stacks/k8s/.kube/agyn-local-kubeconfig.yaml`.
 
 ## Restore an existing artifact
 

--- a/scripts/local-appliance.sh
+++ b/scripts/local-appliance.sh
@@ -1,0 +1,575 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DEFAULT_CLUSTER_NAME="agyn-local"
+DEFAULT_RESTORE_CLUSTER_NAME="agyn-local"
+DEFAULT_ARTIFACT_DIR="dist/local-appliance"
+DEFAULT_IMAGE_REPOSITORY="ghcr.io/agynio/bootstrap-local-appliance"
+DEFAULT_IMAGE_TAG="dev"
+DEFAULT_DOMAIN="agyn.dev"
+DEFAULT_PORT="2496"
+DEFAULT_API_PORT="6443"
+DEFAULT_SERVERS="1"
+DEFAULT_AGENTS="0"
+DEFAULT_K3S_VERSION="v1.34.3-k3s1"
+DEFAULT_PLATFORM_HEALTH_TIMEOUT="900"
+DEFAULT_ARTIFACT_VERSION="1"
+KUBECONFIG_PATH="stacks/k8s/.kube/agyn-local-kubeconfig.yaml"
+
+mode=""
+cluster_name="${APPLIANCE_CLUSTER_NAME:-$DEFAULT_CLUSTER_NAME}"
+restore_cluster_name="${APPLIANCE_RESTORE_CLUSTER_NAME:-$DEFAULT_RESTORE_CLUSTER_NAME}"
+artifact_dir="${APPLIANCE_ARTIFACT_DIR:-$DEFAULT_ARTIFACT_DIR}"
+image_repository="${APPLIANCE_IMAGE_REPOSITORY:-$DEFAULT_IMAGE_REPOSITORY}"
+image_tag="${APPLIANCE_IMAGE_TAG:-$DEFAULT_IMAGE_TAG}"
+domain="${DOMAIN:-$DEFAULT_DOMAIN}"
+port="${PORT:-$DEFAULT_PORT}"
+api_port="${APPLIANCE_API_PORT:-$DEFAULT_API_PORT}"
+servers="${APPLIANCE_SERVERS:-$DEFAULT_SERVERS}"
+agents="${APPLIANCE_AGENTS:-$DEFAULT_AGENTS}"
+k3s_version="${APPLIANCE_K3S_VERSION:-$DEFAULT_K3S_VERSION}"
+platform_health_timeout="${APPLIANCE_PLATFORM_HEALTH_TIMEOUT:-$DEFAULT_PLATFORM_HEALTH_TIMEOUT}"
+publish="false"
+skip_provision="false"
+skip_restore_validation="false"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/local-appliance.sh <command> [options]
+
+Commands:
+  build     Provision a normal bootstrap k3d cluster and capture an appliance artifact.
+  restore   Restore a captured appliance artifact into a new k3d cluster.
+  publish   Push appliance images and OCI artifact metadata to GHCR.
+
+Options:
+  --cluster-name NAME           Source cluster for build (default: agyn-local).
+  --restore-cluster-name NAME   Restore target cluster (default: agyn-local).
+  --artifact-dir DIR            Appliance artifact directory (default: dist/local-appliance).
+  --image-repository REPO       OCI repository for published images/artifacts.
+  --image-tag TAG               Image/artifact tag (default: dev).
+  --domain DOMAIN               Bootstrap ingress domain (default: agyn.dev).
+  --port PORT                   Bootstrap ingress host port (default: 2496).
+  --api-port PORT               Kubernetes API host port (default: 6443).
+  --servers N                   k3d server node count (default: 1).
+  --agents N                    k3d agent node count for the restore shell (default: 0).
+  --k3s-version VERSION         k3s image tag without rancher/k3s: prefix.
+  --platform-health-timeout S   Timeout for verify_platform_health.sh (default: 900).
+  --publish                     Build command also publishes after capture.
+  --skip-provision              Build command captures an already-provisioned cluster.
+  --skip-restore-validation     Build command skips restore smoke test.
+  -h, --help                    Show this help.
+
+Environment variables mirror the option names with APPLIANCE_ prefixes where
+applicable. The path is opt-in only and does not change apply.sh behavior.
+USAGE
+}
+
+log() {
+  printf '[appliance] %s\n' "$*"
+}
+
+fail() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+require_command() {
+  local command_name=$1
+
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    fail "required command not found: ${command_name}"
+  fi
+}
+
+require_common_commands() {
+  local commands=(docker k3d kubectl jq tar)
+  local command_name
+
+  for command_name in "${commands[@]}"; do
+    require_command "$command_name"
+  done
+}
+
+require_build_commands() {
+  require_common_commands
+  require_command terraform
+  require_command curl
+}
+
+validate_integer() {
+  local name=$1
+  local value=$2
+
+  if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+    fail "${name} must be an integer"
+  fi
+}
+
+validate_port() {
+  local name=$1
+  local value=$2
+
+  validate_integer "$name" "$value"
+  if (( value < 1 || value > 65535 )); then
+    fail "${name} must be between 1 and 65535"
+  fi
+}
+
+parse_args() {
+  if [[ $# -lt 1 ]]; then
+    usage >&2
+    exit 1
+  fi
+
+  mode=$1
+  shift
+
+  case "$mode" in
+    build | restore | publish)
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --cluster-name)
+        cluster_name="${2:-}"
+        shift 2
+        ;;
+      --restore-cluster-name)
+        restore_cluster_name="${2:-}"
+        shift 2
+        ;;
+      --artifact-dir)
+        artifact_dir="${2:-}"
+        shift 2
+        ;;
+      --image-repository)
+        image_repository="${2:-}"
+        shift 2
+        ;;
+      --image-tag)
+        image_tag="${2:-}"
+        shift 2
+        ;;
+      --domain)
+        domain="${2:-}"
+        shift 2
+        ;;
+      --port)
+        port="${2:-}"
+        shift 2
+        ;;
+      --api-port)
+        api_port="${2:-}"
+        shift 2
+        ;;
+      --servers)
+        servers="${2:-}"
+        shift 2
+        ;;
+      --agents)
+        agents="${2:-}"
+        shift 2
+        ;;
+      --k3s-version)
+        k3s_version="${2:-}"
+        shift 2
+        ;;
+      --platform-health-timeout)
+        platform_health_timeout="${2:-}"
+        shift 2
+        ;;
+      --publish)
+        publish="true"
+        shift
+        ;;
+      --skip-provision)
+        skip_provision="true"
+        shift
+        ;;
+      --skip-restore-validation)
+        skip_restore_validation="true"
+        shift
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      *)
+        usage >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  [[ -n "$cluster_name" ]] || fail "cluster name cannot be empty"
+  [[ -n "$restore_cluster_name" ]] || fail "restore cluster name cannot be empty"
+  [[ -n "$artifact_dir" ]] || fail "artifact directory cannot be empty"
+  [[ -n "$image_repository" ]] || fail "image repository cannot be empty"
+  [[ -n "$image_tag" ]] || fail "image tag cannot be empty"
+  [[ -n "$domain" ]] || fail "domain cannot be empty"
+  [[ -n "$k3s_version" ]] || fail "k3s version cannot be empty"
+
+  validate_port "port" "$port"
+  validate_port "api port" "$api_port"
+  validate_integer "servers" "$servers"
+  validate_integer "agents" "$agents"
+  validate_integer "platform health timeout" "$platform_health_timeout"
+
+  if (( servers != 1 )); then
+    fail "this spike captures exactly one k3d server; set --servers 1"
+  fi
+
+  if (( agents != 0 )); then
+    fail "restore validation is limited to a single-node k3d shell; set --agents 0"
+  fi
+}
+
+cluster_exists() {
+  local name=$1
+
+  k3d cluster list --no-headers 2>/dev/null | awk '{print $1}' | grep -Fxq "$name"
+}
+
+remove_restore_cluster_if_present() {
+  if cluster_exists "$restore_cluster_name"; then
+    log "Deleting existing restore cluster ${restore_cluster_name}."
+    k3d cluster delete "$restore_cluster_name"
+  fi
+}
+
+source_node_name() {
+  printf 'k3d-%s-server-0' "$cluster_name"
+}
+
+source_load_balancer_name() {
+  printf 'k3d-%s-serverlb' "$cluster_name"
+}
+
+restore_node_name() {
+  printf 'k3d-%s-server-0' "$restore_cluster_name"
+}
+
+image_ref() {
+  printf '%s:%s' "$image_repository" "$image_tag"
+}
+
+runtime_image_ref() {
+  printf '%s-runtime:%s' "$image_repository" "$image_tag"
+}
+
+metadata_ref() {
+  printf '%s-metadata:%s' "$image_repository" "$image_tag"
+}
+
+run_bootstrap() {
+  log "Provisioning ${cluster_name} with existing apply.sh."
+  DOMAIN="$domain" PORT="$port" ./apply.sh -y
+}
+
+wait_for_platform_health() {
+  log "Waiting for platform health."
+  timeout "${platform_health_timeout}s" ./.github/scripts/verify_platform_health.sh
+}
+
+volume_name_for_destination() {
+  local container_name=$1
+  local destination=$2
+
+  docker inspect "$container_name" | jq -r --arg destination "$destination" '
+    .[0].Mounts[]
+    | select(.Destination == $destination and .Type == "volume")
+    | .Name
+  '
+}
+
+bind_source_for_destination() {
+  local container_name=$1
+  local destination=$2
+
+  docker inspect "$container_name" | jq -r --arg destination "$destination" '
+    .[0].Mounts[]
+    | select(.Destination == $destination and .Type == "bind")
+    | .Source
+  '
+}
+
+capture_volume() {
+  local volume_name=$1
+  local destination=$2
+  local output_path=$3
+
+  [[ -n "$volume_name" ]] || fail "missing Docker volume for ${destination}"
+  log "Capturing ${destination} from volume ${volume_name}."
+  docker run --rm \
+    -v "${volume_name}:/source:ro" \
+    alpine:3.20 \
+    tar -C /source -czf - . >"$output_path"
+}
+
+write_json_array() {
+  local output_path=$1
+  shift
+
+  jq -n '$ARGS.positional' --args "$@" >"$output_path"
+}
+
+capture_source_state() {
+  local source_node
+  local server_rancher_volume
+  local server_kubelet_volume
+  local server_cni_volume
+  local shared_source
+  local artifact_image
+  local runtime_image
+  local created_at
+
+  source_node=$(source_node_name)
+  artifact_image=$(image_ref)
+  runtime_image=$(runtime_image_ref)
+  created_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  docker inspect "$source_node" >/dev/null
+
+  log "Stopping ${cluster_name} cleanly before capture."
+  k3d cluster stop "$cluster_name"
+
+  rm -rf "$artifact_dir"
+  mkdir -p "${artifact_dir}/volumes" "${artifact_dir}/inspect"
+  artifact_dir=$(cd "$artifact_dir" && pwd)
+
+  log "Committing ${source_node} to ${artifact_image}."
+  docker commit "$source_node" "$artifact_image"
+
+  server_rancher_volume=$(volume_name_for_destination "$source_node" /var/lib/rancher/k3s)
+  server_kubelet_volume=$(volume_name_for_destination "$source_node" /var/lib/kubelet)
+  server_cni_volume=$(volume_name_for_destination "$source_node" /var/lib/cni)
+  shared_source=$(bind_source_for_destination "$source_node" /shared)
+
+  capture_volume "$server_rancher_volume" /var/lib/rancher/k3s "${artifact_dir}/volumes/server-var-lib-rancher-k3s.tar.gz"
+  capture_volume "$server_kubelet_volume" /var/lib/kubelet "${artifact_dir}/volumes/server-var-lib-kubelet.tar.gz"
+  capture_volume "$server_cni_volume" /var/lib/cni "${artifact_dir}/volumes/server-var-lib-cni.tar.gz"
+
+  if [[ -n "$shared_source" && -d "$shared_source" ]]; then
+    log "Capturing /shared bind source ${shared_source}."
+    tar -C "$shared_source" -czf "${artifact_dir}/volumes/shared.tar.gz" .
+  else
+    log "No /shared bind source found; creating empty shared snapshot."
+    tar -C /tmp --files-from /dev/null -czf "${artifact_dir}/volumes/shared.tar.gz"
+  fi
+
+  docker inspect "$source_node" >"${artifact_dir}/inspect/source-server.json"
+  if docker inspect "$(source_load_balancer_name)" >/dev/null 2>&1; then
+    docker inspect "$(source_load_balancer_name)" >"${artifact_dir}/inspect/source-load-balancer.json"
+  fi
+
+  write_json_array "${artifact_dir}/agent-images.json" "rancher/k3s:${k3s_version}"
+
+  jq -n \
+    --arg artifact_version "$DEFAULT_ARTIFACT_VERSION" \
+    --arg created_at "$created_at" \
+    --arg source_cluster_name "$cluster_name" \
+    --arg restore_cluster_name "$restore_cluster_name" \
+    --arg image "$artifact_image" \
+    --arg runtime_image "$runtime_image" \
+    --arg k3s_image "rancher/k3s:${k3s_version}" \
+    --arg domain "$domain" \
+    --argjson port "$port" \
+    --argjson api_port "$api_port" \
+    --argjson agents "$agents" \
+    '{
+      artifactVersion: $artifact_version,
+      createdAt: $created_at,
+      sourceClusterName: $source_cluster_name,
+      defaultRestoreClusterName: $restore_cluster_name,
+      image: $image,
+      runtimeImage: $runtime_image,
+      k3sImage: $k3s_image,
+      domain: $domain,
+      port: $port,
+      apiPort: $api_port,
+      servers: 1,
+      agents: $agents,
+      capturedPaths: [
+        "/var/lib/rancher/k3s",
+        "/var/lib/kubelet",
+        "/var/lib/cni",
+        "/shared"
+      ]
+    }' >"${artifact_dir}/manifest.json"
+
+  tar -C "$artifact_dir" -czf "${artifact_dir}.tar.gz" .
+
+  cat >"${artifact_dir}/Dockerfile.metadata" <<EOF_METADATA
+FROM scratch
+LABEL org.opencontainers.image.title="agyn-local-appliance-metadata"
+LABEL org.opencontainers.image.description="Metadata and volume snapshots for the opt-in Agyn local appliance spike"
+ADD manifest.json /manifest.json
+ADD agent-images.json /agent-images.json
+ADD volumes /volumes
+ADD inspect /inspect
+EOF_METADATA
+  docker build -f "${artifact_dir}/Dockerfile.metadata" -t "$runtime_image" "$artifact_dir"
+
+  log "Artifact written to ${artifact_dir} and ${artifact_dir}.tar.gz."
+  log "Committed source server image: ${artifact_image}."
+  log "Metadata image: ${runtime_image}."
+}
+
+create_restore_cluster_shell() {
+  local restore_image
+  local tmp_kubeconfig
+
+  restore_image=$(image_ref)
+  tmp_kubeconfig=$(mktemp)
+
+  remove_restore_cluster_if_present
+  log "Creating restore cluster ${restore_cluster_name} from ${restore_image}."
+  k3d cluster create "$restore_cluster_name" \
+    --servers 1 \
+    --agents "$agents" \
+    --image "$restore_image" \
+    --api-port "127.0.0.1:${api_port}" \
+    --port "127.0.0.1:${port}:443@loadbalancer" \
+    --volume "$(pwd)/shared:/shared@all" \
+    --k3s-arg "--disable=traefik@server:0" \
+    --wait \
+    --timeout 180s
+
+  k3d kubeconfig get "$restore_cluster_name" >"$tmp_kubeconfig"
+  mkdir -p "$(dirname "$KUBECONFIG_PATH")"
+  cp "$tmp_kubeconfig" "$KUBECONFIG_PATH"
+  rm -f "$tmp_kubeconfig"
+}
+
+restore_volume_into_container() {
+  local archive_path=$1
+  local container_name=$2
+  local destination=$3
+  local volume_name
+
+  [[ -f "$archive_path" ]] || fail "missing archive ${archive_path}"
+  volume_name=$(volume_name_for_destination "$container_name" "$destination")
+  [[ -n "$volume_name" ]] || fail "restore cluster does not expose ${destination} as a Docker volume"
+
+  log "Restoring ${destination} into volume ${volume_name}."
+  docker run --rm -i \
+    -v "${volume_name}:/target" \
+    alpine:3.20 \
+    sh -c "rm -rf /target/* /target/.[!.]* /target/..?* 2>/dev/null || true; tar -C /target -xzf -" <"$archive_path"
+}
+
+restore_shared_snapshot() {
+  local archive_path="${artifact_dir}/volumes/shared.tar.gz"
+
+  [[ -f "$archive_path" ]] || fail "missing archive ${archive_path}"
+  mkdir -p shared
+  log "Restoring /shared snapshot into $(pwd)/shared."
+  rm -rf shared/* shared/.[!.]* shared/..?* 2>/dev/null || true
+  tar -C shared -xzf "$archive_path"
+}
+
+restore_artifact() {
+  local restore_node
+
+  require_common_commands
+  create_restore_cluster_shell
+  restore_node=$(restore_node_name)
+
+  log "Stopping ${restore_cluster_name} before volume restore."
+  k3d cluster stop "$restore_cluster_name"
+
+  restore_volume_into_container "${artifact_dir}/volumes/server-var-lib-rancher-k3s.tar.gz" "$restore_node" /var/lib/rancher/k3s
+  restore_volume_into_container "${artifact_dir}/volumes/server-var-lib-kubelet.tar.gz" "$restore_node" /var/lib/kubelet
+  restore_volume_into_container "${artifact_dir}/volumes/server-var-lib-cni.tar.gz" "$restore_node" /var/lib/cni
+
+  restore_shared_snapshot
+
+  log "Starting restored cluster ${restore_cluster_name}."
+  k3d cluster start "$restore_cluster_name" --wait --timeout 180s
+  k3d kubeconfig get "$restore_cluster_name" >"$KUBECONFIG_PATH"
+
+  smoke_validate_restore
+}
+
+smoke_validate_restore() {
+  log "Validating restored Kubernetes API and persisted objects."
+  kubectl --kubeconfig "$KUBECONFIG_PATH" wait --for=condition=Ready nodes --all --timeout=180s
+  kubectl --kubeconfig "$KUBECONFIG_PATH" get nodes -o wide
+  kubectl --kubeconfig "$KUBECONFIG_PATH" get pv,pvc -A
+  kubectl --kubeconfig "$KUBECONFIG_PATH" -n argocd get applications.argoproj.io
+}
+
+publish_artifact() {
+  local artifact_image
+  local runtime_image
+  local metadata_image
+
+  require_common_commands
+  artifact_image=$(image_ref)
+  runtime_image=$(runtime_image_ref)
+  metadata_image=$(metadata_ref)
+
+  docker image inspect "$artifact_image" >/dev/null
+  docker image inspect "$runtime_image" >/dev/null
+
+  log "Tagging metadata artifact ${runtime_image} as ${metadata_image}."
+  docker tag "$runtime_image" "$metadata_image"
+
+  log "Pushing ${artifact_image}."
+  docker push "$artifact_image"
+  log "Pushing ${metadata_image}."
+  docker push "$metadata_image"
+}
+
+build_artifact() {
+  require_build_commands
+
+  if [[ "$skip_provision" == "false" ]]; then
+    run_bootstrap
+    wait_for_platform_health
+  fi
+
+  capture_source_state
+
+  if [[ "$skip_restore_validation" == "false" ]]; then
+    restore_artifact
+  else
+    log "Skipping restore validation; run scripts/local-appliance.sh restore to test the artifact."
+  fi
+
+  if [[ "$publish" == "true" ]]; then
+    publish_artifact
+  fi
+}
+
+main() {
+  parse_args "$@"
+
+  case "$mode" in
+    build)
+      build_artifact
+      ;;
+    restore)
+      restore_artifact
+      ;;
+    publish)
+      publish_artifact
+      ;;
+    *)
+      fail "unsupported mode ${mode}"
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/local-appliance.sh
+++ b/scripts/local-appliance.sh
@@ -11,11 +11,13 @@ DEFAULT_DOMAIN="agyn.dev"
 DEFAULT_PORT="2496"
 DEFAULT_API_PORT="6443"
 DEFAULT_SERVERS="1"
-DEFAULT_AGENTS="0"
+DEFAULT_AGENTS="2"
 DEFAULT_K3S_VERSION="v1.34.3-k3s1"
 DEFAULT_PLATFORM_HEALTH_TIMEOUT="900"
 DEFAULT_ARTIFACT_VERSION="1"
 KUBECONFIG_PATH="stacks/k8s/.kube/agyn-local-kubeconfig.yaml"
+NODE_VOLUME_DESTINATIONS=(/var/lib/rancher/k3s /var/lib/kubelet /var/lib/cni)
+NODE_ARCHIVE_SUFFIXES=(var-lib-rancher-k3s var-lib-kubelet var-lib-cni)
 
 mode=""
 cluster_name="${APPLIANCE_CLUSTER_NAME:-$DEFAULT_CLUSTER_NAME}"
@@ -53,12 +55,12 @@ Options:
   --port PORT                   Bootstrap ingress host port (default: 2496).
   --api-port PORT               Kubernetes API host port (default: 6443).
   --servers N                   k3d server node count (default: 1).
-  --agents N                    k3d agent node count for the restore shell (default: 0).
+  --agents N                    k3d agent node count (default: 2).
   --k3s-version VERSION         k3s image tag without rancher/k3s: prefix.
   --platform-health-timeout S   Timeout for verify_platform_health.sh (default: 900).
-  --publish                     Build command also publishes after capture.
+  --publish                     Build command also publishes after successful validation.
+  --skip-restore-validation     Build command skips restore smoke test. Cannot be combined with --publish.
   --skip-provision              Build command captures an already-provisioned cluster.
-  --skip-restore-validation     Build command skips restore smoke test.
   -h, --help                    Show this help.
 
 Environment variables mirror the option names with APPLIANCE_ prefixes where
@@ -230,8 +232,8 @@ parse_args() {
     fail "this spike captures exactly one k3d server; set --servers 1"
   fi
 
-  if (( agents != 0 )); then
-    fail "restore validation is limited to a single-node k3d shell; set --agents 0"
+  if [[ "$publish" == "true" && "$skip_restore_validation" == "true" ]]; then
+    fail "--publish requires restore validation; remove --skip-restore-validation"
   fi
 }
 
@@ -248,24 +250,20 @@ remove_restore_cluster_if_present() {
   fi
 }
 
-source_node_name() {
-  printf 'k3d-%s-server-0' "$cluster_name"
+node_name() {
+  local cluster=$1
+  local role=$2
+  local index=$3
+
+  printf 'k3d-%s-%s-%s' "$cluster" "$role" "$index"
 }
 
 source_load_balancer_name() {
   printf 'k3d-%s-serverlb' "$cluster_name"
 }
 
-restore_node_name() {
-  printf 'k3d-%s-server-0' "$restore_cluster_name"
-}
-
 image_ref() {
   printf '%s:%s' "$image_repository" "$image_tag"
-}
-
-runtime_image_ref() {
-  printf '%s-runtime:%s' "$image_repository" "$image_tag"
 }
 
 metadata_ref() {
@@ -273,8 +271,18 @@ metadata_ref() {
 }
 
 run_bootstrap() {
-  log "Provisioning ${cluster_name} with existing apply.sh."
-  DOMAIN="$domain" PORT="$port" ./apply.sh -y
+  local tfvars
+
+  tfvars=(
+    -var "cluster_name=${cluster_name}"
+    -var "servers=${servers}"
+    -var "agents=${agents}"
+    -var "k3s_version=${k3s_version}"
+    -var "api_port=${api_port}"
+  )
+
+  log "Provisioning ${cluster_name} with existing apply.sh and appliance topology overrides."
+  TF_CLI_ARGS_apply="${tfvars[*]}" DOMAIN="$domain" PORT="$port" ./apply.sh -y
 }
 
 wait_for_platform_health() {
@@ -304,6 +312,21 @@ bind_source_for_destination() {
   '
 }
 
+node_archive_prefix() {
+  local role=$1
+  local index=$2
+
+  printf '%s-%s' "$role" "$index"
+}
+
+node_archive_path() {
+  local role=$1
+  local index=$2
+  local suffix=$3
+
+  printf '%s/volumes/%s-%s.tar.gz' "$artifact_dir" "$(node_archive_prefix "$role" "$index")" "$suffix"
+}
+
 capture_volume() {
   local volume_name=$1
   local destination=$2
@@ -317,6 +340,62 @@ capture_volume() {
     tar -C /source -czf - . >"$output_path"
 }
 
+restore_volume_into_container() {
+  local archive_path=$1
+  local container_name=$2
+  local destination=$3
+  local volume_name
+
+  [[ -f "$archive_path" ]] || fail "missing archive ${archive_path}"
+  volume_name=$(volume_name_for_destination "$container_name" "$destination")
+  [[ -n "$volume_name" ]] || fail "restore cluster does not expose ${destination} as a Docker volume"
+
+  log "Restoring ${destination} into volume ${volume_name}."
+  docker run --rm -i \
+    -v "${volume_name}:/target" \
+    alpine:3.20 \
+    sh -c "rm -rf /target/* /target/.[!.]* /target/..?* 2>/dev/null || true; tar -C /target -xzf -" <"$archive_path"
+}
+
+capture_node() {
+  local role=$1
+  local index=$2
+  local container_name
+  local destination_index
+  local destination
+  local suffix
+  local volume_name
+
+  container_name=$(node_name "$cluster_name" "$role" "$index")
+  docker inspect "$container_name" >/dev/null
+
+  for destination_index in "${!NODE_VOLUME_DESTINATIONS[@]}"; do
+    destination="${NODE_VOLUME_DESTINATIONS[$destination_index]}"
+    suffix="${NODE_ARCHIVE_SUFFIXES[$destination_index]}"
+    volume_name=$(volume_name_for_destination "$container_name" "$destination")
+    capture_volume "$volume_name" "${container_name}:${destination}" "$(node_archive_path "$role" "$index" "$suffix")"
+  done
+
+  docker inspect "$container_name" >"${artifact_dir}/inspect/source-${role}-${index}.json"
+}
+
+restore_node_volumes() {
+  local role=$1
+  local index=$2
+  local container_name
+  local destination_index
+  local destination
+  local suffix
+
+  container_name=$(node_name "$restore_cluster_name" "$role" "$index")
+
+  for destination_index in "${!NODE_VOLUME_DESTINATIONS[@]}"; do
+    destination="${NODE_VOLUME_DESTINATIONS[$destination_index]}"
+    suffix="${NODE_ARCHIVE_SUFFIXES[$destination_index]}"
+    restore_volume_into_container "$(node_archive_path "$role" "$index" "$suffix")" "$container_name" "$destination"
+  done
+}
+
 write_json_array() {
   local output_path=$1
   shift
@@ -326,17 +405,15 @@ write_json_array() {
 
 capture_source_state() {
   local source_node
-  local server_rancher_volume
-  local server_kubelet_volume
-  local server_cni_volume
   local shared_source
   local artifact_image
-  local runtime_image
+  local metadata_image
   local created_at
+  local agent_index
 
-  source_node=$(source_node_name)
+  source_node=$(node_name "$cluster_name" server 0)
   artifact_image=$(image_ref)
-  runtime_image=$(runtime_image_ref)
+  metadata_image=$(metadata_ref)
   created_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
   docker inspect "$source_node" >/dev/null
@@ -351,15 +428,12 @@ capture_source_state() {
   log "Committing ${source_node} to ${artifact_image}."
   docker commit "$source_node" "$artifact_image"
 
-  server_rancher_volume=$(volume_name_for_destination "$source_node" /var/lib/rancher/k3s)
-  server_kubelet_volume=$(volume_name_for_destination "$source_node" /var/lib/kubelet)
-  server_cni_volume=$(volume_name_for_destination "$source_node" /var/lib/cni)
+  capture_node server 0
+  for (( agent_index = 0; agent_index < agents; agent_index++ )); do
+    capture_node agent "$agent_index"
+  done
+
   shared_source=$(bind_source_for_destination "$source_node" /shared)
-
-  capture_volume "$server_rancher_volume" /var/lib/rancher/k3s "${artifact_dir}/volumes/server-var-lib-rancher-k3s.tar.gz"
-  capture_volume "$server_kubelet_volume" /var/lib/kubelet "${artifact_dir}/volumes/server-var-lib-kubelet.tar.gz"
-  capture_volume "$server_cni_volume" /var/lib/cni "${artifact_dir}/volumes/server-var-lib-cni.tar.gz"
-
   if [[ -n "$shared_source" && -d "$shared_source" ]]; then
     log "Capturing /shared bind source ${shared_source}."
     tar -C "$shared_source" -czf "${artifact_dir}/volumes/shared.tar.gz" .
@@ -368,12 +442,11 @@ capture_source_state() {
     tar -C /tmp --files-from /dev/null -czf "${artifact_dir}/volumes/shared.tar.gz"
   fi
 
-  docker inspect "$source_node" >"${artifact_dir}/inspect/source-server.json"
   if docker inspect "$(source_load_balancer_name)" >/dev/null 2>&1; then
     docker inspect "$(source_load_balancer_name)" >"${artifact_dir}/inspect/source-load-balancer.json"
   fi
 
-  write_json_array "${artifact_dir}/agent-images.json" "rancher/k3s:${k3s_version}"
+  write_json_array "${artifact_dir}/node-images.json" "rancher/k3s:${k3s_version}"
 
   jq -n \
     --arg artifact_version "$DEFAULT_ARTIFACT_VERSION" \
@@ -381,7 +454,7 @@ capture_source_state() {
     --arg source_cluster_name "$cluster_name" \
     --arg restore_cluster_name "$restore_cluster_name" \
     --arg image "$artifact_image" \
-    --arg runtime_image "$runtime_image" \
+    --arg metadata_image "$metadata_image" \
     --arg k3s_image "rancher/k3s:${k3s_version}" \
     --arg domain "$domain" \
     --argjson port "$port" \
@@ -393,7 +466,7 @@ capture_source_state() {
       sourceClusterName: $source_cluster_name,
       defaultRestoreClusterName: $restore_cluster_name,
       image: $image,
-      runtimeImage: $runtime_image,
+      metadataImage: $metadata_image,
       k3sImage: $k3s_image,
       domain: $domain,
       port: $port,
@@ -405,7 +478,10 @@ capture_source_state() {
         "/var/lib/kubelet",
         "/var/lib/cni",
         "/shared"
-      ]
+      ],
+      nodeArchives: ([
+        {role: "server", index: 0}
+      ] + [range(0; $agents) | {role: "agent", index: .}])
     }' >"${artifact_dir}/manifest.json"
 
   tar -C "$artifact_dir" -czf "${artifact_dir}.tar.gz" .
@@ -415,15 +491,15 @@ FROM scratch
 LABEL org.opencontainers.image.title="agyn-local-appliance-metadata"
 LABEL org.opencontainers.image.description="Metadata and volume snapshots for the opt-in Agyn local appliance spike"
 ADD manifest.json /manifest.json
-ADD agent-images.json /agent-images.json
+ADD node-images.json /node-images.json
 ADD volumes /volumes
 ADD inspect /inspect
 EOF_METADATA
-  docker build -f "${artifact_dir}/Dockerfile.metadata" -t "$runtime_image" "$artifact_dir"
+  docker build -f "${artifact_dir}/Dockerfile.metadata" -t "$metadata_image" "$artifact_dir"
 
   log "Artifact written to ${artifact_dir} and ${artifact_dir}.tar.gz."
   log "Committed source server image: ${artifact_image}."
-  log "Metadata image: ${runtime_image}."
+  log "Metadata image: ${metadata_image}."
 }
 
 create_restore_cluster_shell() {
@@ -452,23 +528,6 @@ create_restore_cluster_shell() {
   rm -f "$tmp_kubeconfig"
 }
 
-restore_volume_into_container() {
-  local archive_path=$1
-  local container_name=$2
-  local destination=$3
-  local volume_name
-
-  [[ -f "$archive_path" ]] || fail "missing archive ${archive_path}"
-  volume_name=$(volume_name_for_destination "$container_name" "$destination")
-  [[ -n "$volume_name" ]] || fail "restore cluster does not expose ${destination} as a Docker volume"
-
-  log "Restoring ${destination} into volume ${volume_name}."
-  docker run --rm -i \
-    -v "${volume_name}:/target" \
-    alpine:3.20 \
-    sh -c "rm -rf /target/* /target/.[!.]* /target/..?* 2>/dev/null || true; tar -C /target -xzf -" <"$archive_path"
-}
-
 restore_shared_snapshot() {
   local archive_path="${artifact_dir}/volumes/shared.tar.gz"
 
@@ -479,20 +538,61 @@ restore_shared_snapshot() {
   tar -C shared -xzf "$archive_path"
 }
 
+pull_artifact() {
+  local metadata_image
+  local extract_container
+
+  metadata_image=$(metadata_ref)
+
+  if [[ -f "${artifact_dir}/manifest.json" ]]; then
+    return 0
+  fi
+
+  require_command docker
+  if docker image inspect "$metadata_image" >/dev/null 2>&1; then
+    log "Artifact directory ${artifact_dir} is missing; extracting local ${metadata_image}."
+  else
+    log "Artifact directory ${artifact_dir} is missing; pulling ${metadata_image}."
+    docker pull "$metadata_image"
+  fi
+
+  rm -rf "$artifact_dir"
+  mkdir -p "$artifact_dir"
+  extract_container=$(docker create --entrypoint true "$metadata_image")
+  docker cp "${extract_container}:/manifest.json" "${artifact_dir}/manifest.json"
+  docker cp "${extract_container}:/node-images.json" "${artifact_dir}/node-images.json"
+  docker cp "${extract_container}:/volumes" "${artifact_dir}/volumes"
+  docker cp "${extract_container}:/inspect" "${artifact_dir}/inspect"
+  docker rm "$extract_container" >/dev/null
+}
+
+load_manifest_defaults() {
+  local manifest_path="${artifact_dir}/manifest.json"
+
+  [[ -f "$manifest_path" ]] || fail "missing manifest ${manifest_path}"
+
+  agents=$(jq -r '.agents' "$manifest_path")
+  api_port=$(jq -r '.apiPort' "$manifest_path")
+  port=$(jq -r '.port' "$manifest_path")
+  domain=$(jq -r '.domain' "$manifest_path")
+  k3s_version=$(jq -r '.k3sImage | sub("^rancher/k3s:"; "")' "$manifest_path")
+}
+
 restore_artifact() {
-  local restore_node
+  local agent_index
 
   require_common_commands
+  pull_artifact
+  load_manifest_defaults
   create_restore_cluster_shell
-  restore_node=$(restore_node_name)
 
   log "Stopping ${restore_cluster_name} before volume restore."
   k3d cluster stop "$restore_cluster_name"
 
-  restore_volume_into_container "${artifact_dir}/volumes/server-var-lib-rancher-k3s.tar.gz" "$restore_node" /var/lib/rancher/k3s
-  restore_volume_into_container "${artifact_dir}/volumes/server-var-lib-kubelet.tar.gz" "$restore_node" /var/lib/kubelet
-  restore_volume_into_container "${artifact_dir}/volumes/server-var-lib-cni.tar.gz" "$restore_node" /var/lib/cni
-
+  restore_node_volumes server 0
+  for (( agent_index = 0; agent_index < agents; agent_index++ )); do
+    restore_node_volumes agent "$agent_index"
+  done
   restore_shared_snapshot
 
   log "Starting restored cluster ${restore_cluster_name}."
@@ -512,19 +612,14 @@ smoke_validate_restore() {
 
 publish_artifact() {
   local artifact_image
-  local runtime_image
   local metadata_image
 
   require_common_commands
   artifact_image=$(image_ref)
-  runtime_image=$(runtime_image_ref)
   metadata_image=$(metadata_ref)
 
   docker image inspect "$artifact_image" >/dev/null
-  docker image inspect "$runtime_image" >/dev/null
-
-  log "Tagging metadata artifact ${runtime_image} as ${metadata_image}."
-  docker tag "$runtime_image" "$metadata_image"
+  docker image inspect "$metadata_image" >/dev/null
 
   log "Pushing ${artifact_image}."
   docker push "$artifact_image"

--- a/scripts/local-appliance.sh
+++ b/scripts/local-appliance.sh
@@ -46,8 +46,6 @@ Commands:
   publish   Push appliance images and OCI artifact metadata to GHCR.
 
 Options:
-  --cluster-name NAME           Source cluster for build (default: agyn-local).
-  --restore-cluster-name NAME   Restore target cluster (default: agyn-local).
   --artifact-dir DIR            Appliance artifact directory (default: dist/local-appliance).
   --image-repository REPO       OCI repository for published images/artifacts.
   --image-tag TAG               Image/artifact tag (default: dev).
@@ -143,13 +141,8 @@ parse_args() {
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --cluster-name)
-        cluster_name="${2:-}"
-        shift 2
-        ;;
-      --restore-cluster-name)
-        restore_cluster_name="${2:-}"
-        shift 2
+      --cluster-name | --restore-cluster-name)
+        fail "$1 is not supported because bootstrap health checks and dependent stacks use ${KUBECONFIG_PATH}"
         ;;
       --artifact-dir)
         artifact_dir="${2:-}"
@@ -270,19 +263,22 @@ metadata_ref() {
   printf '%s-metadata:%s' "$image_repository" "$image_tag"
 }
 
+write_k8s_tfvars() {
+  local tfvars_path="stacks/k8s/local-appliance.auto.tfvars"
+
+  cat >"$tfvars_path" <<EOF_TFVARS
+cluster_name = "${cluster_name}"
+servers      = ${servers}
+agents       = ${agents}
+k3s_version  = "${k3s_version}"
+api_port     = ${api_port}
+EOF_TFVARS
+}
+
 run_bootstrap() {
-  local tfvars
-
-  tfvars=(
-    -var "cluster_name=${cluster_name}"
-    -var "servers=${servers}"
-    -var "agents=${agents}"
-    -var "k3s_version=${k3s_version}"
-    -var "api_port=${api_port}"
-  )
-
-  log "Provisioning ${cluster_name} with existing apply.sh and appliance topology overrides."
-  TF_CLI_ARGS_apply="${tfvars[*]}" DOMAIN="$domain" PORT="$port" ./apply.sh -y
+  log "Provisioning ${cluster_name} with existing apply.sh and k8s-only appliance topology overrides."
+  write_k8s_tfvars
+  DOMAIN="$domain" PORT="$port" ./apply.sh -y
 }
 
 wait_for_platform_health() {

--- a/scripts/local-appliance.sh
+++ b/scripts/local-appliance.sh
@@ -15,13 +15,14 @@ DEFAULT_AGENTS="2"
 DEFAULT_K3S_VERSION="v1.34.3-k3s1"
 DEFAULT_PLATFORM_HEALTH_TIMEOUT="900"
 DEFAULT_ARTIFACT_VERSION="1"
+K8S_TFVARS_PATH="stacks/k8s/local-appliance.auto.tfvars"
 KUBECONFIG_PATH="stacks/k8s/.kube/agyn-local-kubeconfig.yaml"
 NODE_VOLUME_DESTINATIONS=(/var/lib/rancher/k3s /var/lib/kubelet /var/lib/cni)
 NODE_ARCHIVE_SUFFIXES=(var-lib-rancher-k3s var-lib-kubelet var-lib-cni)
 
 mode=""
-cluster_name="${APPLIANCE_CLUSTER_NAME:-$DEFAULT_CLUSTER_NAME}"
-restore_cluster_name="${APPLIANCE_RESTORE_CLUSTER_NAME:-$DEFAULT_RESTORE_CLUSTER_NAME}"
+cluster_name="$DEFAULT_CLUSTER_NAME"
+restore_cluster_name="$DEFAULT_RESTORE_CLUSTER_NAME"
 artifact_dir="${APPLIANCE_ARTIFACT_DIR:-$DEFAULT_ARTIFACT_DIR}"
 image_repository="${APPLIANCE_IMAGE_REPOSITORY:-$DEFAULT_IMAGE_REPOSITORY}"
 image_tag="${APPLIANCE_IMAGE_TAG:-$DEFAULT_IMAGE_TAG}"
@@ -264,9 +265,7 @@ metadata_ref() {
 }
 
 write_k8s_tfvars() {
-  local tfvars_path="stacks/k8s/local-appliance.auto.tfvars"
-
-  cat >"$tfvars_path" <<EOF_TFVARS
+  cat >"$K8S_TFVARS_PATH" <<EOF_TFVARS
 cluster_name = "${cluster_name}"
 servers      = ${servers}
 agents       = ${agents}
@@ -278,6 +277,7 @@ EOF_TFVARS
 run_bootstrap() {
   log "Provisioning ${cluster_name} with existing apply.sh and k8s-only appliance topology overrides."
   write_k8s_tfvars
+  trap 'rm -f "$K8S_TFVARS_PATH"' EXIT INT TERM RETURN
   DOMAIN="$domain" PORT="$port" ./apply.sh -y
 }
 


### PR DESCRIPTION
## Summary

- Adds an opt-in `scripts/local-appliance.sh` spike path to build, restore-test, and publish a local appliance artifact without changing `apply.sh` or default CI behavior.
- Captures the closest feasible artifact shape found locally: committed k3d server image plus explicit snapshots of k3d-mounted state volumes and `/shared`.
- Adds a manual-only `local appliance spike` workflow for workflow_dispatch builds and optional GHCR publish.
- Documents build/publish/restore usage, security constraints, exact local validation, Docker inspect mount findings, and the restore blocker/next artifact shape.

Closes #575

## Validation

Commands run locally:

```sh
terraform fmt -check -recursive
shellcheck scripts/local-appliance.sh apply.sh install-ca-cert.sh .github/scripts/verify_platform_health.sh
bash -n scripts/local-appliance.sh
scripts/local-appliance.sh --help
scripts/local-appliance.sh build --skip-provision --skip-restore-validation --image-repository local/agyn-bootstrap-appliance --image-tag smoke-skip
scripts/local-appliance.sh build --skip-provision --image-repository local/agyn-bootstrap-appliance --image-tag smoke
```

Results:

- Static validation: passed with no errors.
- Help/argument validation: passed.
- Capture-only smoke: passed; created committed server image, metadata image, `dist/local-appliance`, and `dist/local-appliance.tar.gz`.
- Restore smoke: capture passed, restore failed at k3d server readiness with:

```text
Failed to start server k3d-agyn-local-server-0: Node k3d-agyn-local-server-0 failed to get ready: error waiting for log line `k3s is up and running` from node 'k3d-agyn-local-server-0': stopped returning log lines: context deadline exceeded
```

Docker inspect findings are documented in `docs/local-appliance.md`: k3d uses Docker volumes for `/var/lib/rancher/k3s`, `/var/lib/kubelet`, `/var/lib/cni`, `/var/log`, and `/k3d/images`, so a single `docker commit` image cannot contain the full portable cluster state.

## Notes

- Existing bootstrap behavior remains unchanged by default.
- The new workflow is manual-only (`workflow_dispatch`).
- The follow-up artifact shape should likely treat explicit Docker volume snapshots as first-class artifacts, or investigate k3s datastore/node identity assumptions that block restored startup.