### PR TITLE
Bump agents-orchestrator to v0.13.21

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -26,7 +26,7 @@ variable "gateway_chart_version" {
 variable "agents_orchestrator_chart_version" {
   type        = string
   description = "Version of the agents-orchestrator Helm chart published to GHCR"
-  default     = "0.13.20"
+  default     = "0.13.21"
 }
 
 variable "threads_chart_version" {


### PR DESCRIPTION
## Summary

- Bumps `agents_orchestrator_chart_version` from `0.13.20` to `0.13.21`.

## Context

- Release: https://github.com/agynio/agents-orchestrator/releases/tag/v0.13.21
- Fix PR: https://github.com/agynio/agents-orchestrator/pull/229
- Bootstrap issue: Closes #586

## Testing

- Not run; version-only Terraform variable update.