### PR TITLE
fix(platform): bump console app chart

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -152,7 +152,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.10.12"
+  default     = "0.10.14"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
## Summary
- Bump `console_app_chart_version` default from `0.10.12` to `0.10.14`.
- Keep `console_app_image_tag` behavior unchanged so it continues resolving from the chart version by default.

Closes #583

## Verification
- `terraform -chdir=stacks/platform fmt -check -recursive`
- `terraform -chdir=stacks/platform validate`