### PR TITLE
Bump egress-gateway to 0.1.5

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -744,7 +744,7 @@ variable "egress_db_pvc_size" {
 variable "egress_gateway_chart_version" {
   type        = string
   description = "Version of the egress-gateway Helm chart published to GHCR"
-  default     = "0.1.4"
+  default     = "0.1.5"
 }
 
 variable "egress_gateway_image_tag" {

--- a/stacks/platform/ziti_workload_dns.tf
+++ b/stacks/platform/ziti_workload_dns.tf
@@ -219,7 +219,7 @@ resource "kubernetes_network_policy_v1" "ziti_workload_dns" {
 resource "kubernetes_network_policy_v1" "workload_ziti_egress" {
   metadata {
     name      = "workload-ziti-egress"
-    namespace = local.workload_namespace
+    namespace = kubernetes_namespace_v1.agyn_workloads.metadata[0].name
   }
 
   spec {

--- a/stacks/system/main.tf
+++ b/stacks/system/main.tf
@@ -249,7 +249,9 @@ resource "helm_release" "argo_cd" {
       }
       configs = {
         params = {
-          "server.insecure" = true
+          "controller.repo.server.timeout.seconds" = "180"
+          "server.insecure"                        = true
+          "server.repo.server.timeout.seconds"     = "180"
         }
         cm = {
           admin = {


### PR DESCRIPTION
## Summary
- Bump `egress_gateway_chart_version` from `0.1.4` to `0.1.5` in the platform stack.
- Leave all unrelated service versions unchanged.

## Validation
- `terraform -chdir=stacks/platform fmt -check -recursive`
- `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt terraform -chdir=stacks/platform init -backend=false -input=false`
- `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt terraform -chdir=stacks/platform validate`
- `git diff --check`

Closes #579