### PR TITLE
fix(ziti): wire workload underlay egress

### DIFF
--- a/.github/scripts/verify_platform_health.sh
+++ b/.github/scripts/verify_platform_health.sh
@@ -7,8 +7,10 @@ POLL_INTERVAL=${POLL_INTERVAL:-10}
 PLATFORM_NAMESPACE=${PLATFORM_NAMESPACE:-platform}
 ARGO_NAMESPACE=${ARGO_NAMESPACE:-argocd}
 ZITI_NAMESPACE=${ZITI_NAMESPACE:-ziti}
+WORKLOAD_NAMESPACE=${WORKLOAD_NAMESPACE:-agyn-workloads}
 DEFAULT_DOMAIN="agyn.dev"
 DEFAULT_PORT="2496"
+DEFAULT_ZITI_CLIENT_PORT="443"
 POD_TERMINAL_FAILURE_GRACE_CYCLES=${POD_TERMINAL_FAILURE_GRACE_CYCLES:-5}
 POD_CRASH_BACKOFF_GRACE_CYCLES=${POD_CRASH_BACKOFF_GRACE_CYCLES:-5}
 
@@ -104,6 +106,76 @@ ziti_api_get() {
   local path=$2
 
   curl -sk --fail -H "zt-session: ${token}" "${ZITI_MGMT_ENDPOINT}${path}"
+}
+
+verify_ziti_client_oidc_runtime() {
+  local dns_ip
+  local domain
+  local oidc_url
+  local pod_name
+  local port
+  local version_url
+
+  domain="${DOMAIN:-$DEFAULT_DOMAIN}"
+  port="${ZITI_CLIENT_PORT:-$DEFAULT_ZITI_CLIENT_PORT}"
+  pod_name="ziti-client-runtime-health"
+  version_url="https://ziti.${domain}:${port}/edge/client/v1/version"
+  oidc_url="https://ziti.${domain}:${port}/oidc/.well-known/openid-configuration"
+
+  dns_ip=$(kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$ZITI_NAMESPACE" \
+    get svc ziti-workload-dns -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)
+  if [[ -z "$dns_ip" ]]; then
+    log "Ziti workload DNS service is not available"
+    return 1
+  fi
+
+  kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$WORKLOAD_NAMESPACE" \
+    delete pod "$pod_name" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+
+  if ! kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$WORKLOAD_NAMESPACE" apply -f - >/dev/null <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${pod_name}
+  labels:
+    app.kubernetes.io/name: ziti-client-runtime-health
+spec:
+  restartPolicy: Never
+  dnsPolicy: None
+  dnsConfig:
+    nameservers:
+      - ${dns_ip}
+  containers:
+    - name: curl
+      image: curlimages/curl:8.16.0
+      command:
+        - sh
+        - -ec
+        - |
+          version_json="$(curl -skf '${version_url}')"
+          if printf '%s' "\$version_json" | grep -q 'OIDC_AUTH'; then
+            curl -skf '${oidc_url}' | grep -q '"issuer"'
+          else
+            echo 'OIDC_AUTH not advertised; cert-auth-only runtime path'
+          fi
+EOF
+  then
+    log "Unable to create Ziti client runtime health pod"
+    return 1
+  fi
+
+  if ! kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$WORKLOAD_NAMESPACE" \
+    wait --for=jsonpath='{.status.phase}'=Succeeded "pod/${pod_name}" --timeout=60s >/dev/null; then
+    log "Ziti client runtime OIDC check failed: ${version_url} / ${oidc_url}"
+    kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$WORKLOAD_NAMESPACE" logs "$pod_name" --all-containers --tail=50 || true
+    kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$WORKLOAD_NAMESPACE" describe pod "$pod_name" || true
+    kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$WORKLOAD_NAMESPACE" delete pod "$pod_name" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+    return 1
+  fi
+
+  kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$WORKLOAD_NAMESPACE" logs "$pod_name" --all-containers --tail=20 || true
+  kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$WORKLOAD_NAMESPACE" delete pod "$pod_name" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  log "Ziti client runtime auth discovery is valid from workload DNS context"
 }
 
 jq_unhealthy_pods() {
@@ -401,6 +473,12 @@ while (( SECONDS < deadline )); do
     if (( ${#ziti_overlay_pending[@]} > 0 )); then
       ziti_overlay_message=$(join_lines "$(printf '%s\n' "${ziti_overlay_pending[@]}")")
       outstanding+=("waiting for Ziti overlay: ${ziti_overlay_message}")
+    fi
+  fi
+
+  if (( ${#outstanding[@]} == 0 )); then
+    if ! verify_ziti_client_oidc_runtime; then
+      outstanding+=("waiting for Ziti client OIDC runtime endpoint")
     fi
   fi
 

--- a/stacks/apps/main.tf
+++ b/stacks/apps/main.tf
@@ -276,7 +276,11 @@ locals {
           {
             name = "ingress-gateway"
             cidr = format("%s/32", data.kubernetes_service_v1.istio_ingressgateway.spec[0].cluster_ip)
-            port = 443
+            namespaceSelector = {
+              "kubernetes.io/metadata.name" = data.terraform_remote_state.system.outputs.istio_gateway_namespace
+            }
+            podSelector = data.kubernetes_service_v1.istio_ingressgateway.spec[0].selector
+            port        = 443
           },
           {
             name = "controller-enrollment"

--- a/stacks/apps/main.tf
+++ b/stacks/apps/main.tf
@@ -290,7 +290,7 @@ locals {
           {
             name = "controller-enrollment"
             cidr = format("%s/32", data.kubernetes_service_v1.ziti_controller_client.spec[0].cluster_ip)
-            port = local.ingress_port
+            port = local.ziti_client_runtime_port
           },
           {
             name = "router"

--- a/stacks/apps/main.tf
+++ b/stacks/apps/main.tf
@@ -265,6 +265,27 @@ locals {
         }
       ]
     }
+    workloadNamespace = "agyn-workloads"
+    workloadEgressNetworkPolicy = {
+      enabled = true
+      zitiWorkloadDNS = {
+        enabled = true
+      }
+      zitiUnderlay = {
+        endpoints = [
+          {
+            name = "controller"
+            cidr = format("%s/32", data.kubernetes_service_v1.ziti_controller_client.spec[0].cluster_ip)
+            port = local.ingress_port
+          },
+          {
+            name = "router"
+            cidr = format("%s/32", data.kubernetes_service_v1.ziti_router_edge.spec[0].cluster_ip)
+            port = local.ingress_port
+          },
+        ]
+      }
+    }
   })
 }
 

--- a/stacks/apps/main.tf
+++ b/stacks/apps/main.tf
@@ -279,6 +279,11 @@ locals {
             port = 443
           },
           {
+            name = "controller-enrollment"
+            cidr = format("%s/32", data.kubernetes_service_v1.ziti_controller_client.spec[0].cluster_ip)
+            port = local.ingress_port
+          },
+          {
             name = "router"
             cidr = format("%s/32", data.kubernetes_service_v1.ziti_router_edge.spec[0].cluster_ip)
             port = local.ingress_port

--- a/stacks/apps/main.tf
+++ b/stacks/apps/main.tf
@@ -276,6 +276,11 @@ locals {
           {
             name = "ingress-gateway"
             cidr = format("%s/32", data.kubernetes_service_v1.istio_ingressgateway.spec[0].cluster_ip)
+            backendCIDRs = distinct(flatten([
+              for subset in data.kubernetes_endpoints_v1.istio_ingressgateway.subset : [
+                for address in subset.address : format("%s/32", address.ip)
+              ]
+            ]))
             namespaceSelector = {
               "kubernetes.io/metadata.name" = data.terraform_remote_state.system.outputs.istio_gateway_namespace
             }

--- a/stacks/apps/main.tf
+++ b/stacks/apps/main.tf
@@ -274,9 +274,9 @@ locals {
       zitiUnderlay = {
         endpoints = [
           {
-            name = "controller"
-            cidr = format("%s/32", data.kubernetes_service_v1.ziti_controller_client.spec[0].cluster_ip)
-            port = local.ingress_port
+            name = "ingress-gateway"
+            cidr = format("%s/32", data.kubernetes_service_v1.istio_ingressgateway.spec[0].cluster_ip)
+            port = 443
           },
           {
             name = "router"

--- a/stacks/apps/remote_state.tf
+++ b/stacks/apps/remote_state.tf
@@ -50,3 +50,10 @@ data "kubernetes_service_v1" "istio_ingressgateway" {
     namespace = data.terraform_remote_state.system.outputs.istio_gateway_namespace
   }
 }
+
+data "kubernetes_endpoints_v1" "istio_ingressgateway" {
+  metadata {
+    name      = data.kubernetes_service_v1.istio_ingressgateway.metadata[0].name
+    namespace = data.terraform_remote_state.system.outputs.istio_gateway_namespace
+  }
+}

--- a/stacks/apps/remote_state.tf
+++ b/stacks/apps/remote_state.tf
@@ -6,6 +6,14 @@ data "terraform_remote_state" "k8s" {
   }
 }
 
+data "terraform_remote_state" "system" {
+  backend = "local"
+
+  config = {
+    path = "../system/state/terraform.tfstate"
+  }
+}
+
 data "terraform_remote_state" "platform" {
   backend = "local"
 
@@ -19,4 +27,19 @@ locals {
   ingress_port        = data.terraform_remote_state.k8s.outputs.ingress_port
   gateway_url         = format("https://gateway.%s:%d", local.base_domain, local.ingress_port)
   cluster_admin_token = data.terraform_remote_state.platform.outputs.cluster_admin_api_token
+  ziti_namespace      = data.terraform_remote_state.system.outputs.installed_namespaces[1]
+}
+
+data "kubernetes_service_v1" "ziti_controller_client" {
+  metadata {
+    name      = "ziti-controller-client"
+    namespace = local.ziti_namespace
+  }
+}
+
+data "kubernetes_service_v1" "ziti_router_edge" {
+  metadata {
+    name      = "ziti-router-edge"
+    namespace = local.ziti_namespace
+  }
 }

--- a/stacks/apps/remote_state.tf
+++ b/stacks/apps/remote_state.tf
@@ -43,3 +43,10 @@ data "kubernetes_service_v1" "ziti_router_edge" {
     namespace = local.ziti_namespace
   }
 }
+
+data "kubernetes_service_v1" "istio_ingressgateway" {
+  metadata {
+    name      = "istio-ingressgateway"
+    namespace = data.terraform_remote_state.system.outputs.istio_gateway_namespace
+  }
+}

--- a/stacks/apps/remote_state.tf
+++ b/stacks/apps/remote_state.tf
@@ -23,11 +23,12 @@ data "terraform_remote_state" "platform" {
 }
 
 locals {
-  base_domain         = data.terraform_remote_state.k8s.outputs.domain
-  ingress_port        = data.terraform_remote_state.k8s.outputs.ingress_port
-  gateway_url         = format("https://gateway.%s:%d", local.base_domain, local.ingress_port)
-  cluster_admin_token = data.terraform_remote_state.platform.outputs.cluster_admin_api_token
-  ziti_namespace      = data.terraform_remote_state.system.outputs.installed_namespaces[1]
+  base_domain              = data.terraform_remote_state.k8s.outputs.domain
+  ingress_port             = data.terraform_remote_state.k8s.outputs.ingress_port
+  ziti_client_runtime_port = 443
+  gateway_url              = format("https://gateway.%s:%d", local.base_domain, local.ingress_port)
+  cluster_admin_token      = data.terraform_remote_state.platform.outputs.cluster_admin_api_token
+  ziti_namespace           = data.terraform_remote_state.system.outputs.installed_namespaces[1]
 }
 
 data "kubernetes_service_v1" "ziti_controller_client" {

--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -61,7 +61,7 @@ variable "reminders_image_tag" {
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.10.15"
+  default     = "0.10.14"
 }
 
 variable "k8s_runner_image_tag" {

--- a/stacks/apps/variables.tf
+++ b/stacks/apps/variables.tf
@@ -61,7 +61,7 @@ variable "reminders_image_tag" {
 variable "k8s_runner_chart_version" {
   type        = string
   description = "Version of the k8s-runner Helm chart published to GHCR"
-  default     = "0.10.14"
+  default     = "0.10.15"
 }
 
 variable "k8s_runner_image_tag" {

--- a/stacks/deps/main.tf
+++ b/stacks/deps/main.tf
@@ -20,13 +20,15 @@ locals {
     }
   })
 
+  ziti_client_advertised_port = 443
+
   ziti_controller_values = yamlencode({
     cluster = {
       mode = "standalone"
     }
     clientApi = {
       advertisedHost = "ziti.${local.base_domain}"
-      advertisedPort = local.ingress_port
+      advertisedPort = local.ziti_client_advertised_port
       service = {
         enabled = true
         type    = "ClusterIP"

--- a/stacks/deps/variables.tf
+++ b/stacks/deps/variables.tf
@@ -32,5 +32,5 @@ variable "trust_manager_chart_version" {
 variable "ziti_controller_chart_version" {
   type        = string
   description = "OpenZiti controller chart version"
-  default     = "3.2.0-pre6"
+  default     = "3.2.0"
 }

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -886,7 +886,7 @@ locals {
       },
       {
         name  = "ZITI_SIDECAR_IMAGE"
-        value = "openziti/ziti-tunnel:1.5.16"
+        value = "openziti/ziti-tunnel:1.6.15"
       },
       {
         name  = "WORKLOAD_DNS_UPSTREAM"

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -886,7 +886,7 @@ locals {
       },
       {
         name  = "ZITI_SIDECAR_IMAGE"
-        value = "openziti/ziti-tunnel:2.0.0"
+        value = "openziti/ziti-tunnel:1.5.16"
       },
       {
         name  = "WORKLOAD_DNS_UPSTREAM"

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -67,6 +67,7 @@ locals {
   istio_gateway_tls_secret_name = data.terraform_remote_state.system.outputs.wildcard_tls_gateway_secret_name
   ziti_namespace                = data.terraform_remote_state.system.outputs.installed_namespaces[1]
   workload_namespace            = "agyn-workloads"
+  ziti_client_runtime_port      = 443
   openfga_api_url_external      = format("https://openfga.%s:%d", local.base_domain, local.ingress_port)
   openfga_api_url_internal      = format("http://openfga.%s.svc.cluster.local:8080", var.openfga_namespace)
   nats_endpoint                 = format("nats://nats.%s.svc.cluster.local:4222", var.platform_namespace)
@@ -902,7 +903,7 @@ locals {
       },
       {
         name  = "ZITI_ENROLLMENT_CONTROLLER_PORT"
-        value = tostring(local.ingress_port)
+        value = tostring(local.ziti_client_runtime_port)
       },
       {
         name  = "ZITI_RUNTIME_CONTROLLER_RESOLVE_HOST"

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -886,11 +886,15 @@ locals {
       },
       {
         name  = "ZITI_SIDECAR_IMAGE"
-        value = "openziti/ziti-tunnel:2.0.0-pre8"
+        value = "openziti/ziti-tunnel:2.0.0"
       },
       {
         name  = "WORKLOAD_DNS_UPSTREAM"
         value = kubernetes_service_v1.ziti_workload_dns.spec[0].cluster_ip
+      },
+      {
+        name  = "ZITI_ENROLLMENT_DNS_UPSTREAM"
+        value = "10.43.0.10"
       },
       {
         name  = "RUNNER_ADDRESS"

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -4529,12 +4529,9 @@ resource "argocd_application" "llm_proxy" {
               type = "RuntimeDefault"
             }
           }
-          env = [
-            {
-              name  = "ZITI_ENABLED"
-              value = "true"
-            },
-          ]
+          llmProxy = {
+            zitiEnabled = true
+          }
         })
       }
     }

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -897,6 +897,14 @@ locals {
         value = "10.43.0.10"
       },
       {
+        name  = "ZITI_RUNTIME_CONTROLLER_RESOLVE_HOST"
+        value = format("istio-ingressgateway.%s.svc.cluster.local", local.istio_gateway_namespace)
+      },
+      {
+        name  = "ZITI_RUNTIME_CONTROLLER_PORT"
+        value = "443"
+      },
+      {
         name  = "RUNNER_ADDRESS"
         value = "k8s-runner:50051"
       },

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -897,6 +897,14 @@ locals {
         value = "10.43.0.10"
       },
       {
+        name  = "ZITI_ENROLLMENT_CONTROLLER_RESOLVE_HOST"
+        value = format("ziti-controller-client.%s.svc.cluster.local", local.ziti_namespace)
+      },
+      {
+        name  = "ZITI_ENROLLMENT_CONTROLLER_PORT"
+        value = tostring(local.ingress_port)
+      },
+      {
         name  = "ZITI_RUNTIME_CONTROLLER_RESOLVE_HOST"
         value = format("istio-ingressgateway.%s.svc.cluster.local", local.istio_gateway_namespace)
       },

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -895,7 +895,7 @@ locals {
       },
       {
         name  = "ZITI_ENROLLMENT_DNS_UPSTREAM"
-        value = "10.43.0.10"
+        value = data.kubernetes_service_v1.kube_dns.spec[0].cluster_ip
       },
       {
         name  = "ZITI_ENROLLMENT_CONTROLLER_RESOLVE_HOST"

--- a/stacks/platform/remote_state.tf
+++ b/stacks/platform/remote_state.tf
@@ -40,3 +40,10 @@ data "kubernetes_service_v1" "ziti_router_edge" {
     namespace = local.ziti_namespace
   }
 }
+
+data "kubernetes_service_v1" "istio_ingressgateway" {
+  metadata {
+    name      = "istio-ingressgateway"
+    namespace = local.istio_gateway_namespace
+  }
+}

--- a/stacks/platform/remote_state.tf
+++ b/stacks/platform/remote_state.tf
@@ -47,3 +47,10 @@ data "kubernetes_service_v1" "istio_ingressgateway" {
     namespace = local.istio_gateway_namespace
   }
 }
+
+data "kubernetes_service_v1" "kube_dns" {
+  metadata {
+    name      = "kube-dns"
+    namespace = "kube-system"
+  }
+}

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -26,7 +26,7 @@ variable "gateway_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.18"
+  default     = "0.13.19"
 }
 
 variable "threads_chart_version" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -26,7 +26,7 @@ variable "gateway_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.19"
+  default     = "0.13.18"
 }
 
 variable "threads_chart_version" {

--- a/stacks/platform/ziti_workload_dns.tf
+++ b/stacks/platform/ziti_workload_dns.tf
@@ -40,8 +40,8 @@ resource "kubernetes_config_map_v1" "ziti_workload_dns" {
       $TTL 30
       @ IN SOA ns.ziti.${local.base_domain}. hostmaster.${local.base_domain}. 1 7200 3600 1209600 30
       @ IN NS ns.ziti.${local.base_domain}.
-      @ IN A ${data.kubernetes_service_v1.ziti_controller_client.spec[0].cluster_ip}
-      ns IN A ${data.kubernetes_service_v1.ziti_controller_client.spec[0].cluster_ip}
+      @ IN A ${data.kubernetes_service_v1.istio_ingressgateway.spec[0].cluster_ip}
+      ns IN A ${data.kubernetes_service_v1.istio_ingressgateway.spec[0].cluster_ip}
     ZONE
 
     "ziti-router.db" = <<-ZONE

--- a/stacks/routing/main.tf
+++ b/stacks/routing/main.tf
@@ -3,6 +3,8 @@ locals {
   istio_gateway_tls_secret_name = data.terraform_remote_state.system.outputs.wildcard_tls_gateway_secret_name
   # Explicit host list prevents platform SIMPLE TLS from shadowing
   # Ziti passthrough SNI; add new platform hosts here as needed.
+  ziti_client_runtime_port = 443
+
   platform_gateway_hosts = [
     local.base_domain,
     "argocd.${local.base_domain}",
@@ -159,7 +161,7 @@ resource "kubernetes_manifest" "virtualservice_ziti_controller" {
               "destination" = {
                 "host" = "ziti-controller-client.ziti.svc.cluster.local"
                 "port" = {
-                  "number" = local.ingress_port
+                  "number" = local.ziti_client_runtime_port
                 }
               }
             }

--- a/stacks/ziti/main.tf
+++ b/stacks/ziti/main.tf
@@ -6,10 +6,12 @@ locals {
   management_identity_secret_name   = "ziti-management-enrollment"
   orchestrator_identity_secret_name = "ziti-orchestrator-enrollment"
 
+  ziti_client_runtime_port = 443
+
   router_values = yamlencode({
     ctrl = {
-      # Use controller service port (ingress advertised port), not container 1280.
-      endpoint = "ziti.${local.base_domain}:${local.ingress_port}"
+      # Use the client API service port advertised to edge routers.
+      endpoint = "ziti.${local.base_domain}:${local.ziti_client_runtime_port}"
     }
     edge = {
       advertisedHost = "ziti-router.${local.base_domain}"

--- a/stacks/ziti/variables.tf
+++ b/stacks/ziti/variables.tf
@@ -13,7 +13,7 @@ variable "ziti_admin_username" {
 variable "ziti_router_chart_version" {
   type        = string
   description = "OpenZiti router chart version"
-  default     = "3.0.0-pre5"
+  default     = "3.0.0"
 }
 
 variable "enable_ziti_diagnostics" {


### PR DESCRIPTION
## Summary

- Pins OpenZiti controller/router chart defaults to released versions (`3.2.0` / `3.0.0`).
- Updates agents-orchestrator defaults for the fixed release and released sidecar image.
- Adds `ZITI_ENROLLMENT_DNS_UPSTREAM` while keeping `WORKLOAD_DNS_UPSTREAM` on `ziti-workload-dns`.
- Wires k8s-runner workload egress values for Ziti workload DNS plus explicit controller/router underlay service `/32` endpoints.

Fixes #577.

## Verification

- `terraform -chdir=stacks/deps fmt -check -diff`
- `terraform -chdir=stacks/ziti fmt -check -diff`
- `terraform -chdir=stacks/platform fmt -check -diff`
- `terraform -chdir=stacks/apps fmt -check -diff`
- `terraform -chdir=stacks/deps init -backend=false -input=false && terraform -chdir=stacks/deps validate`
- `terraform -chdir=stacks/ziti init -backend=false -input=false && terraform -chdir=stacks/ziti validate`
- `terraform -chdir=stacks/platform init -backend=false -input=false && terraform -chdir=stacks/platform validate`
- `terraform -chdir=stacks/apps init -backend=false -input=false && terraform -chdir=stacks/apps validate`