### PR TITLE
Bump console-app to 0.10.15

### DIFF
--- a/stacks/platform/variables.tf
+++ b/stacks/platform/variables.tf
@@ -152,7 +152,7 @@ variable "chat_app_image_tag" {
 variable "console_app_chart_version" {
   type        = string
   description = "Version of the console-app Helm chart published to GHCR"
-  default     = "0.10.14"
+  default     = "0.10.15"
 }
 
 variable "console_app_image_tag" {


### PR DESCRIPTION
## Summary
- Bumps `console_app_chart_version` from `0.10.14` to `0.10.15`.
- Leaves `console_app_image_tag` unset so the image tag resolves from the chart version.

Closes #588

## Release verification
- Created and pushed `agynio/console-app` tag `v0.10.15` from `main` commit `55576258a3f5023b417335b70bea71abacb6815e`.
- Release workflow succeeded: https://github.com/agynio/console-app/actions/runs/30012224222
- Verified image artifact `ghcr.io/agynio/console-app:0.10.15` includes `linux/amd64` and `linux/arm64`.
- Verified chart artifact `oci://ghcr.io/agynio/charts/console-app --version 0.10.15` with chart/app version `0.10.15`.

## Verification
### console-app
- `npm run generate` completed before local checks so generated API types were present.
- `npm run typecheck` passed.
- `npm run lint` passed with no errors.
- `npm test` passed: 95 passed / 0 failed / 0 skipped across 22 files.
- `npm run build` passed.
- `rg -n 'organization-agent-status|label="Status"|sortKey="status"|TBD' src/pages/OrganizationAgentsTab.tsx` returned no matches, as expected.
- `gh run watch 30011237002 -R agynio/console-app --exit-status` passed for main E2E.

### artifacts
- `docker-buildx imagetools inspect ghcr.io/agynio/console-app:0.10.15` passed and showed `linux/amd64` and `linux/arm64` manifests.
- `helm show chart oci://ghcr.io/agynio/charts/console-app --version 0.10.15` passed and showed `version: 0.10.15`, `appVersion: 0.10.15`.

### bootstrap
- `terraform -chdir=stacks/platform fmt -check -recursive` passed.
- `terraform -chdir=stacks/platform init` passed.
- `terraform -chdir=stacks/platform validate` passed.
- `git diff --check` passed.