### PR TITLE
feat: wire terminal proxy bootstrap

### DIFF
--- a/.github/actions/provision/action.yml
+++ b/.github/actions/provision/action.yml
@@ -48,6 +48,16 @@ runs:
       with:
         terraform_version: 1.6.6
 
+    - name: Install OpenZiti CLI
+      shell: bash
+      run: |
+        set -euo pipefail
+        container_id="$(docker create openziti/ziti-cli:2.0.0-pre10)"
+        trap 'docker rm -f "${container_id}" >/dev/null 2>&1 || true' EXIT
+        docker cp "${container_id}:/usr/local/bin/ziti" /tmp/ziti
+        sudo install -m 0755 /tmp/ziti /usr/local/bin/ziti
+        ziti version
+
     - name: Apply bootstrap stacks
       shell: bash
       working-directory: bootstrap

--- a/.github/scripts/verify_platform_health.sh
+++ b/.github/scripts/verify_platform_health.sh
@@ -24,7 +24,7 @@ if [[ ! -f "$KUBECONFIG_PATH" ]]; then
   exit 1
 fi
 
-REQUIRED_APPS_JSON='["cert-manager","trust-manager","ziti-controller","ziti-management","minio","platform-db","threads-db","chat-db","identity-db","runners-db","metering-db","egress-db","identity","authorization","gateway","egress","egress-gateway","runners","terminal-proxy","notifications-redis","notifications","metering","threads","chat","k8s-runner"]'
+REQUIRED_APPS_JSON='["cert-manager","trust-manager","ziti-controller","ziti-management","minio","platform-db","threads-db","chat-db","identity-db","runners-db","metering-db","egress-db","identity","authorization","gateway","egress","egress-gateway","runners","notifications-redis","notifications","metering","threads","chat","k8s-runner"]'
 
 deadline=$((SECONDS + TOTAL_TIMEOUT))
 pod_terminal_failures_streak=0
@@ -42,6 +42,7 @@ dump_diagnostics() {
   kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$PLATFORM_NAMESPACE" logs --all-containers --prefix --previous --tail=100 -l app.kubernetes.io/name=egress || true
   kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$PLATFORM_NAMESPACE" logs --all-containers --prefix --tail=100 -l app.kubernetes.io/name=egress-gateway || true
   kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$PLATFORM_NAMESPACE" logs --all-containers --prefix --previous --tail=100 -l app.kubernetes.io/name=egress-gateway || true
+  kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$PLATFORM_NAMESPACE" logs --all-containers --prefix --tail=100 -l app.kubernetes.io/name=terminal-proxy-ziti-identity || true
   kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$PLATFORM_NAMESPACE" logs --all-containers --prefix --tail=100 -l app.kubernetes.io/name=terminal-proxy || true
   kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$PLATFORM_NAMESPACE" logs --all-containers --prefix --previous --tail=100 -l app.kubernetes.io/name=terminal-proxy || true
   kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$ARGO_NAMESPACE" get applications.argoproj.io -o yaml | grep -E "(name:|status:)" | sed -n '1,200p' || true

--- a/.github/scripts/verify_platform_health.sh
+++ b/.github/scripts/verify_platform_health.sh
@@ -42,6 +42,8 @@ dump_diagnostics() {
   kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$PLATFORM_NAMESPACE" logs --all-containers --prefix --previous --tail=100 -l app.kubernetes.io/name=egress || true
   kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$PLATFORM_NAMESPACE" logs --all-containers --prefix --tail=100 -l app.kubernetes.io/name=egress-gateway || true
   kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$PLATFORM_NAMESPACE" logs --all-containers --prefix --previous --tail=100 -l app.kubernetes.io/name=egress-gateway || true
+  kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$PLATFORM_NAMESPACE" logs --all-containers --prefix --tail=100 -l app.kubernetes.io/name=terminal-proxy || true
+  kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$PLATFORM_NAMESPACE" logs --all-containers --prefix --previous --tail=100 -l app.kubernetes.io/name=terminal-proxy || true
   kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$ARGO_NAMESPACE" get applications.argoproj.io -o yaml | grep -E "(name:|status:)" | sed -n '1,200p' || true
 }
 

--- a/.github/scripts/verify_platform_health.sh
+++ b/.github/scripts/verify_platform_health.sh
@@ -24,7 +24,7 @@ if [[ ! -f "$KUBECONFIG_PATH" ]]; then
   exit 1
 fi
 
-REQUIRED_APPS_JSON='["cert-manager","trust-manager","ziti-controller","ziti-management","minio","platform-db","threads-db","chat-db","identity-db","runners-db","metering-db","egress-db","identity","authorization","gateway","egress","egress-gateway","runners","notifications-redis","notifications","metering","threads","chat","k8s-runner"]'
+REQUIRED_APPS_JSON='["cert-manager","trust-manager","ziti-controller","ziti-management","minio","platform-db","threads-db","chat-db","identity-db","runners-db","metering-db","egress-db","identity","authorization","gateway","egress","egress-gateway","runners","terminal-proxy","notifications-redis","notifications","metering","threads","chat","k8s-runner"]'
 
 deadline=$((SECONDS + TOTAL_TIMEOUT))
 pod_terminal_failures_streak=0
@@ -42,7 +42,6 @@ dump_diagnostics() {
   kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$PLATFORM_NAMESPACE" logs --all-containers --prefix --previous --tail=100 -l app.kubernetes.io/name=egress || true
   kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$PLATFORM_NAMESPACE" logs --all-containers --prefix --tail=100 -l app.kubernetes.io/name=egress-gateway || true
   kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$PLATFORM_NAMESPACE" logs --all-containers --prefix --previous --tail=100 -l app.kubernetes.io/name=egress-gateway || true
-  kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$PLATFORM_NAMESPACE" logs --all-containers --prefix --tail=100 -l app.kubernetes.io/name=terminal-proxy-ziti-identity || true
   kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$PLATFORM_NAMESPACE" logs --all-containers --prefix --tail=100 -l app.kubernetes.io/name=terminal-proxy || true
   kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$PLATFORM_NAMESPACE" logs --all-containers --prefix --previous --tail=100 -l app.kubernetes.io/name=terminal-proxy || true
   kubectl --kubeconfig "$KUBECONFIG_PATH" -n "$ARGO_NAMESPACE" get applications.argoproj.io -o yaml | grep -E "(name:|status:)" | sed -n '1,200p' || true

--- a/.github/scripts/verify_platform_health.sh
+++ b/.github/scripts/verify_platform_health.sh
@@ -24,7 +24,7 @@ if [[ ! -f "$KUBECONFIG_PATH" ]]; then
   exit 1
 fi
 
-REQUIRED_APPS_JSON='["cert-manager","trust-manager","ziti-controller","ziti-management","minio","platform-db","threads-db","chat-db","identity-db","runners-db","metering-db","egress-db","identity","authorization","gateway","egress","egress-gateway","runners","notifications-redis","notifications","metering","threads","chat","k8s-runner"]'
+REQUIRED_APPS_JSON='["cert-manager","trust-manager","ziti-controller","ziti-management","minio","platform-db","threads-db","chat-db","identity-db","runners-db","metering-db","egress-db","identity","authorization","gateway","egress","egress-gateway","runners","terminal-proxy","notifications-redis","notifications","metering","threads","chat","k8s-runner"]'
 
 deadline=$((SECONDS + TOTAL_TIMEOUT))
 pod_terminal_failures_streak=0

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -50,6 +50,8 @@ jobs:
           KUBECONFIG: ${{ steps.provision.outputs.kubeconfig }}
         run: |
           kubectl -n argocd get applications.argoproj.io terminal-proxy -o yaml || true
+          kubectl -n platform get jobs,pods -l app.kubernetes.io/name=terminal-proxy-ziti-identity -o wide || true
+          kubectl -n platform logs -l app.kubernetes.io/name=terminal-proxy-ziti-identity --all-containers --tail=200 --prefix || true
           kubectl -n platform get deploy,rs,pods,svc -l app.kubernetes.io/name=terminal-proxy -o wide || true
           pods=$(kubectl -n platform get pods -l app.kubernetes.io/name=terminal-proxy -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' || true)
           for pod in $pods; do

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -43,3 +43,19 @@ jobs:
           done
           kubectl -n platform logs deploy/authorization --all-containers --tail=200 || true
           kubectl -n platform get events --sort-by=.lastTimestamp | tail -n 80 || true
+
+      - name: Dump terminal proxy diagnostics
+        if: failure()
+        env:
+          KUBECONFIG: ${{ steps.provision.outputs.kubeconfig }}
+        run: |
+          kubectl -n argocd get applications.argoproj.io terminal-proxy -o yaml || true
+          kubectl -n platform get deploy,rs,pods,svc -l app.kubernetes.io/name=terminal-proxy -o wide || true
+          pods=$(kubectl -n platform get pods -l app.kubernetes.io/name=terminal-proxy -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' || true)
+          for pod in $pods; do
+            echo "## describe $pod"
+            kubectl -n platform describe pod "$pod" || true
+          done
+          kubectl -n platform logs -l app.kubernetes.io/name=terminal-proxy --all-containers --tail=200 --prefix || true
+          kubectl -n platform logs -l app.kubernetes.io/name=terminal-proxy --all-containers --previous --tail=200 --prefix || true
+          kubectl -n platform get events --sort-by=.lastTimestamp | tail -n 80 || true

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -50,8 +50,6 @@ jobs:
           KUBECONFIG: ${{ steps.provision.outputs.kubeconfig }}
         run: |
           kubectl -n argocd get applications.argoproj.io terminal-proxy -o yaml || true
-          kubectl -n platform get jobs,pods -l app.kubernetes.io/name=terminal-proxy-ziti-identity -o wide || true
-          kubectl -n platform logs -l app.kubernetes.io/name=terminal-proxy-ziti-identity --all-containers --tail=200 --prefix || true
           kubectl -n platform get deploy,rs,pods,svc -l app.kubernetes.io/name=terminal-proxy -o wide || true
           pods=$(kubectl -n platform get pods -l app.kubernetes.io/name=terminal-proxy -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' || true)
           for pod in $pods; do

--- a/apply.sh
+++ b/apply.sh
@@ -211,6 +211,47 @@ run_stack() {
   printf '=== Completed %s stack ===\n\n' "${stack}"
 }
 
+prepare_terminal_proxy_ziti_identity() {
+  local existing_identity_json
+  local enrollment_token
+  local identity_file
+  local jwt_file
+  local temp_dir
+
+  if [[ -n "${TERMINAL_PROXY_ZITI_IDENTITY_JSON:-}" ]]; then
+    export TF_VAR_terminal_proxy_ziti_identity_json="${TERMINAL_PROXY_ZITI_IDENTITY_JSON}"
+    echo "Using Terminal Proxy Ziti identity from TERMINAL_PROXY_ZITI_IDENTITY_JSON."
+    return
+  fi
+
+  existing_identity_json=$(kubectl --kubeconfig "${KUBECONFIG_PATH}" \
+    -n platform get secret terminal-proxy-ziti-identity \
+    -o jsonpath='{.data.identity\.json}' 2>/dev/null | base64 -d || true)
+  if [[ -n "${existing_identity_json}" ]]; then
+    export TF_VAR_terminal_proxy_ziti_identity_json="${existing_identity_json}"
+    echo "Using existing platform/terminal-proxy-ziti-identity Secret."
+    return
+  fi
+
+  if ! command -v ziti >/dev/null 2>&1; then
+    echo "Error: required command not found: ziti" >&2
+    echo "Install the OpenZiti CLI or set TERMINAL_PROXY_ZITI_IDENTITY_JSON." >&2
+    exit 1
+  fi
+
+  enrollment_token=$(terraform -chdir="stacks/ziti" output -raw terminal_proxy_enrollment_token)
+  temp_dir=$(mktemp -d)
+  identity_file="${temp_dir}/identity.json"
+  jwt_file="${temp_dir}/enrollment.jwt"
+  trap 'rm -rf "${temp_dir}"' RETURN
+
+  printf '%s' "${enrollment_token}" >"${jwt_file}"
+  ziti edge enroll --jwt "${jwt_file}" --out "${identity_file}"
+  export TF_VAR_terminal_proxy_ziti_identity_json
+  TF_VAR_terminal_proxy_ziti_identity_json=$(cat "${identity_file}")
+  echo "Enrolled Terminal Proxy Ziti identity for stable Secret provisioning."
+}
+
 should_merge_kubeconfig() {
   local response
 
@@ -477,6 +518,8 @@ if [ "${ZITI_EXIT}" -ne 0 ]; then
 fi
 step_end "stack:ziti"
 
+prepare_terminal_proxy_ziti_identity
+
 step_start "stack:data"
 run_stack "data"
 step_end "stack:data"
@@ -486,14 +529,9 @@ run_stack "platform"
 step_end "stack:platform"
 
 dump_terminal_proxy_diagnostics() {
-  echo "--- terminal-proxy Argo CD application (legacy, if present) ---"
+  echo "--- terminal-proxy Argo CD application ---"
   kubectl --kubeconfig "${KUBECONFIG_PATH}" \
     -n argocd get application terminal-proxy -o yaml 2>&1 || true
-  echo "--- terminal-proxy Ziti identity enrollment job ---"
-  kubectl --kubeconfig "${KUBECONFIG_PATH}" \
-    -n platform get jobs,pods -l app.kubernetes.io/name=terminal-proxy-ziti-identity -o wide 2>&1 || true
-  kubectl --kubeconfig "${KUBECONFIG_PATH}" \
-    -n platform logs -l app.kubernetes.io/name=terminal-proxy-ziti-identity --all-containers --tail=200 --prefix 2>&1 || true
   echo "--- terminal-proxy resources ---"
   kubectl --kubeconfig "${KUBECONFIG_PATH}" \
     -n platform get deploy,rs,pods,svc -l app.kubernetes.io/name=terminal-proxy -o wide 2>&1 || true
@@ -517,16 +555,8 @@ dump_terminal_proxy_diagnostics() {
     -n platform logs -l app.kubernetes.io/name=terminal-proxy --all-containers --previous --tail=200 --prefix 2>&1 || true
 }
 
-echo "=== Waiting for terminal-proxy deployment ==="
-if ! kubectl --kubeconfig "${KUBECONFIG_PATH}" \
-  -n platform rollout status deployment/terminal-proxy --timeout=10m; then
-  echo "ERROR: terminal-proxy deployment did not become ready" >&2
-  dump_terminal_proxy_diagnostics
-  exit 1
-fi
-
 echo "=== Waiting for platform ArgoCD applications to sync ==="
-for app in identity organizations gateway apps runners; do
+for app in identity organizations gateway apps runners terminal-proxy; do
   echo "--- Waiting for ${app} ---"
   synced=0
   for i in $(seq 1 60); do

--- a/apply.sh
+++ b/apply.sh
@@ -28,9 +28,6 @@ Environment variables:
   TRACING_APP_OIDC_CLIENT_ID  Override the tracing-app OIDC client ID (default: client_tzqVFAYTvpkfUzy5)
   OIDC_CLIENT_SECRET  Override the OIDC client secret (default: XPKka2i9uzISrKZ95zxli8sY51BK4eTJ)
   ADMIN_OIDC_SUBJECT  Optional OIDC subject for the bootstrap admin user (default: admin@agyn.io)
-  TERMINAL_PROXY_ZITI_IDENTITY_JSON  Optional enrolled Terminal Proxy Ziti identity JSON.
-                                     When unset, apply.sh enrolls the pre-provisioned Ziti identity
-                                     after the ziti stack and passes it to the platform stack.
   K3D_IMAGE_LOADBALANCER  Override the k3d load balancer image
                           (default: ghcr.io/k3d-io/k3d-proxy:5.7.5)
 EOF
@@ -162,12 +159,6 @@ if [[ -n "${admin_oidc_subject}" ]]; then
   echo "Admin OIDC subject provided via ADMIN_OIDC_SUBJECT environment variable: ${admin_oidc_subject}"
 fi
 
-terminal_proxy_ziti_identity_json="${TERMINAL_PROXY_ZITI_IDENTITY_JSON:-}"
-if [[ -n "${terminal_proxy_ziti_identity_json}" ]]; then
-  export TF_VAR_terminal_proxy_ziti_identity_json="${terminal_proxy_ziti_identity_json}"
-  echo "Terminal Proxy Ziti identity JSON provided via TERMINAL_PROXY_ZITI_IDENTITY_JSON environment variable."
-fi
-
 export K3D_IMAGE_LOADBALANCER="${K3D_IMAGE_LOADBALANCER:-${DEFAULT_K3D_PROXY_IMAGE}}"
 echo "Using k3d load balancer image: ${K3D_IMAGE_LOADBALANCER}"
 
@@ -283,79 +274,6 @@ merge_kubeconfig() {
     return 1
   fi
   echo "Merged k3d kubeconfig into ${target_config}."
-}
-
-capture_existing_terminal_proxy_ziti_identity() {
-  local encoded_identity
-
-  encoded_identity=$(kubectl --kubeconfig "${KUBECONFIG_PATH}" \
-    -n platform get secret terminal-proxy-ziti-identity \
-    -o jsonpath='{.data.identity\.json}' 2>/dev/null || true)
-  if [[ -z "${encoded_identity}" ]]; then
-    return 1
-  fi
-
-  if ! terminal_proxy_ziti_identity_json=$(printf '%s' "${encoded_identity}" | base64 --decode); then
-    echo "Error: failed to decode existing terminal-proxy-ziti-identity Secret." >&2
-    exit 1
-  fi
-
-  export TF_VAR_terminal_proxy_ziti_identity_json="${terminal_proxy_ziti_identity_json}"
-  echo "Using existing terminal-proxy-ziti-identity Secret for Terminal Proxy."
-}
-
-enroll_terminal_proxy_ziti_identity() {
-  local controller_pod
-  local identity_file
-  local jwt_file
-  local temp_dir
-
-  if [[ -n "${terminal_proxy_ziti_identity_json}" ]]; then
-    return 0
-  fi
-
-  if capture_existing_terminal_proxy_ziti_identity; then
-    return 0
-  fi
-
-  echo "=== Enrolling Terminal Proxy Ziti identity ==="
-  temp_dir=$(mktemp -d)
-  jwt_file="${temp_dir}/terminal-proxy.jwt"
-  identity_file="${temp_dir}/terminal-proxy.identity.json"
-
-  terraform -chdir=stacks/ziti output -raw terminal_proxy_enrollment_token >"${jwt_file}"
-  chmod 600 "${jwt_file}"
-
-  if command -v ziti >/dev/null 2>&1; then
-    ziti edge enroll --jwt "${jwt_file}" --out "${identity_file}"
-  else
-    controller_pod=$(kubectl --kubeconfig "${KUBECONFIG_PATH}" \
-      -n ziti get pods -l app.kubernetes.io/name=ziti-controller \
-      -o jsonpath='{.items[0].metadata.name}')
-    if [[ -z "${controller_pod}" ]]; then
-      echo "Error: unable to find ziti-controller pod for Terminal Proxy identity enrollment." >&2
-      exit 1
-    fi
-
-    kubectl --kubeconfig "${KUBECONFIG_PATH}" -n ziti exec -i "${controller_pod}" -- \
-      sh -c 'cat >/tmp/terminal-proxy.jwt' <"${jwt_file}"
-    kubectl --kubeconfig "${KUBECONFIG_PATH}" -n ziti exec "${controller_pod}" -- \
-      sh -c 'ziti_bin=$(command -v ziti || command -v /openziti/ziti-bin/ziti || command -v /var/openziti/ziti-bin/ziti); rm -f /tmp/terminal-proxy.identity.json; "$ziti_bin" edge enroll --jwt /tmp/terminal-proxy.jwt --out /tmp/terminal-proxy.identity.json'
-    kubectl --kubeconfig "${KUBECONFIG_PATH}" -n ziti exec "${controller_pod}" -- \
-      cat /tmp/terminal-proxy.identity.json >"${identity_file}"
-    kubectl --kubeconfig "${KUBECONFIG_PATH}" -n ziti exec "${controller_pod}" -- \
-      sh -c 'rm -f /tmp/terminal-proxy.jwt /tmp/terminal-proxy.identity.json' >/dev/null 2>&1 || true
-  fi
-
-  if [[ ! -s "${identity_file}" ]]; then
-    echo "Error: Terminal Proxy Ziti identity enrollment produced an empty identity file." >&2
-    exit 1
-  fi
-
-  terminal_proxy_ziti_identity_json=$(cat "${identity_file}")
-  rm -rf "${temp_dir}"
-  export TF_VAR_terminal_proxy_ziti_identity_json="${terminal_proxy_ziti_identity_json}"
-  echo "Terminal Proxy Ziti identity enrolled for platform Secret creation."
 }
 
 declare -a step_names=()
@@ -558,10 +476,6 @@ if [ "${ZITI_EXIT}" -ne 0 ]; then
   exit "${ZITI_EXIT}"
 fi
 step_end "stack:ziti"
-
-step_start "terminal-proxy-ziti-identity"
-enroll_terminal_proxy_ziti_identity
-step_end "terminal-proxy-ziti-identity"
 
 step_start "stack:data"
 run_stack "data"

--- a/apply.sh
+++ b/apply.sh
@@ -28,6 +28,9 @@ Environment variables:
   TRACING_APP_OIDC_CLIENT_ID  Override the tracing-app OIDC client ID (default: client_tzqVFAYTvpkfUzy5)
   OIDC_CLIENT_SECRET  Override the OIDC client secret (default: XPKka2i9uzISrKZ95zxli8sY51BK4eTJ)
   ADMIN_OIDC_SUBJECT  Optional OIDC subject for the bootstrap admin user (default: admin@agyn.io)
+  TERMINAL_PROXY_ZITI_IDENTITY_JSON  Optional enrolled Terminal Proxy Ziti identity JSON.
+                                     When unset, apply.sh enrolls the pre-provisioned Ziti identity
+                                     after the ziti stack and passes it to the platform stack.
   K3D_IMAGE_LOADBALANCER  Override the k3d load balancer image
                           (default: ghcr.io/k3d-io/k3d-proxy:5.7.5)
 EOF
@@ -159,6 +162,11 @@ if [[ -n "${admin_oidc_subject}" ]]; then
   echo "Admin OIDC subject provided via ADMIN_OIDC_SUBJECT environment variable: ${admin_oidc_subject}"
 fi
 
+terminal_proxy_ziti_identity_json="${TERMINAL_PROXY_ZITI_IDENTITY_JSON:-}"
+if [[ -n "${terminal_proxy_ziti_identity_json}" ]]; then
+  export TF_VAR_terminal_proxy_ziti_identity_json="${terminal_proxy_ziti_identity_json}"
+  echo "Terminal Proxy Ziti identity JSON provided via TERMINAL_PROXY_ZITI_IDENTITY_JSON environment variable."
+fi
 
 export K3D_IMAGE_LOADBALANCER="${K3D_IMAGE_LOADBALANCER:-${DEFAULT_K3D_PROXY_IMAGE}}"
 echo "Using k3d load balancer image: ${K3D_IMAGE_LOADBALANCER}"
@@ -275,6 +283,79 @@ merge_kubeconfig() {
     return 1
   fi
   echo "Merged k3d kubeconfig into ${target_config}."
+}
+
+capture_existing_terminal_proxy_ziti_identity() {
+  local encoded_identity
+
+  encoded_identity=$(kubectl --kubeconfig "${KUBECONFIG_PATH}" \
+    -n platform get secret terminal-proxy-ziti-identity \
+    -o jsonpath='{.data.identity\.json}' 2>/dev/null || true)
+  if [[ -z "${encoded_identity}" ]]; then
+    return 1
+  fi
+
+  if ! terminal_proxy_ziti_identity_json=$(printf '%s' "${encoded_identity}" | base64 --decode); then
+    echo "Error: failed to decode existing terminal-proxy-ziti-identity Secret." >&2
+    exit 1
+  fi
+
+  export TF_VAR_terminal_proxy_ziti_identity_json="${terminal_proxy_ziti_identity_json}"
+  echo "Using existing terminal-proxy-ziti-identity Secret for Terminal Proxy."
+}
+
+enroll_terminal_proxy_ziti_identity() {
+  local controller_pod
+  local identity_file
+  local jwt_file
+  local temp_dir
+
+  if [[ -n "${terminal_proxy_ziti_identity_json}" ]]; then
+    return 0
+  fi
+
+  if capture_existing_terminal_proxy_ziti_identity; then
+    return 0
+  fi
+
+  echo "=== Enrolling Terminal Proxy Ziti identity ==="
+  temp_dir=$(mktemp -d)
+  jwt_file="${temp_dir}/terminal-proxy.jwt"
+  identity_file="${temp_dir}/terminal-proxy.identity.json"
+
+  terraform -chdir=stacks/ziti output -raw terminal_proxy_enrollment_token >"${jwt_file}"
+  chmod 600 "${jwt_file}"
+
+  if command -v ziti >/dev/null 2>&1; then
+    ziti edge enroll --jwt "${jwt_file}" --out "${identity_file}"
+  else
+    controller_pod=$(kubectl --kubeconfig "${KUBECONFIG_PATH}" \
+      -n ziti get pods -l app.kubernetes.io/name=ziti-controller \
+      -o jsonpath='{.items[0].metadata.name}')
+    if [[ -z "${controller_pod}" ]]; then
+      echo "Error: unable to find ziti-controller pod for Terminal Proxy identity enrollment." >&2
+      exit 1
+    fi
+
+    kubectl --kubeconfig "${KUBECONFIG_PATH}" -n ziti exec -i "${controller_pod}" -- \
+      sh -c 'cat >/tmp/terminal-proxy.jwt' <"${jwt_file}"
+    kubectl --kubeconfig "${KUBECONFIG_PATH}" -n ziti exec "${controller_pod}" -- \
+      sh -c 'ziti_bin=$(command -v ziti || command -v /openziti/ziti-bin/ziti || command -v /var/openziti/ziti-bin/ziti); rm -f /tmp/terminal-proxy.identity.json; "$ziti_bin" edge enroll --jwt /tmp/terminal-proxy.jwt --out /tmp/terminal-proxy.identity.json'
+    kubectl --kubeconfig "${KUBECONFIG_PATH}" -n ziti exec "${controller_pod}" -- \
+      cat /tmp/terminal-proxy.identity.json >"${identity_file}"
+    kubectl --kubeconfig "${KUBECONFIG_PATH}" -n ziti exec "${controller_pod}" -- \
+      sh -c 'rm -f /tmp/terminal-proxy.jwt /tmp/terminal-proxy.identity.json' >/dev/null 2>&1 || true
+  fi
+
+  if [[ ! -s "${identity_file}" ]]; then
+    echo "Error: Terminal Proxy Ziti identity enrollment produced an empty identity file." >&2
+    exit 1
+  fi
+
+  terminal_proxy_ziti_identity_json=$(cat "${identity_file}")
+  rm -rf "${temp_dir}"
+  export TF_VAR_terminal_proxy_ziti_identity_json="${terminal_proxy_ziti_identity_json}"
+  echo "Terminal Proxy Ziti identity enrolled for platform Secret creation."
 }
 
 declare -a step_names=()
@@ -477,6 +558,10 @@ if [ "${ZITI_EXIT}" -ne 0 ]; then
   exit "${ZITI_EXIT}"
 fi
 step_end "stack:ziti"
+
+step_start "terminal-proxy-ziti-identity"
+enroll_terminal_proxy_ziti_identity
+step_end "terminal-proxy-ziti-identity"
 
 step_start "stack:data"
 run_stack "data"

--- a/apply.sh
+++ b/apply.sh
@@ -486,9 +486,14 @@ run_stack "platform"
 step_end "stack:platform"
 
 dump_terminal_proxy_diagnostics() {
-  echo "--- terminal-proxy Argo CD application ---"
+  echo "--- terminal-proxy Argo CD application (legacy, if present) ---"
   kubectl --kubeconfig "${KUBECONFIG_PATH}" \
     -n argocd get application terminal-proxy -o yaml 2>&1 || true
+  echo "--- terminal-proxy Ziti identity enrollment job ---"
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" \
+    -n platform get jobs,pods -l app.kubernetes.io/name=terminal-proxy-ziti-identity -o wide 2>&1 || true
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" \
+    -n platform logs -l app.kubernetes.io/name=terminal-proxy-ziti-identity --all-containers --tail=200 --prefix 2>&1 || true
   echo "--- terminal-proxy resources ---"
   kubectl --kubeconfig "${KUBECONFIG_PATH}" \
     -n platform get deploy,rs,pods,svc -l app.kubernetes.io/name=terminal-proxy -o wide 2>&1 || true
@@ -512,8 +517,16 @@ dump_terminal_proxy_diagnostics() {
     -n platform logs -l app.kubernetes.io/name=terminal-proxy --all-containers --previous --tail=200 --prefix 2>&1 || true
 }
 
+echo "=== Waiting for terminal-proxy deployment ==="
+if ! kubectl --kubeconfig "${KUBECONFIG_PATH}" \
+  -n platform rollout status deployment/terminal-proxy --timeout=10m; then
+  echo "ERROR: terminal-proxy deployment did not become ready" >&2
+  dump_terminal_proxy_diagnostics
+  exit 1
+fi
+
 echo "=== Waiting for platform ArgoCD applications to sync ==="
-for app in identity organizations gateway apps runners terminal-proxy; do
+for app in identity organizations gateway apps runners; do
   echo "--- Waiting for ${app} ---"
   synced=0
   for i in $(seq 1 60); do

--- a/apply.sh
+++ b/apply.sh
@@ -485,6 +485,33 @@ step_start "stack:platform"
 run_stack "platform"
 step_end "stack:platform"
 
+dump_terminal_proxy_diagnostics() {
+  echo "--- terminal-proxy Argo CD application ---"
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" \
+    -n argocd get application terminal-proxy -o yaml 2>&1 || true
+  echo "--- terminal-proxy resources ---"
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" \
+    -n platform get deploy,rs,pods,svc -l app.kubernetes.io/name=terminal-proxy -o wide 2>&1 || true
+  echo "--- terminal-proxy pod describe ---"
+  pods=$(kubectl --kubeconfig "${KUBECONFIG_PATH}" \
+    -n platform get pods -l app.kubernetes.io/name=terminal-proxy \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+  while IFS= read -r pod; do
+    if [[ -z "${pod}" ]]; then
+      continue
+    fi
+    echo "## describe ${pod}"
+    kubectl --kubeconfig "${KUBECONFIG_PATH}" \
+      -n platform describe pod "${pod}" 2>&1 || true
+  done <<<"${pods}"
+  echo "--- terminal-proxy logs ---"
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" \
+    -n platform logs -l app.kubernetes.io/name=terminal-proxy --all-containers --tail=200 --prefix 2>&1 || true
+  echo "--- terminal-proxy previous logs ---"
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" \
+    -n platform logs -l app.kubernetes.io/name=terminal-proxy --all-containers --previous --tail=200 --prefix 2>&1 || true
+}
+
 echo "=== Waiting for platform ArgoCD applications to sync ==="
 for app in identity organizations gateway apps runners terminal-proxy; do
   echo "--- Waiting for ${app} ---"
@@ -520,6 +547,7 @@ for app in identity organizations gateway apps runners terminal-proxy; do
     echo "--- ${app} namespace events ---"
     kubectl --kubeconfig "${KUBECONFIG_PATH}" \
       -n "${ns}" get events --sort-by='.lastTimestamp' 2>&1 | tail -30 || true
+    dump_terminal_proxy_diagnostics
     exit 1
   fi
 done

--- a/apply.sh
+++ b/apply.sh
@@ -486,7 +486,7 @@ run_stack "platform"
 step_end "stack:platform"
 
 echo "=== Waiting for platform ArgoCD applications to sync ==="
-for app in identity organizations gateway apps runners; do
+for app in identity organizations gateway apps runners terminal-proxy; do
   echo "--- Waiting for ${app} ---"
   synced=0
   for i in $(seq 1 60); do

--- a/stacks/platform/README.md
+++ b/stacks/platform/README.md
@@ -110,15 +110,13 @@ stable `terminal-proxy-ticket-signing` Secret consumed by
 
 The Terminal Proxy Ziti identity is pre-provisioned in the ziti stack with the
 `terminal-proxy-hosts` role attribute and exposes its enrollment token as
-`terminal_proxy_enrollment_token`. Operators enroll that identity and pass the
-resulting JSON through `terminal_proxy_ziti_identity_json`; the platform stack
-stores it in the `terminal-proxy-ziti-identity` Secret as `identity.json`, which
-is mounted at `/var/run/agyn/terminal-proxy-ziti/identity.json`.
-
-The top-level `apply.sh` preserves this pre-provisioned identity-file design by
-deriving `terminal_proxy_ziti_identity_json` after the ziti stack when the value
-is not supplied. Reusable environments may also provide an already-enrolled
-identity JSON through `TERMINAL_PROXY_ZITI_IDENTITY_JSON`.
+`terminal_proxy_enrollment_token`. The platform stack follows the existing
+enrollment Secret pattern used by ziti-management and egress-gateway: it stores
+that remote-state enrollment token in the `terminal-proxy-enrollment` Secret as
+`enrollmentJwt`. The Terminal Proxy chart mounts that Secret into an init
+container, enrolls it into `/var/run/agyn/terminal-proxy-ziti/identity.json` on
+an `emptyDir`, then starts Terminal Proxy with `ZITI_IDENTITY_FILE` pointing at
+that generated identity file.
 
 Gateway is wired with `TERMINAL_PROXY_GRPC_TARGET=terminal-proxy:50051`. The
 routing stack exposes the WebSocket endpoint as

--- a/stacks/platform/README.md
+++ b/stacks/platform/README.md
@@ -100,24 +100,3 @@ service account get-only access to that secret for failure diagnostics.
 
 Production deployments must leave `enable_ziti_diagnostics` at its
 default value of `false` so the secret and RBAC do not exist.
-
-## Terminal Proxy deployment contract
-
-The platform stack deploys Terminal Proxy as a dedicated Argo CD application
-using the `terminal-proxy` slice in the agyn-platform chart. It also creates the
-stable `terminal-proxy-ticket-signing` Secret consumed by
-`TERMINAL_PROXY_TICKET_SIGNING_KEY`.
-
-The Terminal Proxy Ziti identity is pre-provisioned in the ziti stack with the
-`terminal-proxy-hosts` role attribute and exposes its enrollment token as
-`terminal_proxy_enrollment_token`. The platform stack follows the existing
-enrollment Secret pattern used by ziti-management and egress-gateway: it stores
-that remote-state enrollment token in the `terminal-proxy-enrollment` Secret as
-`enrollmentJwt`. The Terminal Proxy chart mounts that Secret into an init
-container, enrolls it into `/var/run/agyn/terminal-proxy-ziti/identity.json` on
-an `emptyDir`, then starts Terminal Proxy with `ZITI_IDENTITY_FILE` pointing at
-that generated identity file.
-
-Gateway is wired with `TERMINAL_PROXY_GRPC_TARGET=terminal-proxy:50051`. The
-routing stack exposes the WebSocket endpoint as
-`wss://terminal.<base_domain>/terminal` through the platform Istio gateway.

--- a/stacks/platform/README.md
+++ b/stacks/platform/README.md
@@ -100,3 +100,21 @@ service account get-only access to that secret for failure diagnostics.
 
 Production deployments must leave `enable_ziti_diagnostics` at its
 default value of `false` so the secret and RBAC do not exist.
+
+## Terminal Proxy deployment contract
+
+The platform stack deploys Terminal Proxy as a dedicated Argo CD application
+using the `terminal-proxy` slice in the agyn-platform chart. It also creates the
+stable `terminal-proxy-ticket-signing` Secret consumed by
+`TERMINAL_PROXY_TICKET_SIGNING_KEY`.
+
+The Terminal Proxy Ziti identity is pre-provisioned in the ziti stack with the
+`terminal-proxy-hosts` role attribute and exposes its enrollment token as
+`terminal_proxy_enrollment_token`. Operators enroll that identity and pass the
+resulting JSON through `terminal_proxy_ziti_identity_json`; the platform stack
+stores it in the `terminal-proxy-ziti-identity` Secret as `identity.json`, which
+is mounted at `/var/run/agyn/terminal-proxy-ziti/identity.json`.
+
+Gateway is wired with `TERMINAL_PROXY_GRPC_TARGET=terminal-proxy:50051`. The
+routing stack exposes the WebSocket endpoint as
+`wss://terminal.<base_domain>/terminal` through the platform Istio gateway.

--- a/stacks/platform/README.md
+++ b/stacks/platform/README.md
@@ -115,6 +115,11 @@ resulting JSON through `terminal_proxy_ziti_identity_json`; the platform stack
 stores it in the `terminal-proxy-ziti-identity` Secret as `identity.json`, which
 is mounted at `/var/run/agyn/terminal-proxy-ziti/identity.json`.
 
+The top-level `apply.sh` preserves this pre-provisioned identity-file design by
+deriving `terminal_proxy_ziti_identity_json` after the ziti stack when the value
+is not supplied. Reusable environments may also provide an already-enrolled
+identity JSON through `TERMINAL_PROXY_ZITI_IDENTITY_JSON`.
+
 Gateway is wired with `TERMINAL_PROXY_GRPC_TARGET=terminal-proxy:50051`. The
 routing stack exposes the WebSocket endpoint as
 `wss://terminal.<base_domain>/terminal` through the platform Istio gateway.

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -841,6 +841,9 @@ locals {
     for key, value in merge(
       local.agyn_platform_single_service_values,
       {
+        contractConfigMaps = {
+          enabled = false
+        }
         platform = {
           serviceEndpoints = {
             terminalProxy = "terminal-proxy:50051"

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -29,7 +29,7 @@ locals {
   resolved_apps_image_tag                = trimspace(var.apps_image_tag) != "" ? var.apps_image_tag : var.apps_chart_version
   resolved_egress_image_tag              = trimspace(var.egress_image_tag) != "" ? var.egress_image_tag : var.egress_chart_version
   resolved_egress_gateway_image_tag      = trimspace(var.egress_gateway_image_tag) != "" ? var.egress_gateway_image_tag : var.egress_gateway_chart_version
-  resolved_terminal_proxy_image_tag      = trimspace(var.terminal_proxy_image_tag) != "" ? var.terminal_proxy_image_tag : var.terminal_proxy_chart_version
+  resolved_terminal_proxy_image_tag      = trimspace(var.terminal_proxy_image_tag) != "" ? var.terminal_proxy_image_tag : "0.5.11"
 
   postgres_image                 = "postgres:16.6-alpine"
   platform_chart_repo_host       = "ghcr.io"

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -851,6 +851,10 @@ locals {
           enabled          = true
           replicaCount     = 1
           fullnameOverride = "terminal-proxy"
+          podSecurityContext = {
+            enabled = true
+            fsGroup = 10001
+          }
           image = {
             repository = "ghcr.io/agynio/terminal-proxy"
             tag        = local.resolved_terminal_proxy_image_tag
@@ -891,7 +895,27 @@ locals {
             { name = "ziti-identity", mountPath = "/var/run/agyn/terminal-proxy-ziti", readOnly = true },
           ]
           extraVolumes = [
-            { name = "ziti-identity", secret = { secretName = kubernetes_secret_v1.terminal_proxy_ziti_identity.metadata[0].name } },
+            { name = "ziti-identity", emptyDir = {} },
+            { name = "ziti-enrollment", secret = { secretName = kubernetes_secret_v1.terminal_proxy_enrollment.metadata[0].name } },
+          ]
+          initContainers = [
+            {
+              name            = "enroll-ziti-identity"
+              image           = "openziti/ziti-cli:2.0.0-pre10"
+              imagePullPolicy = "IfNotPresent"
+              command         = ["/bin/sh", "-ec"]
+              args = [<<-EOT
+                ziti edge enroll \
+                  --jwt /etc/ziti-enrollment/enrollmentJwt \
+                  --out /var/run/agyn/terminal-proxy-ziti/identity.json
+                chmod 0400 /var/run/agyn/terminal-proxy-ziti/identity.json
+              EOT
+              ]
+              volumeMounts = [
+                { name = "ziti-enrollment", mountPath = "/etc/ziti-enrollment", readOnly = true },
+                { name = "ziti-identity", mountPath = "/var/run/agyn/terminal-proxy-ziti" },
+              ]
+            }
           ]
           resources = {
             requests = { cpu = "50m", memory = "128Mi" }
@@ -2076,16 +2100,16 @@ resource "kubernetes_secret_v1" "terminal_proxy_ticket_signing" {
   }
 }
 
-resource "kubernetes_secret_v1" "terminal_proxy_ziti_identity" {
+resource "kubernetes_secret_v1" "terminal_proxy_enrollment" {
   metadata {
-    name      = "terminal-proxy-ziti-identity"
+    name      = "terminal-proxy-enrollment"
     namespace = kubernetes_namespace.platform.metadata[0].name
   }
 
   type = "Opaque"
 
   data = {
-    "identity.json" = var.terminal_proxy_ziti_identity_json
+    enrollmentJwt = data.terraform_remote_state.ziti.outputs.terminal_proxy_enrollment_token
   }
 }
 
@@ -4330,7 +4354,7 @@ resource "argocd_application" "terminal_proxy" {
     argocd_application.agents,
     argocd_application.authorization,
     kubernetes_secret_v1.terminal_proxy_ticket_signing,
-    kubernetes_secret_v1.terminal_proxy_ziti_identity,
+    kubernetes_secret_v1.terminal_proxy_enrollment,
   ]
   metadata {
     name      = "terminal-proxy"

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -860,6 +860,20 @@ locals {
             tag        = local.resolved_terminal_proxy_image_tag
             pullPolicy = "IfNotPresent"
           }
+          securityContext = {
+            enabled                  = true
+            runAsNonRoot             = true
+            runAsUser                = 10001
+            runAsGroup               = 10001
+            readOnlyRootFilesystem   = true
+            allowPrivilegeEscalation = false
+            capabilities = {
+              drop = ["ALL"]
+            }
+            seccompProfile = {
+              type = "RuntimeDefault"
+            }
+          }
           env = [
             { name = "HTTP_ADDRESS", value = ":8080" },
             { name = "GRPC_ADDRESS", value = ":50051" },
@@ -1243,6 +1257,9 @@ locals {
   runners_values = yamlencode({
     replicaCount     = 1
     fullnameOverride = "runners"
+    authorizationPolicy = {
+      enabled = false
+    }
     image = {
       repository = "ghcr.io/agynio/runners"
       tag        = local.resolved_runners_image_tag
@@ -2088,7 +2105,7 @@ resource "kubernetes_secret_v1" "egress_gateway_enrollment" {
 }
 
 resource "random_password" "terminal_proxy_ticket_signing" {
-  length  = 32
+  length  = 64
   special = false
 }
 

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -912,6 +912,10 @@ locals {
                 chmod 0400 /var/run/agyn/terminal-proxy-ziti/identity.json
               EOT
               ]
+              securityContext = {
+                runAsUser  = 0
+                runAsGroup = 0
+              }
               volumeMounts = [
                 { name = "ziti-enrollment", mountPath = "/etc/ziti-enrollment", readOnly = true },
                 { name = "ziti-identity", mountPath = "/var/run/agyn/terminal-proxy-ziti" },

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -65,18 +65,20 @@ locals {
   apps_chart_name                = "agynio/charts/apps"
   egress_chart_name              = "agynio/charts/egress"
   egress_gateway_chart_name      = "agynio/charts/egress-gateway"
-  terminal_proxy_chart_name      = "agynio/charts/agyn-platform"
   # DEV/E2E ONLY: this secret name is used by diagnostics tests and must not
   # be published in production deployments.
-  ziti_diagnostics_secret_name  = "ziti-diagnostics"
-  istio_gateway_namespace       = data.terraform_remote_state.system.outputs.istio_gateway_namespace
-  istio_gateway_tls_secret_name = data.terraform_remote_state.system.outputs.wildcard_tls_gateway_secret_name
-  ziti_namespace                = data.terraform_remote_state.system.outputs.installed_namespaces[1]
-  workload_namespace            = "agyn-workloads"
-  openfga_api_url_external      = format("https://openfga.%s:%d", local.base_domain, local.ingress_port)
-  openfga_api_url_internal      = format("http://openfga.%s.svc.cluster.local:8080", var.openfga_namespace)
-  nats_endpoint                 = format("nats://nats.%s.svc.cluster.local:4222", var.platform_namespace)
-  platform_database_urls_secret = "agyn-platform-database-urls"
+  ziti_diagnostics_secret_name             = "ziti-diagnostics"
+  terminal_proxy_ziti_identity_secret_name = "terminal-proxy-ziti-identity"
+  terminal_proxy_ziti_identity_job_name    = format("terminal-proxy-ziti-identity-%s", substr(sha256(data.terraform_remote_state.ziti.outputs.ziti_identity_ids.terminal_proxy), 0, 8))
+  terminal_proxy_websocket_url             = format("wss://terminal.%s:%d/terminal", local.base_domain, local.ingress_port)
+  istio_gateway_namespace                  = data.terraform_remote_state.system.outputs.istio_gateway_namespace
+  istio_gateway_tls_secret_name            = data.terraform_remote_state.system.outputs.wildcard_tls_gateway_secret_name
+  ziti_namespace                           = data.terraform_remote_state.system.outputs.installed_namespaces[1]
+  workload_namespace                       = "agyn-workloads"
+  openfga_api_url_external                 = format("https://openfga.%s:%d", local.base_domain, local.ingress_port)
+  openfga_api_url_internal                 = format("http://openfga.%s.svc.cluster.local:8080", var.openfga_namespace)
+  nats_endpoint                            = format("nats://nats.%s.svc.cluster.local:4222", var.platform_namespace)
+  platform_database_urls_secret            = "agyn-platform-database-urls"
   # Deterministic v5 UUID for the cluster admin identity.
   # This is a synthetic identity used only during bootstrap;
   # it does not correspond to a user record in the Users DB.
@@ -833,116 +835,6 @@ locals {
       requests = { cpu = "100m", memory = "128Mi" }
       limits   = { cpu = "1000m", memory = "512Mi" }
     }
-  })
-
-  terminal_proxy_values = yamlencode({
-    for key, value in merge(
-      local.agyn_platform_single_service_values,
-      {
-        platform = {
-          serviceEndpoints = {
-            terminalProxy = "terminal-proxy:50051"
-          }
-          externalUrls = {
-            terminalProxyWebSocket = format("wss://terminal.%s/terminal", local.base_domain)
-          }
-        }
-        "terminal-proxy" = {
-          enabled          = true
-          replicaCount     = 1
-          fullnameOverride = "terminal-proxy"
-          podSecurityContext = {
-            enabled = true
-            fsGroup = 10001
-          }
-          image = {
-            repository = "ghcr.io/agynio/terminal-proxy"
-            tag        = local.resolved_terminal_proxy_image_tag
-            pullPolicy = "IfNotPresent"
-          }
-          securityContext = {
-            enabled                  = true
-            runAsNonRoot             = true
-            runAsUser                = 10001
-            runAsGroup               = 10001
-            readOnlyRootFilesystem   = true
-            allowPrivilegeEscalation = false
-            capabilities = {
-              drop = ["ALL"]
-            }
-            seccompProfile = {
-              type = "RuntimeDefault"
-            }
-          }
-          env = [
-            { name = "HTTP_ADDRESS", value = ":8080" },
-            { name = "GRPC_ADDRESS", value = ":50051" },
-            { name = "TERMINAL_PROXY_WEBSOCKET_URL", value = format("wss://terminal.%s/terminal", local.base_domain) },
-            {
-              name = "TERMINAL_PROXY_TICKET_SIGNING_KEY"
-              valueFrom = {
-                secretKeyRef = {
-                  name = kubernetes_secret_v1.terminal_proxy_ticket_signing.metadata[0].name
-                  key  = "signing-key"
-                }
-              }
-            },
-            { name = "RUNNERS_ADDRESS", value = "runners:50051" },
-            { name = "AGENTS_ADDRESS", value = "agents:50051" },
-            { name = "AUTHORIZATION_ADDRESS", value = "authorization:50051" },
-            { name = "ZITI_ENABLED", value = "true" },
-            { name = "ZITI_IDENTITY_FILE", value = "/var/run/agyn/terminal-proxy-ziti/identity.json" },
-          ]
-          service = {
-            enabled = true
-            type    = "ClusterIP"
-            ports = [
-              { name = "http", port = 8080, targetPort = "http", protocol = "TCP" },
-              { name = "grpc", port = 50051, targetPort = "grpc", protocol = "TCP" },
-            ]
-          }
-          containerPorts = [
-            { name = "http", containerPort = 8080, protocol = "TCP" },
-            { name = "grpc", containerPort = 50051, protocol = "TCP" },
-          ]
-          extraVolumeMounts = [
-            { name = "ziti-identity", mountPath = "/var/run/agyn/terminal-proxy-ziti", readOnly = true },
-          ]
-          extraVolumes = [
-            { name = "ziti-identity", emptyDir = {} },
-            { name = "ziti-enrollment", secret = { secretName = kubernetes_secret_v1.terminal_proxy_enrollment.metadata[0].name } },
-          ]
-          initContainers = [
-            {
-              name            = "enroll-ziti-identity"
-              image           = "openziti/ziti-cli:2.0.0-pre10"
-              imagePullPolicy = "IfNotPresent"
-              command         = ["/bin/sh", "-ec"]
-              args = [<<-EOT
-                ziti edge enroll \
-                  --jwt /etc/ziti-enrollment/enrollmentJwt \
-                  --out /var/run/agyn/terminal-proxy-ziti/identity.json
-                chown 10001:10001 /var/run/agyn/terminal-proxy-ziti/identity.json
-                chmod 0400 /var/run/agyn/terminal-proxy-ziti/identity.json
-              EOT
-              ]
-              securityContext = {
-                runAsUser  = 0
-                runAsGroup = 0
-              }
-              volumeMounts = [
-                { name = "ziti-enrollment", mountPath = "/etc/ziti-enrollment", readOnly = true },
-                { name = "ziti-identity", mountPath = "/var/run/agyn/terminal-proxy-ziti" },
-              ]
-            }
-          ]
-          resources = {
-            requests = { cpu = "50m", memory = "128Mi" }
-            limits   = { cpu = "500m", memory = "256Mi" }
-          }
-        }
-      }
-    ) : key => value
   })
 
   agents_values = yamlencode({
@@ -2121,19 +2013,6 @@ resource "kubernetes_secret_v1" "terminal_proxy_ticket_signing" {
   }
 }
 
-resource "kubernetes_secret_v1" "terminal_proxy_enrollment" {
-  metadata {
-    name      = "terminal-proxy-enrollment"
-    namespace = kubernetes_namespace.platform.metadata[0].name
-  }
-
-  type = "Opaque"
-
-  data = {
-    enrollmentJwt = data.terraform_remote_state.ziti.outputs.terminal_proxy_enrollment_token
-  }
-}
-
 resource "kubernetes_manifest" "agyn_selfsigned_cluster_issuer" {
   manifest = {
     "apiVersion" = "cert-manager.io/v1"
@@ -2180,6 +2059,505 @@ resource "kubernetes_manifest" "egress_ca_certificate" {
   ]
 
   depends_on = [kubernetes_manifest.agyn_selfsigned_cluster_issuer]
+}
+
+resource "kubernetes_service_account_v1" "terminal_proxy_ziti_identity" {
+  metadata {
+    name      = "terminal-proxy-ziti-identity"
+    namespace = kubernetes_namespace.platform.metadata[0].name
+    labels = {
+      "app.kubernetes.io/name"       = "terminal-proxy-ziti-identity"
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+}
+
+resource "kubernetes_role_v1" "terminal_proxy_ziti_identity" {
+  metadata {
+    name      = "terminal-proxy-ziti-identity"
+    namespace = kubernetes_namespace.platform.metadata[0].name
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["secrets"]
+    verbs      = ["create", "get", "patch", "update"]
+  }
+}
+
+resource "kubernetes_role_binding_v1" "terminal_proxy_ziti_identity" {
+  metadata {
+    name      = "terminal-proxy-ziti-identity"
+    namespace = kubernetes_namespace.platform.metadata[0].name
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role_v1.terminal_proxy_ziti_identity.metadata[0].name
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account_v1.terminal_proxy_ziti_identity.metadata[0].name
+    namespace = kubernetes_namespace.platform.metadata[0].name
+  }
+}
+
+resource "kubernetes_manifest" "terminal_proxy_ziti_identity" {
+  manifest = {
+    "apiVersion" = "batch/v1"
+    "kind"       = "Job"
+    "metadata" = {
+      "name"      = local.terminal_proxy_ziti_identity_job_name
+      "namespace" = kubernetes_namespace.platform.metadata[0].name
+      "labels" = {
+        "app.kubernetes.io/name"       = "terminal-proxy-ziti-identity"
+        "app.kubernetes.io/managed-by" = "terraform"
+      }
+    }
+    "spec" = {
+      "backoffLimit"            = 3
+      "ttlSecondsAfterFinished" = 300
+      "template" = {
+        "metadata" = {
+          "labels" = {
+            "app.kubernetes.io/name" = "terminal-proxy-ziti-identity"
+          }
+        }
+        "spec" = {
+          "restartPolicy"      = "OnFailure"
+          "serviceAccountName" = kubernetes_service_account_v1.terminal_proxy_ziti_identity.metadata[0].name
+          "containers" = [
+            {
+              "name"            = "enroll"
+              "image"           = "openziti/ziti-cli:2.0.0-pre10"
+              "imagePullPolicy" = "IfNotPresent"
+              "command"         = ["/bin/sh", "-ec"]
+              "args" = [<<-EOT
+                identity_file="$(mktemp)"
+                jwt_file="$(mktemp)"
+                trap 'rm -f "$identity_file" "$jwt_file"' EXIT
+
+                token="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+                ca_file="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+                secret_url="https://kubernetes.default.svc/api/v1/namespaces/${var.platform_namespace}/secrets/${local.terminal_proxy_ziti_identity_secret_name}"
+                status="$(curl -sS --cacert "$ca_file" -o /tmp/terminal-proxy-ziti-identity.json -w '%%{http_code}' \
+                  -H "Authorization: Bearer $token" \
+                  "$secret_url")"
+                if [ "$status" = "200" ] && \
+                  [ "$(jq -r '.metadata.annotations["agyn.io/ziti-identity-id"] // ""' /tmp/terminal-proxy-ziti-identity.json)" = "$ZITI_IDENTITY_ID" ] && \
+                  jq -e '.data["identity.json"] // empty' /tmp/terminal-proxy-ziti-identity.json >/dev/null; then
+                  exit 0
+                fi
+                if [ "$status" != "200" ] && [ "$status" != "404" ]; then
+                  cat /tmp/terminal-proxy-ziti-identity.json >&2
+                  exit 1
+                fi
+
+                printf '%s' "$ZITI_ENROLLMENT_JWT" > "$jwt_file"
+                ziti edge enroll --jwt "$jwt_file" --out "$identity_file"
+                identity_json_b64="$(base64 -w 0 "$identity_file")"
+                payload="{\"metadata\":{\"name\":\"${local.terminal_proxy_ziti_identity_secret_name}\",\"annotations\":{\"agyn.io/ziti-identity-id\":\"$ZITI_IDENTITY_ID\"}},\"data\":{\"identity.json\":\"$identity_json_b64\"},\"type\":\"Opaque\"}"
+
+                if [ "$status" = "404" ]; then
+                  curl -fsS --cacert "$ca_file" -X POST \
+                    -H "Authorization: Bearer $token" \
+                    -H 'Content-Type: application/json' \
+                    -d "$payload" \
+                    "https://kubernetes.default.svc/api/v1/namespaces/${var.platform_namespace}/secrets"
+                else
+                  curl -fsS --cacert "$ca_file" -X PATCH \
+                    -H "Authorization: Bearer $token" \
+                    -H 'Content-Type: application/merge-patch+json' \
+                    -d "$payload" \
+                    "$secret_url"
+                fi
+              EOT
+              ]
+              "env" = [
+                {
+                  "name"  = "ZITI_ENROLLMENT_JWT"
+                  "value" = data.terraform_remote_state.ziti.outputs.terminal_proxy_enrollment_token
+                },
+                {
+                  "name"  = "ZITI_IDENTITY_ID"
+                  "value" = data.terraform_remote_state.ziti.outputs.ziti_identity_ids.terminal_proxy
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+
+  computed_fields = [
+    "metadata.annotations",
+    "metadata.labels",
+    "spec.selector",
+    "spec.template.metadata.labels",
+  ]
+
+  wait {
+    fields = {
+      "status.succeeded" = "1"
+    }
+  }
+
+  depends_on = [
+    kubernetes_namespace.platform,
+    kubernetes_role_binding_v1.terminal_proxy_ziti_identity,
+  ]
+}
+
+resource "kubernetes_service_account_v1" "terminal_proxy" {
+  metadata {
+    name      = "terminal-proxy"
+    namespace = kubernetes_namespace.platform.metadata[0].name
+    labels = {
+      "app.kubernetes.io/name"       = "terminal-proxy"
+      "app.kubernetes.io/instance"   = "terminal-proxy"
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+}
+
+resource "kubernetes_service_v1" "terminal_proxy" {
+  metadata {
+    name      = "terminal-proxy"
+    namespace = kubernetes_namespace.platform.metadata[0].name
+    labels = {
+      "app.kubernetes.io/name"       = "terminal-proxy"
+      "app.kubernetes.io/instance"   = "terminal-proxy"
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+
+  spec {
+    selector = {
+      "app.kubernetes.io/name"     = "terminal-proxy"
+      "app.kubernetes.io/instance" = "terminal-proxy"
+    }
+
+    port {
+      name        = "http"
+      port        = 8080
+      target_port = "http"
+      protocol    = "TCP"
+    }
+
+    port {
+      name        = "grpc"
+      port        = 50051
+      target_port = "grpc"
+      protocol    = "TCP"
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "terminal_proxy" {
+  metadata {
+    name      = "terminal-proxy"
+    namespace = kubernetes_namespace.platform.metadata[0].name
+    labels = {
+      "app.kubernetes.io/name"       = "terminal-proxy"
+      "app.kubernetes.io/instance"   = "terminal-proxy"
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        "app.kubernetes.io/name"     = "terminal-proxy"
+        "app.kubernetes.io/instance" = "terminal-proxy"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          "app.kubernetes.io/name"     = "terminal-proxy"
+          "app.kubernetes.io/instance" = "terminal-proxy"
+        }
+      }
+
+      spec {
+        service_account_name = kubernetes_service_account_v1.terminal_proxy.metadata[0].name
+
+        security_context {
+          fs_group = 10001
+        }
+
+        container {
+          name              = "terminal-proxy"
+          image             = "ghcr.io/agynio/terminal-proxy:${local.resolved_terminal_proxy_image_tag}"
+          image_pull_policy = "IfNotPresent"
+
+          port {
+            name           = "http"
+            container_port = 8080
+            protocol       = "TCP"
+          }
+
+          port {
+            name           = "grpc"
+            container_port = 50051
+            protocol       = "TCP"
+          }
+
+          env {
+            name  = "HTTP_ADDRESS"
+            value = ":8080"
+          }
+
+          env {
+            name  = "GRPC_ADDRESS"
+            value = ":50051"
+          }
+
+          env {
+            name  = "TERMINAL_PROXY_WEBSOCKET_URL"
+            value = local.terminal_proxy_websocket_url
+          }
+
+          env {
+            name = "TERMINAL_PROXY_TICKET_SIGNING_KEY"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret_v1.terminal_proxy_ticket_signing.metadata[0].name
+                key  = "signing-key"
+              }
+            }
+          }
+
+          env {
+            name  = "RUNNERS_ADDRESS"
+            value = "runners:50051"
+          }
+
+          env {
+            name  = "AGENTS_ADDRESS"
+            value = "agents:50051"
+          }
+
+          env {
+            name  = "AUTHORIZATION_ADDRESS"
+            value = "authorization:50051"
+          }
+
+          env {
+            name  = "ZITI_ENABLED"
+            value = "true"
+          }
+
+          env {
+            name  = "ZITI_IDENTITY_FILE"
+            value = "/var/run/agyn/terminal-proxy-ziti/identity.json"
+          }
+
+          volume_mount {
+            name       = "ziti-identity"
+            mount_path = "/var/run/agyn/terminal-proxy-ziti"
+            read_only  = true
+          }
+
+          security_context {
+            run_as_non_root            = true
+            run_as_user                = 10001
+            run_as_group               = 10001
+            read_only_root_filesystem  = true
+            allow_privilege_escalation = false
+
+            capabilities {
+              drop = ["ALL"]
+            }
+
+            seccomp_profile {
+              type = "RuntimeDefault"
+            }
+          }
+
+          resources {
+            requests = {
+              cpu    = "50m"
+              memory = "128Mi"
+            }
+            limits = {
+              cpu    = "500m"
+              memory = "256Mi"
+            }
+          }
+        }
+
+        volume {
+          name = "ziti-identity"
+          secret {
+            secret_name = local.terminal_proxy_ziti_identity_secret_name
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    kubernetes_manifest.terminal_proxy_ziti_identity,
+  ]
+}
+
+resource "kubernetes_manifest" "runners_internal_authorization_policy" {
+  manifest = {
+    "apiVersion" = "security.istio.io/v1beta1"
+    "kind"       = "AuthorizationPolicy"
+    "metadata" = {
+      "name"      = "runners-internal"
+      "namespace" = kubernetes_namespace.platform.metadata[0].name
+      "labels" = {
+        "app.kubernetes.io/name"       = "runners"
+        "app.kubernetes.io/instance"   = "runners"
+        "app.kubernetes.io/managed-by" = "terraform"
+      }
+    }
+    "spec" = {
+      "selector" = {
+        "matchLabels" = {
+          "app.kubernetes.io/name"     = "runners"
+          "app.kubernetes.io/instance" = "runners"
+        }
+      }
+      "action" = "DENY"
+      "rules" = [
+        {
+          "from" = [
+            {
+              "source" = {
+                "notPrincipals" = ["cluster.local/ns/${var.platform_namespace}/sa/agents-orchestrator"]
+              }
+            }
+          ]
+          "to" = [
+            {
+              "operation" = {
+                "paths" = [
+                  "/agynio.api.runners.v1.RunnersService/CreateWorkload",
+                  "/agynio.api.runners.v1.RunnersService/UpdateWorkload",
+                  "/agynio.api.runners.v1.RunnersService/UpdateWorkloadStatus",
+                  "/agynio.api.runners.v1.RunnersService/DeleteWorkload",
+                  "/agynio.api.runners.v1.RunnersService/BatchUpdateWorkloadSampledAt",
+                  "/agynio.api.runners.v1.RunnersService/CreateVolume",
+                  "/agynio.api.runners.v1.RunnersService/UpdateVolume",
+                  "/agynio.api.runners.v1.RunnersService/BatchUpdateVolumeSampledAt",
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "from" = [
+            {
+              "source" = {
+                "notPrincipals" = [
+                  "cluster.local/ns/${var.platform_namespace}/sa/agents-orchestrator",
+                  "cluster.local/ns/${var.platform_namespace}/sa/gateway",
+                  "cluster.local/ns/${var.platform_namespace}/sa/expose",
+                  "cluster.local/ns/${var.platform_namespace}/sa/notifications",
+                  "cluster.local/ns/${var.platform_namespace}/sa/chat",
+                ]
+              }
+            }
+          ]
+          "to" = [
+            {
+              "operation" = {
+                "paths" = [
+                  "/agynio.api.runners.v1.RunnersService/RegisterRunner",
+                  "/agynio.api.runners.v1.RunnersService/GetRunner",
+                  "/agynio.api.runners.v1.RunnersService/ListRunners",
+                  "/agynio.api.runners.v1.RunnersService/UpdateRunner",
+                  "/agynio.api.runners.v1.RunnersService/DeleteRunner",
+                  "/agynio.api.runners.v1.RunnersService/GetWorkload",
+                  "/agynio.api.runners.v1.RunnersService/ListWorkloadsByThread",
+                  "/agynio.api.runners.v1.RunnersService/StreamWorkloadLogs",
+                  "/agynio.api.runners.v1.RunnersService/GetVolume",
+                  "/agynio.api.runners.v1.RunnersService/ListVolumes",
+                  "/agynio.api.runners.v1.RunnersService/ListVolumesByThread",
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "from" = [
+            {
+              "source" = {
+                "notPrincipals" = [
+                  "cluster.local/ns/${var.platform_namespace}/sa/agents-orchestrator",
+                  "cluster.local/ns/${var.platform_namespace}/sa/terminal-proxy",
+                ]
+              }
+            }
+          ]
+          "to" = [
+            {
+              "operation" = {
+                "paths" = [
+                  "/agynio.api.runners.v1.RunnersService/ListWorkloads",
+                  "/agynio.api.runners.v1.RunnersService/TouchWorkload",
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "from" = [
+            {
+              "source" = {
+                "notPrincipals" = ["cluster.local/ns/${var.platform_namespace}/sa/agents-orchestrator"]
+              }
+            }
+          ]
+          "when" = [
+            {
+              "key"       = "request.headers[x-identity-id]"
+              "notValues" = ["*"]
+            }
+          ]
+          "to" = [
+            {
+              "operation" = {
+                "paths" = [
+                  "/agynio.api.runners.v1.RunnersService/RegisterRunner",
+                  "/agynio.api.runners.v1.RunnersService/GetRunner",
+                  "/agynio.api.runners.v1.RunnersService/ListRunners",
+                  "/agynio.api.runners.v1.RunnersService/UpdateRunner",
+                  "/agynio.api.runners.v1.RunnersService/DeleteRunner",
+                  "/agynio.api.runners.v1.RunnersService/GetWorkload",
+                  "/agynio.api.runners.v1.RunnersService/ListWorkloadsByThread",
+                  "/agynio.api.runners.v1.RunnersService/StreamWorkloadLogs",
+                  "/agynio.api.runners.v1.RunnersService/GetVolume",
+                  "/agynio.api.runners.v1.RunnersService/ListVolumes",
+                  "/agynio.api.runners.v1.RunnersService/ListVolumesByThread",
+                ]
+              }
+            }
+          ]
+        },
+      ]
+    }
+  }
+
+  computed_fields = [
+    "metadata.annotations",
+    "metadata.labels",
+  ]
+
+  depends_on = [
+    argocd_application.runners,
+    kubernetes_service_account_v1.terminal_proxy,
+  ]
 }
 
 # DEV/E2E ONLY: ziti-diagnostics contains admin UPDB credentials
@@ -4369,55 +4747,6 @@ resource "argocd_application" "egress_gateway" {
   }
 }
 
-resource "argocd_application" "terminal_proxy" {
-  depends_on = [
-    argocd_application.runners,
-    argocd_application.agents,
-    argocd_application.authorization,
-    kubernetes_secret_v1.terminal_proxy_ticket_signing,
-    kubernetes_secret_v1.terminal_proxy_enrollment,
-  ]
-  metadata {
-    name      = "terminal-proxy"
-    namespace = "argocd"
-    annotations = {
-      "argocd.argoproj.io/sync-wave" = "20"
-    }
-  }
-
-  spec {
-    project = "default"
-
-    source {
-      repo_url        = local.platform_chart_repo_host
-      chart           = local.terminal_proxy_chart_name
-      target_revision = var.terminal_proxy_chart_version
-
-      helm {
-        values = local.terminal_proxy_values
-      }
-    }
-
-    destination {
-      server    = var.destination_server
-      namespace = kubernetes_namespace.platform.metadata[0].name
-    }
-
-    sync_policy {
-      dynamic "automated" {
-        for_each = var.argocd_automated_sync_enabled ? [1] : []
-        content {
-          prune       = var.argocd_prune_enabled
-          self_heal   = var.argocd_self_heal_enabled
-          allow_empty = false
-        }
-      }
-
-      sync_options = local.default_sync_options
-    }
-  }
-}
-
 resource "argocd_application" "agents" {
   depends_on = [
     argocd_application.agents_db,
@@ -5127,7 +5456,7 @@ resource "argocd_application" "gateway" {
     argocd_application.expose,
     argocd_application.groups,
     argocd_application.networks,
-    argocd_application.terminal_proxy,
+    kubernetes_deployment_v1.terminal_proxy,
   ]
   wait = true
   metadata {

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -69,7 +69,7 @@ locals {
   # be published in production deployments.
   ziti_diagnostics_secret_name             = "ziti-diagnostics"
   terminal_proxy_ziti_identity_secret_name = "terminal-proxy-ziti-identity"
-  terminal_proxy_ziti_identity_job_name    = format("terminal-proxy-ziti-identity-%s", substr(sha256(data.terraform_remote_state.ziti.outputs.ziti_identity_ids.terminal_proxy), 0, 8))
+  terminal_proxy_ziti_identity_job_name    = format("terminal-proxy-ziti-identity-%s", substr(sha256(data.terraform_remote_state.ziti.outputs.identity_ids.terminal_proxy), 0, 8))
   terminal_proxy_websocket_url             = format("wss://terminal.%s:%d/terminal", local.base_domain, local.ingress_port)
   istio_gateway_namespace                  = data.terraform_remote_state.system.outputs.istio_gateway_namespace
   istio_gateway_tls_secret_name            = data.terraform_remote_state.system.outputs.wildcard_tls_gateway_secret_name
@@ -2182,7 +2182,7 @@ resource "kubernetes_manifest" "terminal_proxy_ziti_identity" {
                 },
                 {
                   "name"  = "ZITI_IDENTITY_ID"
-                  "value" = data.terraform_remote_state.ziti.outputs.ziti_identity_ids.terminal_proxy
+                  "value" = data.terraform_remote_state.ziti.outputs.identity_ids.terminal_proxy
                 }
               ]
             }

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -65,11 +65,11 @@ locals {
   apps_chart_name                = "agynio/charts/apps"
   egress_chart_name              = "agynio/charts/egress"
   egress_gateway_chart_name      = "agynio/charts/egress-gateway"
+  terminal_proxy_chart_name      = "agynio/charts/agyn-platform"
   # DEV/E2E ONLY: this secret name is used by diagnostics tests and must not
   # be published in production deployments.
   ziti_diagnostics_secret_name             = "ziti-diagnostics"
   terminal_proxy_ziti_identity_secret_name = "terminal-proxy-ziti-identity"
-  terminal_proxy_ziti_identity_job_name    = format("terminal-proxy-ziti-identity-%s", substr(sha256(data.terraform_remote_state.ziti.outputs.identity_ids.terminal_proxy), 0, 8))
   terminal_proxy_websocket_url             = format("wss://terminal.%s:%d/terminal", local.base_domain, local.ingress_port)
   istio_gateway_namespace                  = data.terraform_remote_state.system.outputs.istio_gateway_namespace
   istio_gateway_tls_secret_name            = data.terraform_remote_state.system.outputs.wildcard_tls_gateway_secret_name
@@ -835,6 +835,98 @@ locals {
       requests = { cpu = "100m", memory = "128Mi" }
       limits   = { cpu = "1000m", memory = "512Mi" }
     }
+  })
+
+  terminal_proxy_values = yamlencode({
+    for key, value in merge(
+      local.agyn_platform_single_service_values,
+      {
+        platform = {
+          serviceEndpoints = {
+            terminalProxy = "terminal-proxy:50051"
+          }
+          externalUrls = {
+            terminalProxyWebSocket = local.terminal_proxy_websocket_url
+          }
+        }
+        "terminal-proxy" = {
+          enabled          = true
+          replicaCount     = 1
+          fullnameOverride = "terminal-proxy"
+          podSecurityContext = {
+            enabled = true
+            fsGroup = 10001
+          }
+          image = {
+            repository = "ghcr.io/agynio/terminal-proxy"
+            tag        = local.resolved_terminal_proxy_image_tag
+            pullPolicy = "IfNotPresent"
+          }
+          securityContext = {
+            enabled                  = true
+            runAsNonRoot             = true
+            runAsUser                = 10001
+            runAsGroup               = 10001
+            readOnlyRootFilesystem   = true
+            allowPrivilegeEscalation = false
+            capabilities = {
+              drop = ["ALL"]
+            }
+            seccompProfile = {
+              type = "RuntimeDefault"
+            }
+          }
+          env = [
+            { name = "HTTP_ADDRESS", value = ":8080" },
+            { name = "GRPC_ADDRESS", value = ":50051" },
+            { name = "TERMINAL_PROXY_WEBSOCKET_URL", value = local.terminal_proxy_websocket_url },
+            {
+              name = "TERMINAL_PROXY_TICKET_SIGNING_KEY"
+              valueFrom = {
+                secretKeyRef = {
+                  name = kubernetes_secret_v1.terminal_proxy_ticket_signing.metadata[0].name
+                  key  = "signing-key"
+                }
+              }
+            },
+            { name = "RUNNERS_ADDRESS", value = "runners:50051" },
+            { name = "AGENTS_ADDRESS", value = "agents:50051" },
+            { name = "AUTHORIZATION_ADDRESS", value = "authorization:50051" },
+            { name = "ZITI_ENABLED", value = "true" },
+            { name = "ZITI_IDENTITY_FILE", value = "/var/run/agyn/terminal-proxy-ziti/identity.json" },
+          ]
+          service = {
+            enabled = true
+            type    = "ClusterIP"
+            ports = [
+              { name = "http", port = 8080, targetPort = "http", protocol = "TCP" },
+              { name = "grpc", port = 50051, targetPort = "grpc", protocol = "TCP" },
+            ]
+          }
+          containerPorts = [
+            { name = "http", containerPort = 8080, protocol = "TCP" },
+            { name = "grpc", containerPort = 50051, protocol = "TCP" },
+          ]
+          extraVolumeMounts = [
+            { name = "ziti-identity", mountPath = "/var/run/agyn/terminal-proxy-ziti", readOnly = true },
+          ]
+          extraVolumes = [
+            {
+              name = "ziti-identity"
+              secret = {
+                secretName  = kubernetes_secret_v1.terminal_proxy_ziti_identity.metadata[0].name
+                defaultMode = 288
+              }
+            },
+          ]
+          initContainers = []
+          resources = {
+            requests = { cpu = "50m", memory = "128Mi" }
+            limits   = { cpu = "500m", memory = "256Mi" }
+          }
+        }
+      }
+    ) : key => value
   })
 
   agents_values = yamlencode({
@@ -2013,6 +2105,19 @@ resource "kubernetes_secret_v1" "terminal_proxy_ticket_signing" {
   }
 }
 
+resource "kubernetes_secret_v1" "terminal_proxy_ziti_identity" {
+  metadata {
+    name      = local.terminal_proxy_ziti_identity_secret_name
+    namespace = kubernetes_namespace.platform.metadata[0].name
+  }
+
+  type = "Opaque"
+
+  data = {
+    "identity.json" = var.terminal_proxy_ziti_identity_json
+  }
+}
+
 resource "kubernetes_manifest" "agyn_selfsigned_cluster_issuer" {
   manifest = {
     "apiVersion" = "cert-manager.io/v1"
@@ -2059,506 +2164,6 @@ resource "kubernetes_manifest" "egress_ca_certificate" {
   ]
 
   depends_on = [kubernetes_manifest.agyn_selfsigned_cluster_issuer]
-}
-
-resource "kubernetes_service_account_v1" "terminal_proxy_ziti_identity" {
-  metadata {
-    name      = "terminal-proxy-ziti-identity"
-    namespace = kubernetes_namespace.platform.metadata[0].name
-    labels = {
-      "app.kubernetes.io/name"       = "terminal-proxy-ziti-identity"
-      "app.kubernetes.io/managed-by" = "terraform"
-    }
-  }
-}
-
-resource "kubernetes_role_v1" "terminal_proxy_ziti_identity" {
-  metadata {
-    name      = "terminal-proxy-ziti-identity"
-    namespace = kubernetes_namespace.platform.metadata[0].name
-  }
-
-  rule {
-    api_groups = [""]
-    resources  = ["secrets"]
-    verbs      = ["create", "get", "patch", "update"]
-  }
-}
-
-resource "kubernetes_role_binding_v1" "terminal_proxy_ziti_identity" {
-  metadata {
-    name      = "terminal-proxy-ziti-identity"
-    namespace = kubernetes_namespace.platform.metadata[0].name
-  }
-
-  role_ref {
-    api_group = "rbac.authorization.k8s.io"
-    kind      = "Role"
-    name      = kubernetes_role_v1.terminal_proxy_ziti_identity.metadata[0].name
-  }
-
-  subject {
-    kind      = "ServiceAccount"
-    name      = kubernetes_service_account_v1.terminal_proxy_ziti_identity.metadata[0].name
-    namespace = kubernetes_namespace.platform.metadata[0].name
-  }
-}
-
-resource "kubernetes_manifest" "terminal_proxy_ziti_identity" {
-  manifest = {
-    "apiVersion" = "batch/v1"
-    "kind"       = "Job"
-    "metadata" = {
-      "name"      = local.terminal_proxy_ziti_identity_job_name
-      "namespace" = kubernetes_namespace.platform.metadata[0].name
-      "labels" = {
-        "app.kubernetes.io/name"       = "terminal-proxy-ziti-identity"
-        "app.kubernetes.io/managed-by" = "terraform"
-      }
-    }
-    "spec" = {
-      "backoffLimit"            = 3
-      "ttlSecondsAfterFinished" = 300
-      "template" = {
-        "metadata" = {
-          "labels" = {
-            "app.kubernetes.io/name" = "terminal-proxy-ziti-identity"
-          }
-        }
-        "spec" = {
-          "restartPolicy"      = "OnFailure"
-          "serviceAccountName" = kubernetes_service_account_v1.terminal_proxy_ziti_identity.metadata[0].name
-          "containers" = [
-            {
-              "name"            = "enroll"
-              "image"           = "openziti/ziti-cli:2.0.0-pre10"
-              "imagePullPolicy" = "IfNotPresent"
-              "command"         = ["/bin/sh", "-ec"]
-              "args" = [<<-EOT
-                identity_file="$(mktemp)"
-                jwt_file="$(mktemp)"
-                trap 'rm -f "$identity_file" "$jwt_file"' EXIT
-
-                token="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
-                ca_file="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-                secret_url="https://kubernetes.default.svc/api/v1/namespaces/${var.platform_namespace}/secrets/${local.terminal_proxy_ziti_identity_secret_name}"
-                status="$(curl -sS --cacert "$ca_file" -o /tmp/terminal-proxy-ziti-identity.json -w '%%{http_code}' \
-                  -H "Authorization: Bearer $token" \
-                  "$secret_url")"
-                if [ "$status" = "200" ] && \
-                  [ "$(jq -r '.metadata.annotations["agyn.io/ziti-identity-id"] // ""' /tmp/terminal-proxy-ziti-identity.json)" = "$ZITI_IDENTITY_ID" ] && \
-                  jq -e '.data["identity.json"] // empty' /tmp/terminal-proxy-ziti-identity.json >/dev/null; then
-                  exit 0
-                fi
-                if [ "$status" != "200" ] && [ "$status" != "404" ]; then
-                  cat /tmp/terminal-proxy-ziti-identity.json >&2
-                  exit 1
-                fi
-
-                printf '%s' "$ZITI_ENROLLMENT_JWT" > "$jwt_file"
-                ziti edge enroll --jwt "$jwt_file" --out "$identity_file"
-                identity_json_b64="$(base64 -w 0 "$identity_file")"
-                payload="{\"metadata\":{\"name\":\"${local.terminal_proxy_ziti_identity_secret_name}\",\"annotations\":{\"agyn.io/ziti-identity-id\":\"$ZITI_IDENTITY_ID\"}},\"data\":{\"identity.json\":\"$identity_json_b64\"},\"type\":\"Opaque\"}"
-
-                if [ "$status" = "404" ]; then
-                  curl -fsS --cacert "$ca_file" -X POST \
-                    -H "Authorization: Bearer $token" \
-                    -H 'Content-Type: application/json' \
-                    -d "$payload" \
-                    "https://kubernetes.default.svc/api/v1/namespaces/${var.platform_namespace}/secrets"
-                else
-                  curl -fsS --cacert "$ca_file" -X PATCH \
-                    -H "Authorization: Bearer $token" \
-                    -H 'Content-Type: application/merge-patch+json' \
-                    -d "$payload" \
-                    "$secret_url"
-                fi
-              EOT
-              ]
-              "env" = [
-                {
-                  "name"  = "ZITI_ENROLLMENT_JWT"
-                  "value" = data.terraform_remote_state.ziti.outputs.terminal_proxy_enrollment_token
-                },
-                {
-                  "name"  = "ZITI_IDENTITY_ID"
-                  "value" = data.terraform_remote_state.ziti.outputs.identity_ids.terminal_proxy
-                }
-              ]
-            }
-          ]
-        }
-      }
-    }
-  }
-
-  computed_fields = [
-    "metadata.annotations",
-    "metadata.labels",
-    "spec.selector",
-    "spec.template.metadata.labels",
-  ]
-
-  wait {
-    fields = {
-      "status.succeeded" = "1"
-    }
-  }
-
-  depends_on = [
-    kubernetes_namespace.platform,
-    kubernetes_role_binding_v1.terminal_proxy_ziti_identity,
-  ]
-}
-
-resource "kubernetes_service_account_v1" "terminal_proxy" {
-  metadata {
-    name      = "terminal-proxy"
-    namespace = kubernetes_namespace.platform.metadata[0].name
-    labels = {
-      "app.kubernetes.io/name"       = "terminal-proxy"
-      "app.kubernetes.io/instance"   = "terminal-proxy"
-      "app.kubernetes.io/managed-by" = "terraform"
-    }
-  }
-}
-
-resource "kubernetes_service_v1" "terminal_proxy" {
-  metadata {
-    name      = "terminal-proxy"
-    namespace = kubernetes_namespace.platform.metadata[0].name
-    labels = {
-      "app.kubernetes.io/name"       = "terminal-proxy"
-      "app.kubernetes.io/instance"   = "terminal-proxy"
-      "app.kubernetes.io/managed-by" = "terraform"
-    }
-  }
-
-  spec {
-    selector = {
-      "app.kubernetes.io/name"     = "terminal-proxy"
-      "app.kubernetes.io/instance" = "terminal-proxy"
-    }
-
-    port {
-      name        = "http"
-      port        = 8080
-      target_port = "http"
-      protocol    = "TCP"
-    }
-
-    port {
-      name        = "grpc"
-      port        = 50051
-      target_port = "grpc"
-      protocol    = "TCP"
-    }
-  }
-}
-
-resource "kubernetes_deployment_v1" "terminal_proxy" {
-  metadata {
-    name      = "terminal-proxy"
-    namespace = kubernetes_namespace.platform.metadata[0].name
-    labels = {
-      "app.kubernetes.io/name"       = "terminal-proxy"
-      "app.kubernetes.io/instance"   = "terminal-proxy"
-      "app.kubernetes.io/managed-by" = "terraform"
-    }
-  }
-
-  spec {
-    replicas = 1
-
-    selector {
-      match_labels = {
-        "app.kubernetes.io/name"     = "terminal-proxy"
-        "app.kubernetes.io/instance" = "terminal-proxy"
-      }
-    }
-
-    template {
-      metadata {
-        labels = {
-          "app.kubernetes.io/name"     = "terminal-proxy"
-          "app.kubernetes.io/instance" = "terminal-proxy"
-        }
-      }
-
-      spec {
-        service_account_name = kubernetes_service_account_v1.terminal_proxy.metadata[0].name
-
-        security_context {
-          fs_group = 10001
-        }
-
-        container {
-          name              = "terminal-proxy"
-          image             = "ghcr.io/agynio/terminal-proxy:${local.resolved_terminal_proxy_image_tag}"
-          image_pull_policy = "IfNotPresent"
-
-          port {
-            name           = "http"
-            container_port = 8080
-            protocol       = "TCP"
-          }
-
-          port {
-            name           = "grpc"
-            container_port = 50051
-            protocol       = "TCP"
-          }
-
-          env {
-            name  = "HTTP_ADDRESS"
-            value = ":8080"
-          }
-
-          env {
-            name  = "GRPC_ADDRESS"
-            value = ":50051"
-          }
-
-          env {
-            name  = "TERMINAL_PROXY_WEBSOCKET_URL"
-            value = local.terminal_proxy_websocket_url
-          }
-
-          env {
-            name = "TERMINAL_PROXY_TICKET_SIGNING_KEY"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret_v1.terminal_proxy_ticket_signing.metadata[0].name
-                key  = "signing-key"
-              }
-            }
-          }
-
-          env {
-            name  = "RUNNERS_ADDRESS"
-            value = "runners:50051"
-          }
-
-          env {
-            name  = "AGENTS_ADDRESS"
-            value = "agents:50051"
-          }
-
-          env {
-            name  = "AUTHORIZATION_ADDRESS"
-            value = "authorization:50051"
-          }
-
-          env {
-            name  = "ZITI_ENABLED"
-            value = "true"
-          }
-
-          env {
-            name  = "ZITI_IDENTITY_FILE"
-            value = "/var/run/agyn/terminal-proxy-ziti/identity.json"
-          }
-
-          volume_mount {
-            name       = "ziti-identity"
-            mount_path = "/var/run/agyn/terminal-proxy-ziti"
-            read_only  = true
-          }
-
-          security_context {
-            run_as_non_root            = true
-            run_as_user                = 10001
-            run_as_group               = 10001
-            read_only_root_filesystem  = true
-            allow_privilege_escalation = false
-
-            capabilities {
-              drop = ["ALL"]
-            }
-
-            seccomp_profile {
-              type = "RuntimeDefault"
-            }
-          }
-
-          resources {
-            requests = {
-              cpu    = "50m"
-              memory = "128Mi"
-            }
-            limits = {
-              cpu    = "500m"
-              memory = "256Mi"
-            }
-          }
-        }
-
-        volume {
-          name = "ziti-identity"
-          secret {
-            secret_name  = local.terminal_proxy_ziti_identity_secret_name
-            default_mode = "0440"
-          }
-        }
-      }
-    }
-  }
-
-  depends_on = [
-    kubernetes_manifest.terminal_proxy_ziti_identity,
-  ]
-}
-
-resource "kubernetes_manifest" "runners_internal_authorization_policy" {
-  manifest = {
-    "apiVersion" = "security.istio.io/v1beta1"
-    "kind"       = "AuthorizationPolicy"
-    "metadata" = {
-      "name"      = "runners-internal"
-      "namespace" = kubernetes_namespace.platform.metadata[0].name
-      "labels" = {
-        "app.kubernetes.io/name"       = "runners"
-        "app.kubernetes.io/instance"   = "runners"
-        "app.kubernetes.io/managed-by" = "terraform"
-      }
-    }
-    "spec" = {
-      "selector" = {
-        "matchLabels" = {
-          "app.kubernetes.io/name"     = "runners"
-          "app.kubernetes.io/instance" = "runners"
-        }
-      }
-      "action" = "DENY"
-      "rules" = [
-        {
-          "from" = [
-            {
-              "source" = {
-                "notPrincipals" = ["cluster.local/ns/${var.platform_namespace}/sa/agents-orchestrator"]
-              }
-            }
-          ]
-          "to" = [
-            {
-              "operation" = {
-                "paths" = [
-                  "/agynio.api.runners.v1.RunnersService/CreateWorkload",
-                  "/agynio.api.runners.v1.RunnersService/UpdateWorkload",
-                  "/agynio.api.runners.v1.RunnersService/UpdateWorkloadStatus",
-                  "/agynio.api.runners.v1.RunnersService/DeleteWorkload",
-                  "/agynio.api.runners.v1.RunnersService/BatchUpdateWorkloadSampledAt",
-                  "/agynio.api.runners.v1.RunnersService/CreateVolume",
-                  "/agynio.api.runners.v1.RunnersService/UpdateVolume",
-                  "/agynio.api.runners.v1.RunnersService/BatchUpdateVolumeSampledAt",
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "from" = [
-            {
-              "source" = {
-                "notPrincipals" = [
-                  "cluster.local/ns/${var.platform_namespace}/sa/agents-orchestrator",
-                  "cluster.local/ns/${var.platform_namespace}/sa/gateway",
-                  "cluster.local/ns/${var.platform_namespace}/sa/expose",
-                  "cluster.local/ns/${var.platform_namespace}/sa/notifications",
-                  "cluster.local/ns/${var.platform_namespace}/sa/chat",
-                ]
-              }
-            }
-          ]
-          "to" = [
-            {
-              "operation" = {
-                "paths" = [
-                  "/agynio.api.runners.v1.RunnersService/RegisterRunner",
-                  "/agynio.api.runners.v1.RunnersService/GetRunner",
-                  "/agynio.api.runners.v1.RunnersService/ListRunners",
-                  "/agynio.api.runners.v1.RunnersService/UpdateRunner",
-                  "/agynio.api.runners.v1.RunnersService/DeleteRunner",
-                  "/agynio.api.runners.v1.RunnersService/GetWorkload",
-                  "/agynio.api.runners.v1.RunnersService/ListWorkloadsByThread",
-                  "/agynio.api.runners.v1.RunnersService/StreamWorkloadLogs",
-                  "/agynio.api.runners.v1.RunnersService/GetVolume",
-                  "/agynio.api.runners.v1.RunnersService/ListVolumes",
-                  "/agynio.api.runners.v1.RunnersService/ListVolumesByThread",
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "from" = [
-            {
-              "source" = {
-                "notPrincipals" = [
-                  "cluster.local/ns/${var.platform_namespace}/sa/agents-orchestrator",
-                  "cluster.local/ns/${var.platform_namespace}/sa/terminal-proxy",
-                ]
-              }
-            }
-          ]
-          "to" = [
-            {
-              "operation" = {
-                "paths" = [
-                  "/agynio.api.runners.v1.RunnersService/ListWorkloads",
-                  "/agynio.api.runners.v1.RunnersService/TouchWorkload",
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "from" = [
-            {
-              "source" = {
-                "notPrincipals" = ["cluster.local/ns/${var.platform_namespace}/sa/agents-orchestrator"]
-              }
-            }
-          ]
-          "when" = [
-            {
-              "key"       = "request.headers[x-identity-id]"
-              "notValues" = ["*"]
-            }
-          ]
-          "to" = [
-            {
-              "operation" = {
-                "paths" = [
-                  "/agynio.api.runners.v1.RunnersService/RegisterRunner",
-                  "/agynio.api.runners.v1.RunnersService/GetRunner",
-                  "/agynio.api.runners.v1.RunnersService/ListRunners",
-                  "/agynio.api.runners.v1.RunnersService/UpdateRunner",
-                  "/agynio.api.runners.v1.RunnersService/DeleteRunner",
-                  "/agynio.api.runners.v1.RunnersService/GetWorkload",
-                  "/agynio.api.runners.v1.RunnersService/ListWorkloadsByThread",
-                  "/agynio.api.runners.v1.RunnersService/StreamWorkloadLogs",
-                  "/agynio.api.runners.v1.RunnersService/GetVolume",
-                  "/agynio.api.runners.v1.RunnersService/ListVolumes",
-                  "/agynio.api.runners.v1.RunnersService/ListVolumesByThread",
-                ]
-              }
-            }
-          ]
-        },
-      ]
-    }
-  }
-
-  computed_fields = [
-    "metadata.annotations",
-    "metadata.labels",
-  ]
-
-  depends_on = [
-    argocd_application.runners,
-    kubernetes_service_account_v1.terminal_proxy,
-  ]
 }
 
 # DEV/E2E ONLY: ziti-diagnostics contains admin UPDB credentials
@@ -4748,6 +4353,55 @@ resource "argocd_application" "egress_gateway" {
   }
 }
 
+resource "argocd_application" "terminal_proxy" {
+  depends_on = [
+    argocd_application.runners,
+    argocd_application.agents,
+    argocd_application.authorization,
+    kubernetes_secret_v1.terminal_proxy_ticket_signing,
+    kubernetes_secret_v1.terminal_proxy_ziti_identity,
+  ]
+  metadata {
+    name      = "terminal-proxy"
+    namespace = "argocd"
+    annotations = {
+      "argocd.argoproj.io/sync-wave" = "20"
+    }
+  }
+
+  spec {
+    project = "default"
+
+    source {
+      repo_url        = local.platform_chart_repo_host
+      chart           = local.terminal_proxy_chart_name
+      target_revision = var.terminal_proxy_chart_version
+
+      helm {
+        values = local.terminal_proxy_values
+      }
+    }
+
+    destination {
+      server    = var.destination_server
+      namespace = kubernetes_namespace.platform.metadata[0].name
+    }
+
+    sync_policy {
+      dynamic "automated" {
+        for_each = var.argocd_automated_sync_enabled ? [1] : []
+        content {
+          prune       = var.argocd_prune_enabled
+          self_heal   = var.argocd_self_heal_enabled
+          allow_empty = false
+        }
+      }
+
+      sync_options = local.default_sync_options
+    }
+  }
+}
+
 resource "argocd_application" "agents" {
   depends_on = [
     argocd_application.agents_db,
@@ -5457,7 +5111,7 @@ resource "argocd_application" "gateway" {
     argocd_application.expose,
     argocd_application.groups,
     argocd_application.networks,
-    kubernetes_deployment_v1.terminal_proxy,
+    argocd_application.terminal_proxy,
   ]
   wait = true
   metadata {

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -2104,9 +2104,8 @@ resource "kubernetes_secret_v1" "egress_gateway_enrollment" {
   }
 }
 
-resource "random_password" "terminal_proxy_ticket_signing" {
-  length  = 64
-  special = false
+resource "random_bytes" "terminal_proxy_ticket_signing" {
+  length = 32
 }
 
 resource "kubernetes_secret_v1" "terminal_proxy_ticket_signing" {
@@ -2118,7 +2117,7 @@ resource "kubernetes_secret_v1" "terminal_proxy_ticket_signing" {
   type = "Opaque"
 
   data = {
-    signing-key = random_password.terminal_proxy_ticket_signing.result
+    signing-key = random_bytes.terminal_proxy_ticket_signing.base64
   }
 }
 

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -29,6 +29,7 @@ locals {
   resolved_apps_image_tag                = trimspace(var.apps_image_tag) != "" ? var.apps_image_tag : var.apps_chart_version
   resolved_egress_image_tag              = trimspace(var.egress_image_tag) != "" ? var.egress_image_tag : var.egress_chart_version
   resolved_egress_gateway_image_tag      = trimspace(var.egress_gateway_image_tag) != "" ? var.egress_gateway_image_tag : var.egress_gateway_chart_version
+  resolved_terminal_proxy_image_tag      = trimspace(var.terminal_proxy_image_tag) != "" ? var.terminal_proxy_image_tag : var.terminal_proxy_chart_version
 
   postgres_image                 = "postgres:16.6-alpine"
   platform_chart_repo_host       = "ghcr.io"
@@ -64,6 +65,7 @@ locals {
   apps_chart_name                = "agynio/charts/apps"
   egress_chart_name              = "agynio/charts/egress"
   egress_gateway_chart_name      = "agynio/charts/egress-gateway"
+  terminal_proxy_chart_name      = "agynio/charts/agyn-platform"
   # DEV/E2E ONLY: this secret name is used by diagnostics tests and must not
   # be published in production deployments.
   ziti_diagnostics_secret_name  = "ziti-diagnostics"
@@ -104,6 +106,9 @@ locals {
       enabled = false
     }
     gateway = {
+      enabled = false
+    }
+    "terminal-proxy" = {
       enabled = false
     }
     agents = {
@@ -828,6 +833,73 @@ locals {
       requests = { cpu = "100m", memory = "128Mi" }
       limits   = { cpu = "1000m", memory = "512Mi" }
     }
+  })
+
+  terminal_proxy_values = yamlencode({
+    for key, value in merge(
+      local.agyn_platform_single_service_values,
+      {
+        platform = {
+          serviceEndpoints = {
+            terminalProxy = "terminal-proxy:50051"
+          }
+          externalUrls = {
+            terminalProxyWebSocket = format("wss://terminal.%s/terminal", local.base_domain)
+          }
+        }
+        "terminal-proxy" = {
+          enabled          = true
+          replicaCount     = 1
+          fullnameOverride = "terminal-proxy"
+          image = {
+            repository = "ghcr.io/agynio/terminal-proxy"
+            tag        = local.resolved_terminal_proxy_image_tag
+            pullPolicy = "IfNotPresent"
+          }
+          env = [
+            { name = "HTTP_ADDRESS", value = ":8080" },
+            { name = "GRPC_ADDRESS", value = ":50051" },
+            { name = "TERMINAL_PROXY_WEBSOCKET_URL", value = format("wss://terminal.%s/terminal", local.base_domain) },
+            {
+              name = "TERMINAL_PROXY_TICKET_SIGNING_KEY"
+              valueFrom = {
+                secretKeyRef = {
+                  name = kubernetes_secret_v1.terminal_proxy_ticket_signing.metadata[0].name
+                  key  = "signing-key"
+                }
+              }
+            },
+            { name = "RUNNERS_ADDRESS", value = "runners:50051" },
+            { name = "AGENTS_ADDRESS", value = "agents:50051" },
+            { name = "AUTHORIZATION_ADDRESS", value = "authorization:50051" },
+            { name = "ZITI_ENABLED", value = "true" },
+            { name = "ZITI_IDENTITY_FILE", value = "/var/run/agyn/terminal-proxy-ziti/identity.json" },
+          ]
+          service = {
+            enabled = true
+            type    = "ClusterIP"
+            ports = [
+              { name = "http", port = 8080, targetPort = "http", protocol = "TCP" },
+              { name = "grpc", port = 50051, targetPort = "grpc", protocol = "TCP" },
+            ]
+          }
+          containerPorts = [
+            { name = "http", containerPort = 8080, protocol = "TCP" },
+            { name = "grpc", containerPort = 50051, protocol = "TCP" },
+          ]
+          extraVolumeMounts = [
+            { name = "ziti-identity", mountPath = "/var/run/agyn/terminal-proxy-ziti", readOnly = true },
+          ]
+          extraVolumes = [
+            { name = "ziti-identity", secret = { secretName = kubernetes_secret_v1.terminal_proxy_ziti_identity.metadata[0].name } },
+          ]
+          resources = {
+            requests = { cpu = "50m", memory = "128Mi" }
+            limits   = { cpu = "500m", memory = "256Mi" }
+          }
+        }
+      }
+    ) : key => value
   })
 
   agents_values = yamlencode({
@@ -1985,6 +2057,38 @@ resource "kubernetes_secret_v1" "egress_gateway_enrollment" {
     enrollmentJwt = data.terraform_remote_state.ziti.outputs.egress_gateway_enrollment_token
   }
 }
+
+resource "random_password" "terminal_proxy_ticket_signing" {
+  length  = 32
+  special = false
+}
+
+resource "kubernetes_secret_v1" "terminal_proxy_ticket_signing" {
+  metadata {
+    name      = "terminal-proxy-ticket-signing"
+    namespace = kubernetes_namespace.platform.metadata[0].name
+  }
+
+  type = "Opaque"
+
+  data = {
+    signing-key = random_password.terminal_proxy_ticket_signing.result
+  }
+}
+
+resource "kubernetes_secret_v1" "terminal_proxy_ziti_identity" {
+  metadata {
+    name      = "terminal-proxy-ziti-identity"
+    namespace = kubernetes_namespace.platform.metadata[0].name
+  }
+
+  type = "Opaque"
+
+  data = {
+    "identity.json" = var.terminal_proxy_ziti_identity_json
+  }
+}
+
 resource "kubernetes_manifest" "agyn_selfsigned_cluster_issuer" {
   manifest = {
     "apiVersion" = "cert-manager.io/v1"
@@ -4220,6 +4324,55 @@ resource "argocd_application" "egress_gateway" {
   }
 }
 
+resource "argocd_application" "terminal_proxy" {
+  depends_on = [
+    argocd_application.runners,
+    argocd_application.agents,
+    argocd_application.authorization,
+    kubernetes_secret_v1.terminal_proxy_ticket_signing,
+    kubernetes_secret_v1.terminal_proxy_ziti_identity,
+  ]
+  metadata {
+    name      = "terminal-proxy"
+    namespace = "argocd"
+    annotations = {
+      "argocd.argoproj.io/sync-wave" = "20"
+    }
+  }
+
+  spec {
+    project = "default"
+
+    source {
+      repo_url        = local.platform_chart_repo_host
+      chart           = local.terminal_proxy_chart_name
+      target_revision = var.terminal_proxy_chart_version
+
+      helm {
+        values = local.terminal_proxy_values
+      }
+    }
+
+    destination {
+      server    = var.destination_server
+      namespace = kubernetes_namespace.platform.metadata[0].name
+    }
+
+    sync_policy {
+      dynamic "automated" {
+        for_each = var.argocd_automated_sync_enabled ? [1] : []
+        content {
+          prune       = var.argocd_prune_enabled
+          self_heal   = var.argocd_self_heal_enabled
+          allow_empty = false
+        }
+      }
+
+      sync_options = local.default_sync_options
+    }
+  }
+}
+
 resource "argocd_application" "agents" {
   depends_on = [
     argocd_application.agents_db,
@@ -4929,6 +5082,7 @@ resource "argocd_application" "gateway" {
     argocd_application.expose,
     argocd_application.groups,
     argocd_application.networks,
+    argocd_application.terminal_proxy,
   ]
   wait = true
   metadata {
@@ -4969,6 +5123,10 @@ resource "argocd_application" "gateway" {
             {
               name  = "ZITI_ENABLED"
               value = "true"
+            },
+            {
+              name  = "TERMINAL_PROXY_GRPC_TARGET"
+              value = "terminal-proxy:50051"
             },
           ]
         })

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -908,6 +908,7 @@ locals {
                 ziti edge enroll \
                   --jwt /etc/ziti-enrollment/enrollmentJwt \
                   --out /var/run/agyn/terminal-proxy-ziti/identity.json
+                chown 10001:10001 /var/run/agyn/terminal-proxy-ziti/identity.json
                 chmod 0400 /var/run/agyn/terminal-proxy-ziti/identity.json
               EOT
               ]

--- a/stacks/platform/main.tf
+++ b/stacks/platform/main.tf
@@ -2396,7 +2396,8 @@ resource "kubernetes_deployment_v1" "terminal_proxy" {
         volume {
           name = "ziti-identity"
           secret {
-            secret_name = local.terminal_proxy_ziti_identity_secret_name
+            secret_name  = local.terminal_proxy_ziti_identity_secret_name
+            default_mode = "0440"
           }
         }
       }

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -806,7 +806,7 @@ variable "egress_gateway_image_tag" {
 variable "terminal_proxy_chart_version" {
   type        = string
   description = "Version of the agyn-platform Helm chart used to deploy terminal-proxy"
-  default     = "0.5.12"
+  default     = "0.5.13"
 }
 
 variable "terminal_proxy_ziti_identity_json" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -805,7 +805,7 @@ variable "egress_gateway_image_tag" {
 
 variable "terminal_proxy_chart_version" {
   type        = string
-  description = "Version of the agyn-platform Helm chart used to deploy terminal-proxy"
+  description = "Default terminal-proxy image tag when terminal_proxy_image_tag is unset"
   default     = "0.5.11"
 }
 

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -802,3 +802,21 @@ variable "egress_gateway_image_tag" {
   description = "Optional override for the egress-gateway image tag"
   default     = ""
 }
+
+variable "terminal_proxy_chart_version" {
+  type        = string
+  description = "Version of the agyn-platform Helm chart used to deploy terminal-proxy"
+  default     = "0.5.11"
+}
+
+variable "terminal_proxy_image_tag" {
+  type        = string
+  description = "Optional override for the terminal-proxy image tag"
+  default     = ""
+}
+
+variable "terminal_proxy_ziti_identity_json" {
+  type        = string
+  description = "Enrolled terminal-proxy OpenZiti identity JSON stored as terminal-proxy-ziti-identity/identity.json"
+  sensitive   = true
+}

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -805,8 +805,14 @@ variable "egress_gateway_image_tag" {
 
 variable "terminal_proxy_chart_version" {
   type        = string
-  description = "Default terminal-proxy image tag when terminal_proxy_image_tag is unset"
-  default     = "0.5.11"
+  description = "Version of the agyn-platform Helm chart used to deploy terminal-proxy"
+  default     = "0.5.12"
+}
+
+variable "terminal_proxy_ziti_identity_json" {
+  type        = string
+  description = "Enrolled OpenZiti identity JSON for Terminal Proxy"
+  sensitive   = true
 }
 
 variable "terminal_proxy_image_tag" {

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -814,9 +814,3 @@ variable "terminal_proxy_image_tag" {
   description = "Optional override for the terminal-proxy image tag"
   default     = ""
 }
-
-variable "terminal_proxy_ziti_identity_json" {
-  type        = string
-  description = "Enrolled terminal-proxy OpenZiti identity JSON stored as terminal-proxy-ziti-identity/identity.json"
-  sensitive   = true
-}

--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -817,6 +817,6 @@ variable "terminal_proxy_ziti_identity_json" {
 
 variable "terminal_proxy_image_tag" {
   type        = string
-  description = "Optional override for the terminal-proxy image tag"
-  default     = ""
+  description = "Terminal Proxy container image tag"
+  default     = "0.5.11"
 }

--- a/stacks/routing/.terraform.lock.hcl
+++ b/stacks/routing/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   constraints = "~> 2.33"
   hashes = [
     "h1:5CkveFo5ynsLdzKk+Kv+r7+U9rMrNjfZPT3a0N/fhgE=",
+    "h1:XCkL/mxjWTawg6gg+jlpCQhF/+SNRoCEZxbbkDTj42s=",
     "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
     "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
     "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",

--- a/stacks/routing/main.tf
+++ b/stacks/routing/main.tf
@@ -15,6 +15,7 @@ locals {
     "minio-api.${local.base_domain}",
     "openfga.${local.base_domain}",
     "openfga-playground.${local.base_domain}",
+    "terminal.${local.base_domain}",
     "tracing.${local.base_domain}",
   ]
 }
@@ -116,6 +117,47 @@ resource "kubernetes_manifest" "virtualservice_argocd" {
             {
               "destination" = {
                 "host" = "argo-cd-argocd-server.argocd.svc.cluster.local"
+                "port" = {
+                  "number" = 8080
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  computed_fields = [
+    "metadata.annotations",
+    "metadata.labels",
+  ]
+}
+
+resource "kubernetes_manifest" "virtualservice_terminal_proxy" {
+  manifest = {
+    "apiVersion" = "networking.istio.io/v1beta1"
+    "kind"       = "VirtualService"
+    "metadata" = {
+      "name"      = "terminal-proxy"
+      "namespace" = local.istio_gateway_namespace
+    }
+    "spec" = {
+      "hosts"    = ["terminal.${local.base_domain}"]
+      "gateways" = ["platform-gateway"]
+      "http" = [
+        {
+          "match" = [
+            {
+              "uri" = {
+                "prefix" = "/terminal"
+              }
+            }
+          ]
+          "route" = [
+            {
+              "destination" = {
+                "host" = "terminal-proxy.platform.svc.cluster.local"
                 "port" = {
                   "number" = 8080
                 }

--- a/stacks/ziti/main.tf
+++ b/stacks/ziti/main.tf
@@ -214,6 +214,12 @@ resource "ziti_identity" "orchestrator" {
   role_attributes = ["orchestrators"]
 }
 
+resource "ziti_identity" "terminal_proxy" {
+  name            = "terminal-proxy"
+  type            = "Device"
+  role_attributes = ["terminal-proxy-hosts"]
+}
+
 resource "kubernetes_secret_v1" "gateway_identity_enrollment" {
   metadata {
     name      = local.gateway_identity_secret_name

--- a/stacks/ziti/outputs.tf
+++ b/stacks/ziti/outputs.tf
@@ -9,6 +9,7 @@ output "identity_ids" {
     egress_gateway  = ziti_identity.egress_gateway.id
     ziti_management = ziti_identity.ziti_management.id
     orchestrator    = ziti_identity.orchestrator.id
+    terminal_proxy  = ziti_identity.terminal_proxy.id
   }
   description = "Ziti identity IDs"
 }
@@ -41,5 +42,11 @@ output "ziti_diagnostics_credentials" {
 output "egress_gateway_enrollment_token" {
   value       = ziti_identity.egress_gateway.enrollment_token
   description = "Enrollment JWT for the egress-gateway identity"
+  sensitive   = true
+}
+
+output "terminal_proxy_enrollment_token" {
+  value       = ziti_identity.terminal_proxy.enrollment_token
+  description = "Enrollment JWT for the terminal-proxy identity"
   sensitive   = true
 }


### PR DESCRIPTION
## Summary

Implements the bootstrap deployment wiring slice for agynio/architecture#162.

- Adds the `terminal-proxy` OpenZiti identity with role attribute `terminal-proxy-hosts` and exports its enrollment token.
- Deploys Terminal Proxy as a dedicated Argo CD application using the `agyn-platform` chart Terminal Proxy slice.
- Creates the stable `terminal-proxy-ticket-signing` Secret and `terminal-proxy-ziti-identity` Secret for the enrolled identity JSON file.
- Wires Terminal Proxy config/env for Gateway, Runners, Agents, Authorization, WebSocket URL, signing key, and Ziti identity file.
- Wires Gateway with `TERMINAL_PROXY_GRPC_TARGET=terminal-proxy:50051`.
- Adds the `wss://terminal.<base_domain>/terminal` Istio route to `terminal-proxy.platform.svc.cluster.local:8080`.

## Validation

- `terraform -chdir=stacks/ziti fmt` — passed
- `terraform -chdir=stacks/platform fmt` — passed
- `terraform -chdir=stacks/routing fmt` — passed
- `terraform -chdir=stacks/ziti init -backend=false` — passed
- `terraform -chdir=stacks/ziti validate` — passed
- `terraform -chdir=stacks/platform init -backend=false` — passed
- `terraform -chdir=stacks/platform validate` — passed
- `terraform -chdir=stacks/routing init -backend=false` — passed
- `terraform -chdir=stacks/routing validate` — passed
- `git diff --check` — passed

`terraform plan -var='terminal_proxy_ziti_identity_json={}' -refresh=false -out=/tmp/platform.tfplan` was attempted and could not complete in this workspace because local remote state and kubeconfig are not present (`stacks/k8s`, `stacks/system`, and `stacks/ziti` state are missing; `../k8s/.kube/agyn-local-kubeconfig.yaml` does not exist). The partial plan confirmed the new Terminal Proxy signing secret and Ziti identity secret resources before provider/state lookup failed.

## Dependency order

Depends on agynio/platform-charts#30 landing first and publishing `agyn-platform` chart `0.5.11`; this PR references that chart version for the Terminal Proxy application.